### PR TITLE
Get default route to find local ip address

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 cryptography
 ops
 pyroute2
-netifaces
 jsonschema
 jinja2
 git+https://opendev.org/openstack/sunbeam-charms/#egg=ops-sunbeam&subdirectory=ops-sunbeam


### PR DESCRIPTION
Looking at netifaces.gateways()["default"] does not always yield a result. In this instances, `_get_local_ip_by_default_route` will fail, and microceph will not be able to get a working IP Address.

This is actually old sunbeam code, that has been replace since then with a new method:

Finding default route, then infer iface (and address) from this default route.