### PR TITLE
Pass all MON addresses in relation databag.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -389,6 +389,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         return {
             "auth": "cephx",
             "ceph-public-address": self._lookup_system_interfaces(public_addrs),
+            "ceph-public-addresses": public_addrs,
             "key": get_named_key(name=service_name, caps=caps),
         }
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -389,7 +389,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         return {
             "auth": "cephx",
             "ceph-public-address": self._lookup_system_interfaces(public_addrs),
-            "ceph-public-addresses": public_addrs,
+            "ceph-mon-public-addresses": public_addrs,
             "key": get_named_key(name=service_name, caps=caps),
         }
 

--- a/src/relation_handlers.py
+++ b/src/relation_handlers.py
@@ -559,7 +559,7 @@ class CephClientProvides(Object):
             return
 
         # Place this key (if it exists) in the application data bag.
-        mon_key = 'ceph-mon-public-addresses'
+        mon_key = "ceph-mon-public-addresses"
         mon_addrs = data.pop(mon_key, None)
         if mon_addrs is not None and self.model.unit.is_leader():
             relation.data[self.model.application][mon_key] = str(mon_addrs)

--- a/src/relation_handlers.py
+++ b/src/relation_handlers.py
@@ -558,6 +558,12 @@ class CephClientProvides(Object):
             # Relation has disappeared so skip send of data
             return
 
+        # Place this key (if it exists) in the applicaton data bag.
+        mon_key = 'ceph-mon-public-addresses'
+        mon_addrs = data.pop(mon_key, None)
+        if mon_addrs is not None and self.model.unit.is_leader():
+            relation.data[self.model.application][mon_key] = str(mon_addrs)
+
         for k, v in data.items():
             relation.data[self.this_unit][k] = str(v)
 

--- a/src/relation_handlers.py
+++ b/src/relation_handlers.py
@@ -558,7 +558,7 @@ class CephClientProvides(Object):
             # Relation has disappeared so skip send of data
             return
 
-        # Place this key (if it exists) in the applicaton data bag.
+        # Place this key (if it exists) in the application data bag.
         mon_key = 'ceph-mon-public-addresses'
         mon_addrs = data.pop(mon_key, None)
         if mon_addrs is not None and self.model.unit.is_leader():


### PR DESCRIPTION
# Description

This patchset makes the charm pass all the mon addresses in the relation databag instead of only the local one. This is meant to workaround this issue: https://bugs.launchpad.net/snap-openstack/+bug/2066167

## Type of change

- New feature (non-breaking change which adds functionality)

## Contributor's Checklist

Please check that you have:

- [X] self-reviewed the code in this PR.
