### PR TITLE
Add config option enable-rgw

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -112,6 +112,28 @@ jobs:
           ~/actionutils.sh wait_for_osds 3
           sudo microceph.ceph -s
 
+      - name: Enable RGW
+        run: |
+          set -eux
+          juju config microceph enable-rgw="*"
+          ~/actionutils.sh wait_for_rgw 1
+
+      - name: Collect logs
+        if: always()
+        run: ./tests/scripts/ci_helpers.sh collect_sunbeam_and_microceph_logs
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: microceph_juju_functional_test_logs
+          path: logs
+          retention-days: 30
+
+      - name: Setup tmate session
+        if: ${{ failure() && runner.debug }}
+        uses: canonical/action-tmate@main
+
   juju-cluster-test:
     needs:
       - lint
@@ -181,6 +203,22 @@ jobs:
             juju status
             exit 1
           fi
+
+      - name: Collect logs
+        if: always()
+        run: ./tests/scripts/ci_helpers.sh collect_microceph_logs
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: microceph_juju_cluster_test_logs
+          path: logs
+          retention-days: 30
+
+      - name: Setup tmate session
+        if: ${{ failure() && runner.debug }}
+        uses: canonical/action-tmate@main
 
   juju-single-test:
     needs:
@@ -363,6 +401,22 @@ jobs:
           juju wait-for application microceph --query='status=="blocked"'
           juju status
           juju status blocked | egrep '^microceph/.*Cannot upgrade.*to quincy/stable'
+
+      - name: Collect logs
+        if: always()
+        run: ./tests/scripts/ci_helpers.sh collect_microceph_logs
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: microceph_juju_upgrade_test_logs
+          path: logs
+          retention-days: 30
+
+      - name: Setup tmate session
+        if: ${{ failure() && runner.debug }}
+        uses: canonical/action-tmate@main
 
   juju-network-spaces-test:
     needs:

--- a/config.yaml
+++ b/config.yaml
@@ -14,3 +14,10 @@ options:
       The default replication factor for pools. Note that changing
       this value only sets the default value; it doesn't change
       the replication factor for existing pools.
+  enable-rgw:
+    default: ""
+    type: string
+    description: |
+      Supported values for this option are
+      "*" - Enable RGW on all storage nodes
+      ""  - Disable RGW on all storage nodes

--- a/docs/how-to-guides/enable-rgw.md
+++ b/docs/how-to-guides/enable-rgw.md
@@ -1,0 +1,60 @@
+Enable/Disable Ceph RADOS Gateway by setting the config option `enable-rgw`.
+
+1. Enable RGW service
+
+    juju config microceph enable-rgw="*"
+
+2. Check microceph status
+
+    juju ssh microceph/leader sudo microceph status
+
+The output of the above command should list rgw as part of services
+running on each node.
+Sample output is:
+
+```
+MicroCeph deployment summary:
+- microceph2 (10.121.193.184)
+  Services: mds, mgr, mon, rgw, osd
+  Disks: 1
+- microceph3 (10.121.193.185)
+  Services: mds, mgr, mon, rgw, osd
+  Disks: 1
+- microceph4 (10.121.193.186)
+  Services: mds, mgr, mon, rgw, osd
+  Disks: 1
+```
+
+3. Run ceph cluster status to check if rgw daemon is running
+
+    juju ssh microceph/leader sudo microceph.ceph status
+
+The output of the above command should list rgw under services.
+Sample output is:
+
+```
+  cluster:
+    id:     edd914f5-fdf8-4b56-bdd7-95d6c5e10d81
+    health: HEALTH_OK
+ 
+  services:
+    mon: 3 daemons, quorum microceph2,microceph3,microceph4 (age 12m)
+    mgr: microceph2(active, since 13m), standbys: microceph3, microceph4
+    osd: 3 osds: 3 up (since 34s), 3 in (since 56s)
+    rgw: 3 daemons, quorum microceph2,microceph3,microceph4 (age 30s)
+ 
+  data:
+    pools:   5 pools, 5 pgs
+    objects: 2 objects, 577 KiB
+    usage:   66 MiB used, 30 GiB / 30 GiB avail
+    pgs:     5 active+clean
+ 
+  io:
+    client:   938 B/s rd, 43 KiB/s wr, 0 op/s rd, 1 op/s wr
+```
+
+Now the ceph cluster is healthy and ready to use.
+
+4. Disable RGW service
+
+    juju config microceph enable-rgw=""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["W503", "E501", "D107", "N818"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
 per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
 docstring-convention = "google"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,10 @@ netifaces
 jsonschema
 tenacity
 jinja2
-requests
+requests<2.32 # https://github.com/psf/requests/issues/6707 (similar issue with http+unix)
 git+https://opendev.org/openstack/sunbeam-charms/#egg=ops-sunbeam&subdirectory=ops-sunbeam
+
+# Used for communication with snapd socket
+requests-unixsocket # Apache 2
+urllib3<2 # https://github.com/psf/requests/issues/6432
+

--- a/src/charm.py
+++ b/src/charm.py
@@ -35,6 +35,7 @@ from ops.main import main
 import cluster
 import microceph
 from ceph_broker import get_named_key
+from microceph_client import ClusterServiceUnavailableException
 from relation_handlers import (
     CephClientProviderHandler,
     CephMdsProviderHandler,
@@ -113,7 +114,16 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         self.configure_ceph(event)
 
     def _on_config_changed(self, event: ops.framework.EventBase) -> None:
-        self.configure_charm(event)
+        with sunbeam_guard.guard(self, "Checking configs"):
+            if not self.is_valid_placement_directive(self.model.config.get("enable-rgw")):
+                raise sunbeam_guard.BlockedExceptionError("Improper value for config enable-rgw")
+
+            self.configure_charm(event)
+
+    def is_valid_placement_directive(self, directive: str) -> bool:
+        """Check if placement directive is valid or not."""
+        supported_directives = ["*", ""]
+        return directive in supported_directives
 
     def _set_pool_size_action(self, event: ops.framework.EventBase) -> None:
         """Set the size for one or more pools."""
@@ -242,6 +252,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             self.peers.interface.state.joined = True
 
         self.set_leader_ready()
+        self.manage_rgw_service(event)
         snap_chan = self.model.config.get("snap-channel")
 
         if self.cluster_upgrades.upgrade_requested(snap_chan):
@@ -258,6 +269,9 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         super().configure_app_non_leader(event)
         if isinstance(event, MicroClusterNodeAddedEvent):
             self.cluster_nodes.join_node_to_cluster(event)
+
+        if self.peers.interface.state.joined:
+            self.manage_rgw_service(event)
 
     def _get_space_subnet(self, space: str):
         """Get the first available subnet in the network space."""
@@ -316,6 +330,23 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
             if error_already_exists not in e.stderr:
                 raise e
+
+    def manage_rgw_service(self, event: ops.framework.EventBase) -> None:
+        """Enable/Disable RGW service."""
+        try:
+            enabled = microceph.is_rgw_enabled(gethostname())
+            if self.model.config.get("enable-rgw") == "*":
+                if not enabled:
+                    microceph.enable_rgw()
+            else:
+                if enabled:
+                    microceph.disable_rgw()
+        except ClusterServiceUnavailableException as e:
+            logger.warning(str(e))
+            event.defer()
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            logger.warning(e.stderr)
+            raise e
 
     def configure_ceph(self, event) -> None:
         """Configure Ceph."""

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -24,6 +24,8 @@ from typing import Tuple
 
 import requests
 
+from microceph_client import Client
+
 logger = logging.getLogger(__name__)
 
 MAJOR_VERSIONS = {
@@ -83,6 +85,20 @@ def is_cluster_member(hostname: str) -> bool:
             raise e
 
 
+def is_rgw_enabled(hostname: str) -> bool:
+    """Check if RGW service is enabled on host.
+
+    Raises ClusterServiceUnavailableException if cluster is not available.
+    """
+    client = Client.from_socket()
+    services = client.cluster.list_services()
+    for service in services:
+        if service["service"] == "rgw" and service["location"] == hostname:
+            return True
+
+    return False
+
+
 def bootstrap_cluster(micro_ip: str = None, public_net: str = None, cluster_net: str = None):
     """Bootstrap MicroCeph cluster."""
     cmd = ["microceph", "cluster", "bootstrap"]
@@ -107,6 +123,18 @@ def join_cluster(token: str, micro_ip: str = None, **kwargs):
         cmd.extend(["--microceph-ip", micro_ip])
 
     _run_cmd(cmd=cmd)
+
+
+def enable_rgw() -> None:
+    """Enable RGW service."""
+    cmd = ["microceph", "enable", "rgw"]
+    _run_cmd(cmd)
+
+
+def disable_rgw() -> None:
+    """Disable RGW service."""
+    cmd = ["microceph", "disable", "rgw"]
+    _run_cmd(cmd)
 
 
 # Disk CMDs and Helpers

--- a/src/microceph_client.py
+++ b/src/microceph_client.py
@@ -1,0 +1,174 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""The cluster client module to interact with microceph cluster.
+
+The client module can interact over unix socket or http. This
+module can be used to manage microceph cluster. All the operations
+on microceph can be performed using this module.
+"""
+
+import logging
+from abc import ABC
+from typing import List
+from urllib.parse import quote
+
+import requests_unixsocket
+import urllib3
+from requests.exceptions import ConnectionError, HTTPError
+from requests.sessions import Session
+
+LOG = logging.getLogger(__name__)
+MICROCEPH_SOCKET = "/var/snap/microceph/common/state/control.socket"
+
+
+# Add custom microceph daemon exceptions here
+class RemoteException(Exception):
+    """An Exception raised when interacting with the remote microclusterd service."""
+
+    pass
+
+
+class ClusterServiceUnavailableException(RemoteException):
+    """Raised when cluster service is not yet bootstrapped."""
+
+    pass
+
+
+class CephServiceNotFoundException(RemoteException):
+    """Raised when ceph service is not found."""
+
+    pass
+
+
+class BaseService(ABC):
+    """BaseService is the base service class for microclusterd services."""
+
+    def __init__(self, session: Session, endpoint: str):
+        """Creates a new BaseService for the  microceph daemon API.
+
+        The service class is used to provide convenient APIs for clients to
+        use when interacting with the microceph daemon api.
+
+
+        :param session: session to use when interacting with the microceph daemon API
+        :type: Session
+        :param endpoint: http or unix socket microceph daemon API endpoint
+        :type: str
+        """
+        self.__session = session
+        self._endpoint = endpoint
+
+    def _request(self, method, path, **kwargs):
+        if path.startswith("/"):
+            path = path[1:]
+        netloc = self._endpoint
+        url = f"{netloc}/{path}"
+
+        try:
+            LOG.debug("[%s] %s, args=%s", method, url, kwargs)
+            response = self.__session.request(method=method, url=url, **kwargs)
+            LOG.debug("Response(%s) = %s", response, response.text)
+        except ConnectionError as e:
+            msg = str(e)
+            if "FileNotFoundError" in msg:
+                raise ClusterServiceUnavailableException(
+                    "Microceph Cluster socket not found, is clusterd running ?"
+                    " Check with 'snap services microceph.daemon'",
+                ) from e
+            raise ClusterServiceUnavailableException(msg)
+
+        try:
+            response.raise_for_status()
+        except HTTPError as e:
+            # Do some nice translating to microcephd exceptions
+            error = response.json().get("error")
+            LOG.warning(error)
+            if "Daemon not yet initialized" in error:
+                raise ClusterServiceUnavailableException("Microceph Cluster not initialized")
+            elif 'failed to remove service from db "rgw": Service not found' in error:
+                raise CephServiceNotFoundException("RGW Service not found")
+            else:
+                raise e
+
+        return response.json()
+
+    def _get(self, path, **kwargs):
+        kwargs.setdefault("allow_redirects", True)
+        return self._request("get", path, **kwargs)
+
+    def _head(self, path, **kwargs):
+        kwargs.setdefault("allow_redirects", False)
+        return self._request("head", path, **kwargs)
+
+    def _post(self, path, data=None, json=None, **kwargs):
+        return self._request("post", path, data=data, json=json, **kwargs)
+
+    def _patch(self, path, data=None, **kwargs):
+        return self._request("patch", path, data=data, **kwargs)
+
+    def _put(self, path, data=None, **kwargs):
+        return self._request("put", path, data=data, **kwargs)
+
+    def _delete(self, path, **kwargs):
+        return self._request("delete", path, **kwargs)
+
+    def _options(self, path, **kwargs):
+        kwargs.setdefault("allow_redirects", True)
+        return self._request("options", path, **kwargs)
+
+
+class Client:
+    """A client for interacting with the remote client API."""
+
+    def __init__(self, endpoint: str):
+        super(Client, self).__init__()
+        self._endpoint = endpoint
+        self._session = Session()
+        if self._endpoint.startswith("http+unix://"):
+            self._session.mount(
+                requests_unixsocket.DEFAULT_SCHEME, requests_unixsocket.UnixAdapter()
+            )
+        else:
+            # TODO(gboutry): remove this when proper TLS communication is
+            # implemented
+            urllib3.disable_warnings()
+            self._session.verify = False
+
+        self.cluster = ClusterService(self._session, self._endpoint)
+
+    @classmethod
+    def from_socket(cls) -> "Client":
+        """Return a client initialized to the clusterd socket."""
+        escaped_socket_path = quote(MICROCEPH_SOCKET, safe="")
+        return cls("http+unix://" + escaped_socket_path)
+
+    @classmethod
+    def from_http(cls, endpoint: str) -> "Client":
+        """Return a client initialized to the clusterd http endpoint."""
+        return cls(endpoint)
+
+
+class ClusterService(BaseService):
+    """Lists and manages microceph cluster.
+
+    Placeholder to add socket API calls to interact with microceph daemon instead
+    of using microceph cli subprocess.
+    """
+
+    def list_services(self) -> List[str]:
+        """List all services."""
+        services = self._get("/1.0/services")
+        return services.get("metadata")


### PR DESCRIPTION
# Description

Add new option enable-rgw. 
If the option is "*", enable the rgw on all microceph nodes.
If the option is "", enable the rgw on all microceph nodes.

Add cluster client to interact with microceph
daemon over unix socket. For now, add a function
to get all services from the cluster. In future,
this client can be enhanced to bootstrap the
cluster, join new nodes etc.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update (Doc only change)

## How Has This Been Tested?

Deployed juju with manual controller.
Deployed charm-microceph with single unit with new config set to true.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
