### PR TITLE
Changed default channel to quincy/stable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
 options:
   snap-channel:
-    default: "latest/stable"
+    default: "quincy/stable"
     type: string


### PR DESCRIPTION
Using latest may cause expectation mismatches when the new release (reef) comes out.