### PR TITLE
Add error message in action failure to results

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -125,7 +125,8 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             event.set_results({"status": "success"})
         except subprocess.CalledProcessError:
             logger.warning("Failed to set new pool size")
-            event.fail("set-pool-size failed")
+            event.set_results({"message": "set-pool-size failed"})
+            event.fail()
 
     @property
     def channel(self) -> str:
@@ -334,7 +335,10 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
                 # factor isn't 3, as that is the default, and we run this
                 # method on configuration changes.
                 if default_rf != 3:
-                    event.fail("cannot set pool size: command not supported by microceph")
+                    event.set_results(
+                        {"message": "cannot set pool size: command not supported by microceph"}
+                    )
+                    event.fail()
                 return
             raise e
 

--- a/src/storage.py
+++ b/src/storage.py
@@ -119,7 +119,8 @@ class StorageHandler(Object):
     def _add_osd_action(self, event: ActionEvent):
         """Add OSD disks to microceph."""
         if not self.charm.peers.interface.state.joined:
-            event.fail("Node not yet joined in microceph cluster")
+            event.set_results({"message": "Node not yet joined in microceph cluster"})
+            event.fail()
             return
 
         # list of osd specs to be executed with disk add cmd.
@@ -140,7 +141,8 @@ class StorageHandler(Object):
                 microceph.add_osd_cmd(spec)
             except (CalledProcessError, TimeoutExpired) as e:
                 logger.error(e.stderr)
-                event.fail(e.stderr)
+                event.set_results({"message": e.stderr})
+                event.fail()
                 return
 
         event.set_results({"status": "success"})
@@ -148,14 +150,16 @@ class StorageHandler(Object):
     def _list_disks_action(self, event: ActionEvent):
         """List enrolled and uncofigured disks."""
         if not self.charm.peers.interface.state.joined:
-            event.fail("Node not yet joined in microceph cluster")
+            event.set_results({"message": "Node not yet joined in microceph cluster"})
+            event.fail()
             return
 
         try:
             disks = microceph.list_disk_cmd()
         except (CalledProcessError, TimeoutExpired) as e:
             logger.warning(e.stderr)
-            event.fail(e.stderr)
+            event.set_results({"message": e.stderr})
+            event.fail()
             return
 
         osds = [self._to_lower_dict(osd) for osd in disks["ConfiguredDisks"]]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -122,7 +122,9 @@ class TestCharm(test_utils.CharmTestCase):
         action_event.params = {"device-id": "/dev/sdb"}
         self.harness.charm.storage._add_osd_action(action_event)
 
-        action_event.set_results.assert_not_called()
+        action_event.set_results.assert_called_with(
+            {"message": "Node not yet joined in microceph cluster"}
+        )
         action_event.fail.assert_called()
 
     def _create_subprocess_output_mock(self, stdout):
@@ -148,7 +150,9 @@ class TestCharm(test_utils.CharmTestCase):
 
         action_event = MagicMock()
         self.harness.charm.storage._list_disks_action(action_event)
-        action_event.set_results.assert_not_called()
+        action_event.set_results.assert_called_with(
+            {"message": "Node not yet joined in microceph cluster"}
+        )
         action_event.fail.assert_called()
 
     @patch.object(microceph, "subprocess")


### PR DESCRIPTION
# Description

Current event.fail(message) adds the message to
Action object outside results. However pylibjuju
returns results dict out of action object in the
function get_action_output. So add the error
message to results dict within action object.

Fixes # https://bugs.launchpad.net/charm-microceph/+bug/2025736

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This is a breaking change since any existing tools that reads action failure output should look for error message in results dict instead of directly on action object. If needed, we can add the message at both places but it makes sense to put the error message in results dict which has return-code as well.

## How Has This Been Tested?

Unit tests are updated.
Also tested with deploying microceph using charm.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
