### PR TITLE
Only restart once with bulk config setting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,13 @@
 cryptography
-ops
+ops==2.15
 pyroute2
 netifaces
 jsonschema
 tenacity
 jinja2
 requests<2.32 # https://github.com/psf/requests/issues/6707 (similar issue with http+unix)
-git+https://opendev.org/openstack/sunbeam-charms/#egg=ops-sunbeam&subdirectory=ops-sunbeam
+git+https://opendev.org/openstack/sunbeam-charms/@471e8b9f81c669b2ff2e10c4727e2a4d4bbc28b1#egg=ops-sunbeam&subdirectory=ops-sunbeam
 
 # Used for communication with snapd socket
 requests-unixsocket # Apache 2
 urllib3<2 # https://github.com/psf/requests/issues/6432
-

--- a/src/microceph_client.py
+++ b/src/microceph_client.py
@@ -193,9 +193,9 @@ class ClusterService(BaseService):
         configs = self._get("/1.0/configs", data=json.dumps(data))
         return configs.get("metadata")
 
-    def update_config(self, key: str, value: Any):
+    def update_config(self, key: str, value: Any, skip_restart: bool = False):
         """Update configuration in database, create if missing."""
-        data = {"key": key, "value": value, "wait": True}
+        data = {"key": key, "value": value, "wait": True, "skip_restart": skip_restart}
         self._put("/1.0/configs", data=json.dumps(data))
 
     def delete_config(self, key: str):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -252,7 +252,7 @@ class TestCharm(test_utils.CharmTestCase):
         # Check config rgw_keystone_verify_ssl is updated since certificate
         # transfer relation is set
         cclient.from_socket().cluster.update_config.assert_any_call(
-            "rgw_keystone_verify_ssl", str(True).lower()
+            "rgw_keystone_verify_ssl", str(True).lower(), True
         )
 
     @patch.object(microceph, "Client")
@@ -307,13 +307,13 @@ class TestCharm(test_utils.CharmTestCase):
         # Check config rgw_swift_account_in_url is updated since
         # namespace-projects is set to True.
         cclient.from_socket().cluster.update_config.assert_any_call(
-            "rgw_swift_account_in_url", str(True).lower()
+            "rgw_swift_account_in_url", str(True).lower(), True
         )
 
         # Check config rgw_keystone_verify_ssl is updated since certificate
         # transfer relation is set
         cclient.from_socket().cluster.update_config.assert_any_call(
-            "rgw_keystone_verify_ssl", str(True).lower()
+            "rgw_keystone_verify_ssl", str(True).lower(), True
         )
 
     @patch.object(microceph, "Client")
@@ -366,13 +366,13 @@ class TestCharm(test_utils.CharmTestCase):
         # Check config rgw_swift_account_in_url is updated since
         # namespace-projects is set to True.
         cclient.from_socket().cluster.update_config.assert_any_call(
-            "rgw_swift_account_in_url", str(True).lower()
+            "rgw_swift_account_in_url", str(True).lower(), True
         )
 
         # Check config rgw_keystone_verify_ssl is updated since certificate
         # transfer relation is set
         cclient.from_socket().cluster.update_config.assert_any_call(
-            "rgw_keystone_verify_ssl", str(False).lower()
+            "rgw_keystone_verify_ssl", str(False).lower(), True
         )
 
     @patch.object(microceph, "subprocess")

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -65,7 +65,7 @@ class TestMicroCeph(unittest.TestCase):
         microceph.update_cluster_configs(configs_to_update)
 
         cclient.from_socket().cluster.update_config.assert_called_with(
-            "rgw_keystone_url", "http://dummy-ip"
+            "rgw_keystone_url", "http://dummy-ip", False
         )
 
     @patch("microceph.Client")


### PR DESCRIPTION
# Description
When updating several config items at once, only restart services at the end. This is relevant for the RGW configuration which sets 

Also pin operator libs for harness compatibility

Fixes #113 #96

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

Manual test to verify 

Unittests updated

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
