### PR TITLE
Updated public address lookup method to rely on Ceph conf

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -30,7 +30,6 @@ import charms.operator_libs_linux.v2.snap as snap
 import ops.framework
 import ops_sunbeam.charm as sunbeam_charm
 import ops_sunbeam.relation_handlers as sunbeam_rhandlers
-from netifaces import AF_INET, gateways, ifaddresses
 from ops.charm import ActionEvent
 from ops.main import main
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -46,22 +46,6 @@ from relation_handlers import (
 logger = logging.getLogger(__name__)
 
 
-def _get_local_ip_by_default_route() -> str:
-    """Get IP address of host associated with default gateway."""
-    interface = "lo"
-    ip = "127.0.0.1"
-
-    # TOCHK: Gathering only IPv4
-    if "default" in gateways():
-        interface = gateways()["default"][AF_INET][1]
-
-    ip_list = ifaddresses(interface)[AF_INET]
-    if len(ip_list) > 0 and "addr" in ip_list[0]:
-        ip = ip_list[0]["addr"]
-
-    return ip
-
-
 class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
     """Charm the service."""
 
@@ -239,7 +223,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
     def get_ceph_info_from_configs(self, service_name) -> dict:
         """Update ceph info from configuration."""
         # public address should be updated once config public-network is supported
-        public_addr = _get_local_ip_by_default_route()
+        public_addr = microceph.get_public_address()
         return {
             "auth": "cephx",
             "ceph-public-address": public_addr,

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -28,7 +28,7 @@ def remove_cluster_member(name: str, is_force: bool) -> None:
     _run_cmd(cmd)
 
 
-def get_public_address(hostname:str = None) -> str:
+def get_public_address(hostname: str = None) -> str:
     """Returns MicroCeph public address for hostname, or local address."""
     name = hostname
     if not name:

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -27,7 +27,7 @@ def remove_cluster_member(name: str, is_force: bool) -> None:
     _run_cmd(cmd)
 
 
-def get_public_address() -> str:
+def get_mon_public_addresses() -> list:
     """Returns first mon host address as read from the ceph.conf file."""
     conf_file_path = "/var/snap/microceph/current/conf/ceph.conf"
     public_addrs = []
@@ -40,7 +40,7 @@ def get_public_address() -> str:
                 public_addrs.extend(addrs)
                 break
 
-    return public_addrs[0]
+    return public_addrs
 
 
 def is_cluster_member(hostname: str) -> bool:

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -4,7 +4,6 @@
 
 import logging
 import subprocess
-from socket import gethostname
 
 logger = logging.getLogger(__name__)
 
@@ -28,28 +27,20 @@ def remove_cluster_member(name: str, is_force: bool) -> None:
     _run_cmd(cmd)
 
 
-def get_public_address(hostname: str = None) -> str:
-    """Returns MicroCeph public address for hostname, or local address."""
-    name = hostname
-    if not name:
-        # use local name if none provided.
-        name = gethostname()
+def get_public_address() -> str:
+    """Returns first mon host address as read from the ceph.conf file."""
+    conf_file_path = "/var/snap/microceph/current/conf/ceph.conf"
+    public_addrs = []
+    with open(conf_file_path, "r") as conf_file:
+        lines = conf_file.readlines()
+        for line in lines:
+            if "mon host" in line:
+                addrs = line.split(" ")[-1].split(",")
+                logger.debug(f"Found public addresses {addrs} in conf file.")
+                public_addrs.extend(addrs)
+                break
 
-    cmd = [
-        "microceph",
-        "cluster",
-        "sql",
-        f"select value from config where key = 'mon.host.{name}'",
-    ]
-    # NOTE: output is of the form.
-    # '+-------+\n| value |\n+-------+\n+-------+\n'
-    # '+------------+\n|   value    |\n+------------+\n| 10.5.2.132 |\n+------------+\n'
-    output = _run_cmd(cmd).rsplit(" ", 2)
-
-    if "value" in output[-2]:
-        raise ValueError(f"Provided hostname {name} has no address record in MicroCeph.")
-
-    return output[-2]
+    return public_addrs[0]
 
 
 def is_cluster_member(hostname: str) -> bool:


### PR DESCRIPTION
The updated logic uses ceph.conf file to read the mon host addresses, hence the charm logic can run on any MicroCeph unit.