### PR TITLE
Add action get-rgw-endpoints

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -32,3 +32,6 @@ set-pool-size:
   required:
     - pools
     - size
+get-rgw-endpoints:
+  description: |
+    S3 and swift public endpoints for Rados Gateway.

--- a/src/charm.py
+++ b/src/charm.py
@@ -38,6 +38,7 @@ import cluster
 import microceph
 from ceph_broker import get_named_key
 from microceph_client import ClusterServiceUnavailableException
+from radosgw import RadosGWHandler
 from relation_handlers import (
     CephClientProviderHandler,
     CephMdsProviderHandler,
@@ -68,6 +69,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         self.storage = StorageHandler(self)
         self.cluster_nodes = cluster.ClusterNodes(self)
         self.cluster_upgrades = cluster.ClusterUpgrades(self)
+        self.rgw = RadosGWHandler(self)
 
         # Initialise handlers for events.
         self.framework.observe(self.on.install, self._on_install)

--- a/src/radosgw.py
+++ b/src/radosgw.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Handle Charm's RADOS Gateway Events."""
+
+import logging
+
+from ops.charm import ActionEvent, CharmBase
+from ops.framework import Object
+
+logger = logging.getLogger(__name__)
+
+
+class RadosGWHandler(Object):
+    """The RadosGW class manages the rgw events."""
+
+    name = "rgw"
+    charm = None
+
+    def __init__(self, charm: CharmBase, name="rgw"):
+        super().__init__(charm, name)
+        self.charm = charm
+        self.name = name
+
+        self.framework.observe(charm.on.get_rgw_endpoints_action, self._get_rgw_endpoints_action)
+
+    def _get_rgw_endpoints_action(self, event: ActionEvent):
+        """Return Rados Gateway endpoints."""
+        endpoints = {
+            endpoint.get("service_name"): endpoint.get("public_url")
+            for endpoint in self.charm.service_endpoints
+        }
+        logger.debug(f"RGW endpoints: {endpoints}")
+        if endpoints:
+            event.set_results(endpoints)
+            return
+
+        event.set_results({"message": "Rados gateway endpoints are not set yet"})
+        event.fail()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -537,3 +537,39 @@ class TestCharm(test_utils.CharmTestCase):
         mock_get_snap_tracks.return_value = {"zoidberg", "alphaville", "pyjama"}
         result = microceph.can_upgrade_snap("squid", "pyjama")
         self.assertTrue(result)
+
+    def test_get_rgw_endpoints_action_node_not_bootstrapped(self):
+        """Test action get_rgw_endpoints when node not bootstrapped."""
+        test_utils.add_complete_peer_relation(self.harness)
+
+        action_event = MagicMock()
+        self.harness.charm.rgw._get_rgw_endpoints_action(action_event)
+        action_event.set_results.assert_called_with(
+            {"message": "Rados gateway endpoints are not set yet"}
+        )
+        action_event.fail.assert_called()
+
+    @patch.object(microceph, "Client")
+    @patch.object(microceph, "subprocess")
+    @patch("builtins.open", new_callable=mock_open, read_data="mon host dummy-ip")
+    def test_get_rgw_endpoints_action_after_traefik_is_integrated(
+        self, mock_file, subprocess, cclient
+    ):
+        """Test action get_rgw_endpoints after traefik is integrated."""
+        cclient.from_socket().cluster.list_services.return_value = []
+        self.harness.set_leader()
+        self.harness.update_config(
+            {"snap-channel": "1.0/stable", "enable-rgw": "*", "namespace-projects": True}
+        )
+        test_utils.add_complete_peer_relation(self.harness)
+        self.add_complete_identity_relation(self.harness)
+        self.add_complete_ingress_relation(self.harness)
+
+        action_event = MagicMock()
+        self.harness.charm.rgw._get_rgw_endpoints_action(action_event)
+        expected_endpoints = {
+            "swift": "http://dummy-ip/swift/v1/AUTH_$(project_id)s",
+            "s3": "http://dummy-ip",
+        }
+        action_event.set_results.assert_called_with(expected_endpoints)
+        action_event.fail.assert_not_called()


### PR DESCRIPTION
Add an action get-rgw-endpoints that
returns both S3 and Swift public endpoints.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit tests added

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
