### PR TITLE
Configure ceph before enabling rgw service

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -121,11 +121,6 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
     def _on_peer_relation_departed(self, event: ops.framework.EventBase) -> None:
         self.handle_traefik_ready(event)
 
-    def configure_charm(self, event: ops.framework.EventBase) -> None:
-        """Hook to apply configuration options."""
-        super().configure_charm(event)
-        self.configure_ceph(event)
-
     def _on_config_changed(self, event: ops.framework.EventBase) -> None:
         with sunbeam_guard.guard(self, "Checking configs"):
             if not self.is_valid_placement_directive(self.model.config.get("enable-rgw")):
@@ -385,6 +380,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             self.leader_set(
                 {"namespace-projects": json.dumps(self.model.config.get("namespace-projects"))}
             )
+        self.configure_ceph(event)
         self.manage_rgw_service(event)
         snap_chan = self.model.config.get("snap-channel")
 


### PR DESCRIPTION
Config option default-pool-size resets the
osd_pool_default_size and rgw service picks
the replication size from osd_pool_default_size.
So ceph osd_pool_default_size should be configured first before enabling rgw so that rgw will be
created with right pool replication sizes.

Call configure ceph logic before enabling rgw.
Configure ceph only on leader unit.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual Testing with sunbeam

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
