### PR TITLE
Refresh juju to 3.4 in functional test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -76,6 +76,7 @@ jobs:
           date
           sudo snap install openstack --channel 2023.2
           sunbeam prepare-node-script | bash -x
+          sudo snap refresh juju --channel 3.4/stable
           sg snap_daemon "sunbeam cluster bootstrap --accept-defaults"
           sg snap_daemon "sunbeam cluster list"
           juju status -m admin/controller


### PR DESCRIPTION
sunbeam 2023.2 is broken with charm mysql-k8s
added dependency of juju >=3.4.
Refresh juju snap to 3.4 as workaround.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

CI testing should be good enough for this change

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
