### PR TITLE
add jammy and x64 labels for self-hosted runners

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,7 +58,7 @@ jobs:
       - unit-test
       - build
     name: Functional test
-    runs-on: [self-hosted, xlarge]
+    runs-on: [self-hosted, xlarge, jammy, x64]
     steps:
 
       - name: Download charm
@@ -119,7 +119,7 @@ jobs:
       - unit-test
       - build
     name: Juju cluster test
-    runs-on: [self-hosted, xlarge]
+    runs-on: [self-hosted, xlarge, jammy, x64]
     steps:
 
       - name: Download charm
@@ -189,7 +189,7 @@ jobs:
       - unit-test
       - build
     name: Juju single test
-    runs-on: [self-hosted, xlarge]
+    runs-on: [self-hosted, xlarge, jammy, x64]
     steps:
 
       - name: Download charm
@@ -272,7 +272,7 @@ jobs:
       - unit-test
       - build
     name: Juju upgrade test
-    runs-on: [self-hosted, xlarge]
+    runs-on: [self-hosted, xlarge, jammy, x64]
     steps:
 
       - name: Download charm


### PR DESCRIPTION
# Description

Adds the `jammy` and `x64` labels to the self-hosted runner workflows to ensure they don't break as we add more architectures and Ubuntu OS versions.


