### PR TITLE
Use json instead of str to dump ceph-mon-public-addresses

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -23,4 +23,4 @@ parts:
       - cryptography
       - jsonschema
       - jinja2
-      - git+https://opendev.org/openstack/charm-ops-sunbeam#egg=ops_sunbeam
+      - git+https://opendev.org/openstack/sunbeam-charms/#egg=ops-sunbeam&subdirectory=ops-sunbeam

--- a/src/relation_handlers.py
+++ b/src/relation_handlers.py
@@ -562,7 +562,7 @@ class CephClientProvides(Object):
         mon_key = "ceph-mon-public-addresses"
         mon_addrs = data.pop(mon_key, None)
         if mon_addrs is not None and self.model.unit.is_leader():
-            relation.data[self.model.app][mon_key] = str(mon_addrs)
+            relation.data[self.model.app][mon_key] = json.dumps(mon_addrs)
 
         for k, v in data.items():
             relation.data[self.this_unit][k] = str(v)


### PR DESCRIPTION
# Description

list ceph-mon-public-addresses is converted to string using str. Use json.dumps instead.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual testing with sunbeam multi node.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.