### PR TITLE
Fix set-pool-size action with multiple pools

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -395,9 +395,11 @@ jobs:
       - name: Test the set-pool-size action
         run: |
           set -eux
-          juju ssh microceph/0 -- sudo ceph osd pool create mypool
-          juju run microceph/0 set-pool-size pools=mypool size=1
-          juju ssh microceph/0 -- sudo ceph osd pool get mypool size | fgrep -x "size: 1"
+          juju ssh microceph/0 -- sudo ceph osd pool create mypool1
+          juju ssh microceph/0 -- sudo ceph osd pool create mypool2
+          juju run microceph/0 set-pool-size pools=mypool1,mypool2 size=1
+          juju ssh microceph/0 -- sudo ceph osd pool get mypool1 size | fgrep -x "size: 1"
+          juju ssh microceph/0 -- sudo ceph osd pool get mypool2 size | fgrep -x "size: 1"
 
       - name: Test that downgrade blocks
         run: |

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -273,9 +273,11 @@ def can_upgrade_snap(current, new: str) -> bool:
     return newer
 
 
-def set_pool_size(pools, size):
+def set_pool_size(pools: str, size: int):
     """Set the size for one or more pools."""
-    cmd = ["sudo", "microceph", "pool", "set-rf", "--size", str(size), pools]
+    pools_list = pools.split(",")
+    cmd = ["sudo", "microceph", "pool", "set-rf", "--size", str(size)]
+    cmd.extend(pools_list)
     _run_cmd(cmd)
 
 

--- a/tests/scripts/ci_helpers.sh
+++ b/tests/scripts/ci_helpers.sh
@@ -80,8 +80,10 @@ function collect_microceph_logs() {
     juju debug-log -m $model --replay &> logs/$model_-debug-log.txt || echo "Not able to get logs for model $model"
     juju ssh microceph/leader sudo microceph status &> logs/microceph-status.txt || true
     juju ssh microceph/leader sudo microceph.ceph status &> logs/ceph-status.txt || true
+    juju ssh microceph/leader sudo ceph osd pool ls detail &> logs/ceph-pools.txt || true
     cat logs/$model_.yaml
     cat logs/microceph-status.txt
+    cat logs/ceph-pools.txt
 }
 
 function collect_sunbeam_and_microceph_logs() {

--- a/tests/scripts/ci_helpers.sh
+++ b/tests/scripts/ci_helpers.sh
@@ -80,10 +80,8 @@ function collect_microceph_logs() {
     juju debug-log -m $model --replay &> logs/$model_-debug-log.txt || echo "Not able to get logs for model $model"
     juju ssh microceph/leader sudo microceph status &> logs/microceph-status.txt || true
     juju ssh microceph/leader sudo microceph.ceph status &> logs/ceph-status.txt || true
-    juju ssh microceph/leader sudo ceph osd pool ls detail &> logs/ceph-pools.txt || true
     cat logs/$model_.yaml
     cat logs/microceph-status.txt
-    cat logs/ceph-pools.txt
 }
 
 function collect_sunbeam_and_microceph_logs() {


### PR DESCRIPTION
# Description

Currently for set-pool-size action, the input param pools is passed directly to `microceph pool set-rf` command.
So in case of multiple pools, the pools is passed as single string to microceph command.
Instead the pools should be passed as list or space delimitted strings.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI job `Juju Upgrade Test` is updated to verify this scenario.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] added tests to verify effectiveness of this change.
