### PR TITLE
Don't try to join a cluster that we are already a member of.

### DIFF
--- a/src/cluster.py
+++ b/src/cluster.py
@@ -70,6 +70,10 @@ class ClusterNodes(ops.framework.Object):
             event.defer()
             return
 
+        if self.charm.peers.interface.state.joined is True:
+            logger.info("Unit has already joined the cluster")
+            return
+
         try:
             microceph.join_cluster(token=token, **self.charm._get_bootstrap_params())
             self.charm.peers.interface.state.joined = True


### PR DESCRIPTION
Fixes: LP:#2069672

# Description

Currently, the charm has the ability to attempt to re-join a cluster that it is already a member of. Most likely this is due to the setup not being completed prior to trying to rejoin. I suspect possibly on less than ideal hardware.

Fixes #2069672

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
