### PR TITLE
feat: add support for the `ceph-mds` relation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -417,3 +417,60 @@ jobs:
 
       - name: Validate the network configurations.
         run: ./tests/scripts/ci_helpers.sh verify_juju_spaces_config
+
+  juju-mds-test:
+    needs:
+      - lint
+      - unit-test
+      - build
+    name: Juju mds test
+    runs-on: [self-hosted, xlarge]
+    steps:
+
+      - name: Download charm
+        uses: actions/download-artifact@v3
+        with:
+          name: charms
+          path: ~/artifacts/
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          # pin lxd to LTS release.
+          channel: 5.21/stable
+
+      - name: Install dependencies
+        run: ./tests/scripts/ci_helpers.sh install_deps
+
+      - name: Install MicroCeph charm
+        run: |
+          set -eux
+          date
+          # constraints to deploy on virtual machine.
+          juju deploy ~/artifacts/microceph.charm --storage osd-standalone='2G,3' --constraints="virt-type=virtual-machine root-disk=50G mem=8G"
+          # wait for charm to bootstrap and OSD devices to enroll.
+          juju wait-for unit microceph/0 --timeout '30m' --query='workload-message=="(workload) charm is ready"'
+          bash ./tests/scripts/ci_helpers.sh check_osd_count microceph/0 3
+          date
+
+      - name: Add and relate CephFS charm
+        run: |
+          set -eux
+          juju deploy ch:ceph-fs
+          # wait for charm to bootstrap.
+          juju wait-for unit ceph-fs/0 --query='workload-status=="blocked"' --timeout=30m
+          juju integrate ceph-fs:ceph-mds microceph:mds
+          # wait for filesystem creation
+          juju wait-for application ceph-fs --query='name=="ceph-fs" && (status=="active" || status=="idle")' --timeout=10m
+          filesystems=$(juju ssh microceph/0 -- "sudo microceph.ceph fs ls")
+          if ! echo "$filesystems" | grep -E "ceph-fs" ; then
+            echo "Failed to create the ceph-fs filesystem"
+            juju ssh microceph/0 -- "sudo microceph.ceph fs ls"
+            exit 1
+          # check if the ceph-mds daemon is running
+          juju ssh ceph-fs/0 -- 'sudo systemctl is-active ceph-mds@$HOSTNAME.service --quiet'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -472,5 +472,6 @@ jobs:
             echo "Failed to create the ceph-fs filesystem"
             juju ssh microceph/0 -- "sudo microceph.ceph fs ls"
             exit 1
+          fi
           # check if the ceph-mds daemon is running
           juju ssh ceph-fs/0 -- 'sudo systemctl is-active ceph-mds@$HOSTNAME.service --quiet'

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -30,6 +30,8 @@ provides:
     interface: ceph-client
   radosgw:
     interface: ceph-radosgw
+  mds:
+    interface: ceph-mds
 
 peers:
   peers:

--- a/src/ceph_broker.py
+++ b/src/ceph_broker.py
@@ -28,6 +28,7 @@ import os
 import socket
 from subprocess import CalledProcessError, check_call, check_output
 from tempfile import NamedTemporaryFile
+from typing import Dict, List, TypeAlias
 
 from ceph import (
     DEBUG,
@@ -400,7 +401,9 @@ def handle_replicated_pool(request, service):
 
 LEADER = "leader"
 
-_default_caps = collections.OrderedDict(
+Capabilities: TypeAlias = Dict[str, List[str]]
+
+_default_caps: Capabilities = collections.OrderedDict(
     [
         ("mon", ["allow r", 'allow command "osd blacklist"', 'allow command "osd blocklist"']),
         ("osd", ["allow rwx"]),
@@ -457,8 +460,7 @@ def get_named_key(name, caps=None, pool_list=None):
     :param caps: dict of cephx capabilities
     :returns: Returns a cephx key
     """
-    key_name = "client.{}".format(name)
-    key = ceph_auth_get(key_name)
+    key = ceph_auth_get(name)
     if key:
         return key
 
@@ -472,7 +474,7 @@ def get_named_key(name, caps=None, pool_list=None):
         f"{VAR_LIB_CEPH}/mon/ceph-{socket.gethostname()}/keyring",
         "auth",
         "get-or-create",
-        key_name,
+        name,
     ]
     # Add capabilities
     for subsystem, subcaps in caps.items():

--- a/src/charm.py
+++ b/src/charm.py
@@ -37,6 +37,7 @@ import microceph
 from ceph_broker import get_named_key
 from relation_handlers import (
     CephClientProviderHandler,
+    CephMdsProviderHandler,
     CephRadosGWProviderHandler,
     MicroClusterNewNodeEvent,
     MicroClusterNodeAddedEvent,
@@ -157,6 +158,8 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             handlers.append(self.ceph)
         if self.can_add_handler("radosgw", handlers):
             self.radosgw = CephRadosGWProviderHandler(self, self.handle_ceph)
+        if self.can_add_handler("mds", handlers):
+            self.mds = CephMdsProviderHandler(self, self.handle_ceph)
 
         handlers = super().get_relation_handlers(handlers)
         logger.debug(f"Relation handlers: {handlers}")


### PR DESCRIPTION
# Description

This change allows integrating with `microceph` using the `ceph-mds` relation, which is required by charms such as `ceph-fs` to create filesystems on the cluster.
Do note that this only allows creating filesystems; a separate PR (#71) is in place to allow creating cephfs clients using broker requests.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

A functional test on the CI pipeline.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
