### PR TITLE
Fix: run ceph config on leader only

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -107,13 +107,10 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             if microceph.is_cluster_member(gethostname()):
                 raise e
 
-    def configure_charm(self, event: ops.framework.EventBase) -> None:
+    def configure_app_leader(self, event: ops.framework.EventBase) -> None:
         """Hook to apply configuration options."""
-        super().configure_charm(event)
+        super().configure_app_leader(event)
         self.configure_ceph(event)
-
-    def _on_config_changed(self, event: ops.framework.EventBase) -> None:
-        self.configure_charm(event)
 
     def _set_pool_size_action(self, event: ops.framework.EventBase) -> None:
         """Set the size for one or more pools."""
@@ -318,6 +315,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
     def configure_ceph(self, event) -> None:
         """Configure Ceph."""
+
         if not self.ready_for_service():
             event.defer()
             return


### PR DESCRIPTION
# Description

Buglet: avoid multiple calls to ceph config -- it's sufficient we run config on the leader

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
