### PR TITLE
Delete rgw config only if it exists in db

### DIFF
--- a/src/microceph.py
+++ b/src/microceph.py
@@ -133,7 +133,9 @@ def delete_cluster_configs(configs: list):
     Raises ClusterServiceUnavailableException
     """
     client = Client.from_socket()
-    for key in configs:
+    configs_from_db = list_cluster_configs()
+    configs_to_delete = set(configs) & set(configs_from_db.keys())
+    for key in configs_to_delete:
         try:
             logger.debug(f"Removing microceph cluster config {key}")
             client.cluster.delete_config(key)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -104,12 +104,13 @@ class TestCharm(test_utils.CharmTestCase):
     @patch("builtins.open", new_callable=mock_open, read_data="mon host dummy-ip")
     def test_all_relations(self, mock_file, subprocess, cclient):
         """Test all the charms relations."""
+        cclient.from_socket().cluster.list_services.return_value = []
+
         self.harness.set_leader()
         self.harness.update_config({"snap-channel": "1.0/stable"})
         self.add_complete_peer_relation(self.harness)
         self.add_complete_identity_relation(self.harness)
         self.add_complete_ingress_relation(self.harness)
-        cclient().cluster.list_services.return_value = []
         subprocess.run.assert_any_call(
             [
                 "microceph",
@@ -127,11 +128,6 @@ class TestCharm(test_utils.CharmTestCase):
             check=True,
             timeout=180,
         )
-        # Remove RGW configs when RGW is not enabled
-        # The function might be called more than one time as it is part of
-        # configure_charm and so assert any one removal of config instead
-        # of call count.
-        cclient.from_socket().cluster.delete_config.assert_any_call("rgw_keystone_url")
 
         # Assert RGW update configs is not called
         cclient.from_socket().cluster.update_config.assert_not_called()
@@ -141,12 +137,13 @@ class TestCharm(test_utils.CharmTestCase):
     @patch("builtins.open", new_callable=mock_open, read_data="mon host dummy-ip")
     def test_all_relations_with_enable_rgw_config(self, mock_file, subprocess, cclient):
         """Test all the charms relations."""
+        cclient.from_socket().cluster.list_services.return_value = []
+
         self.harness.set_leader()
         self.harness.update_config({"snap-channel": "1.0/stable", "enable-rgw": "*"})
         test_utils.add_complete_peer_relation(self.harness)
         self.add_complete_identity_relation(self.harness)
         self.add_complete_ingress_relation(self.harness)
-        cclient().cluster.list_services.return_value = []
         subprocess.run.assert_any_call(
             [
                 "microceph",
@@ -189,6 +186,8 @@ class TestCharm(test_utils.CharmTestCase):
         self, mock_file, subprocess, cclient
     ):
         """Test all the charms relations."""
+        cclient.from_socket().cluster.list_services.return_value = []
+
         self.harness.set_leader()
         self.harness.update_config(
             {"snap-channel": "1.0/stable", "enable-rgw": "*", "namespace-projects": True}
@@ -196,7 +195,6 @@ class TestCharm(test_utils.CharmTestCase):
         test_utils.add_complete_peer_relation(self.harness)
         self.add_complete_identity_relation(self.harness)
         self.add_complete_ingress_relation(self.harness)
-        cclient().cluster.list_services.return_value = []
         subprocess.run.assert_any_call(
             [
                 "microceph",

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -1,0 +1,157 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Microceph helper functions."""
+
+import unittest
+from unittest.mock import patch
+
+import microceph
+
+
+class TestMicroCeph(unittest.TestCase):
+
+    @patch("microceph.Client")
+    def test_is_rgw_enabled_service_not_running(self, cclient):
+        """Test is_rgw_enabled when service is not running."""
+        cclient.from_socket().cluster.list_services.return_value = [
+            {"service": "mds", "location": "fake-host"},
+            {"service": "mgr", "location": "fake-host"},
+            {"service": "mon", "location": "fake-host"},
+        ]
+        self.assertFalse(microceph.is_rgw_enabled("fake-host"))
+
+    @patch("microceph.Client")
+    def test_is_rgw_enabled_service_running(self, cclient):
+        """Test is_rgw_enabled when service running."""
+        cclient.from_socket().cluster.list_services.return_value = [
+            {"service": "mds", "location": "fake-host"},
+            {"service": "mgr", "location": "fake-host"},
+            {"service": "mon", "location": "fake-host"},
+            {"service": "rgw", "location": "fake-host"},
+        ]
+        self.assertTrue(microceph.is_rgw_enabled("fake-host"))
+
+    @patch("microceph.Client")
+    def test_is_rgw_enabled_service_running_and_host_mismatch(self, cclient):
+        """Test is_rgw_enabled with host mismatch."""
+        cclient.from_socket().cluster.list_services.return_value = [
+            {"service": "mds", "location": "fake-host"},
+            {"service": "mgr", "location": "fake-host"},
+            {"service": "mon", "location": "fake-host"},
+            {"service": "rgw", "location": "fake-host-2"},
+        ]
+        self.assertFalse(microceph.is_rgw_enabled("fake-host"))
+
+    @patch("microceph.Client")
+    def test_update_cluster_configs(self, cclient):
+        """Test update_cluster_configs."""
+        cclient.from_socket().cluster.get_config.return_value = [
+            {"key": "cluster_network", "value": "10.121.193.0/24", "wait": False},
+            {"key": "osd_pool_default_crush_rule", "value": "1", "wait": False},
+        ]
+        configs_to_update = {"rgw_keystone_url": "http://dummy-ip"}
+        microceph.update_cluster_configs(configs_to_update)
+
+        cclient.from_socket().cluster.update_config.assert_called_with(
+            "rgw_keystone_url", "http://dummy-ip"
+        )
+
+    @patch("microceph.Client")
+    def test_update_cluster_configs_with_some_configs_already_in_db(self, cclient):
+        """Test update_cluster_configs with mix of configs in db and input."""
+        cclient.from_socket().cluster.get_config.return_value = [
+            {"key": "cluster_network", "value": "10.121.193.0/24", "wait": False},
+            {"key": "osd_pool_default_crush_rule", "value": "1", "wait": False},
+            {"key": "rgw_keystone_url", "value": "https://dummy-ip", "wait": False},
+            {"key": "rgw_keystone_accepted_roles", "value": "admin", "wait": False},
+        ]
+        configs_to_update = {
+            "rgw_keystone_url": "https://dummy-ip",
+            "rgw_keystone_verify_ssl": "false",
+            "rgw_keystone_accepted_roles": "Member,member",
+        }
+        microceph.update_cluster_configs(configs_to_update)
+
+        configs_updated = [
+            call.args[0] for call in cclient.from_socket().cluster.update_config.mock_calls
+        ]
+        assert "rgw_keystone_url" not in configs_updated
+        assert "rgw_keystone_verify_ssl" in configs_updated
+        assert "rgw_keystone_accepted_roles" in configs_updated
+
+    @patch("microceph.Client")
+    def test_update_cluster_configs_with_all_configs_already_in_db(self, cclient):
+        """Test update_cluster_configs with all configs in db."""
+        cclient.from_socket().cluster.get_config.return_value = [
+            {"key": "cluster_network", "value": "10.121.193.0/24", "wait": False},
+            {"key": "osd_pool_default_crush_rule", "value": "1", "wait": False},
+            {"key": "rgw_keystone_url", "value": "https://dummy-ip", "wait": False},
+            {"key": "rgw_keystone_verify_ssl", "value": "false", "wait": False},
+        ]
+        configs_to_update = {
+            "rgw_keystone_url": "https://dummy-ip",
+            "rgw_keystone_verify_ssl": "false",
+        }
+        microceph.update_cluster_configs(configs_to_update)
+
+        cclient.from_socket().cluster.update_config.assert_not_called()
+
+    @patch("microceph.Client")
+    def test_delete_cluster_configs(self, cclient):
+        """Test delete_cluster_configs with configs to delete not in db."""
+        cclient.from_socket().cluster.get_config.return_value = [
+            {"key": "cluster_network", "value": "10.121.193.0/24", "wait": False},
+            {"key": "osd_pool_default_crush_rule", "value": "1", "wait": False},
+        ]
+        configs_to_delete = ["rgw_keystone_url"]
+        microceph.delete_cluster_configs(configs_to_delete)
+
+        cclient.from_socket().cluster.delete_config.assert_not_called()
+
+    @patch("microceph.Client")
+    def test_delete_cluster_configs_with_some_configs_already_in_db(self, cclient):
+        """Test delete_cluster_configs with mix of configs to delete in db and input."""
+        cclient.from_socket().cluster.get_config.return_value = [
+            {"key": "cluster_network", "value": "10.121.193.0/24", "wait": False},
+            {"key": "osd_pool_default_crush_rule", "value": "1", "wait": False},
+            {"key": "rgw_keystone_url", "value": "https://dummy-ip", "wait": False},
+            {"key": "rgw_keystone_accepted_roles", "value": "admin", "wait": False},
+        ]
+        configs_to_delete = ["rgw_keystone_url", "rgw_keystone_verify_ssl"]
+        microceph.delete_cluster_configs(configs_to_delete)
+
+        configs_deleted = [
+            call.args[0] for call in cclient.from_socket().cluster.delete_config.mock_calls
+        ]
+        assert "rgw_keystone_url" in configs_deleted
+        assert "rgw_keystone_verify_ssl" not in configs_deleted
+
+    @patch("microceph.Client")
+    def test_delete_cluster_configs_with_all_configs_already_in_db(self, cclient):
+        """Test delete_cluster_configs with all rgw configs to be deleted."""
+        cclient.from_socket().cluster.get_config.return_value = [
+            {"key": "cluster_network", "value": "10.121.193.0/24", "wait": False},
+            {"key": "osd_pool_default_crush_rule", "value": "1", "wait": False},
+            {"key": "rgw_keystone_url", "value": "https://dummy-ip", "wait": False},
+            {"key": "rgw_keystone_accepted_roles", "value": "admin", "wait": False},
+        ]
+        configs_to_delete = ["rgw_keystone_url", "rgw_keystone_accepted_roles"]
+        microceph.delete_cluster_configs(configs_to_delete)
+
+        configs_deleted = [
+            call.args[0] for call in cclient.from_socket().cluster.delete_config.mock_calls
+        ]
+        assert "rgw_keystone_url" in configs_deleted
+        assert "rgw_keystone_accepted_roles" in configs_deleted


### PR DESCRIPTION
Currently microceph daemon API is called to
delete rgw config irrespective of config exists
or not as the daemon call does not return
error if config does not exist in db. However
this causes time delays in running ceph command
for each config given there are almost 15 configs
introduced for rgw.
Add a check to call delete config API call
only when the config exists in db.

Fixes # #91 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual testing
Unit testing

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.