### PR TITLE
Do not change default replication size.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -330,7 +330,6 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         """
         cmds = [
             ["ceph", "config", "set", "global", "mon_allow_pool_size_one", "true"],
-            ["ceph", "config", "set", "global", "osd_pool_default_size", "1"],
         ]
         try:
             for cmd in cmds:


### PR DESCRIPTION
This PR removes the command to change the replication size to 1. Now that we can have OSDs backed by loop files, this setting doesn't make sense anymore.