### PR TITLE
Fix: add jammy and x64 labels for self-hosted runners

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,7 +57,7 @@ jobs:
       - unit-test
       - build
     name: Functional test
-    runs-on: [self-hosted, xlarge]
+    runs-on: [self-hosted, xlarge, jammy, x64]
     steps:
 
       - name: Download charm
@@ -141,7 +141,7 @@ jobs:
       - unit-test
       - build
     name: Juju cluster test
-    runs-on: [self-hosted, xlarge]
+    runs-on: [self-hosted, xlarge, jammy, x64]
     steps:
 
       - name: Download charm
@@ -227,7 +227,7 @@ jobs:
       - unit-test
       - build
     name: Juju single test
-    runs-on: [self-hosted, xlarge]
+    runs-on: [self-hosted, xlarge, jammy, x64]
     steps:
 
       - name: Download charm
@@ -311,7 +311,7 @@ jobs:
       - unit-test
       - build
     name: Juju upgrade test
-    runs-on: [self-hosted, xlarge]
+    runs-on: [self-hosted, xlarge, jammy, x64]
     steps:
 
       - name: Download charm
@@ -441,7 +441,7 @@ jobs:
       - unit-test
       - build
     name: Juju Network spaces test
-    runs-on: [self-hosted, xlarge]
+    runs-on: [self-hosted, xlarge, jammy, x64]
     steps:
 
       - name: Download charm
@@ -494,7 +494,7 @@ jobs:
       - unit-test
       - build
     name: Juju mds test
-    runs-on: [self-hosted, xlarge]
+    runs-on: [self-hosted, xlarge, jammy, x64]
     steps:
 
       - name: Download charm


### PR DESCRIPTION
Re-doing PR #62 from jdkandersson as that had some (spurious?) testing faults which I can't re-run

# Description

Adds labels for runners

## Type of change

Please delete options that are not relevant.

- [x] CleanCode (Code refactor, test updates, does not introduce functional changes)

## How Has This Been Tested?

Existing tests

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
