### PR TITLE
Clean patch for squid clustering issue

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,7 +54,6 @@ jobs:
   functional-test:
     needs:
       - lint
-      - unit-test
       - build
     name: Functional test
     runs-on: [self-hosted, xlarge]
@@ -138,7 +137,6 @@ jobs:
   juju-cluster-test:
     needs:
       - lint
-      - unit-test
       - build
     name: Juju cluster test
     runs-on: [self-hosted, xlarge]
@@ -224,7 +222,6 @@ jobs:
   juju-single-test:
     needs:
       - lint
-      - unit-test
       - build
     name: Juju single test
     runs-on: [self-hosted, xlarge]
@@ -308,7 +305,6 @@ jobs:
   juju-upgrade-test:
     needs:
       - lint
-      - unit-test
       - build
     name: Juju upgrade test
     runs-on: [self-hosted, xlarge]
@@ -438,7 +434,6 @@ jobs:
   juju-network-spaces-test:
     needs:
       - lint
-      - unit-test
       - build
     name: Juju Network spaces test
     runs-on: [self-hosted, xlarge]
@@ -491,7 +486,6 @@ jobs:
   juju-mds-test:
     needs:
       - lint
-      - unit-test
       - build
     name: Juju mds test
     runs-on: [self-hosted, xlarge]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,9 +54,10 @@ jobs:
   functional-test:
     needs:
       - lint
+      - unit-test
       - build
     name: Functional test
-    runs-on: [self-hosted, xlarge]
+    runs-on: [self-hosted, large, ubuntu-24.04]
     steps:
 
       - name: Download charm
@@ -137,6 +138,7 @@ jobs:
   juju-cluster-test:
     needs:
       - lint
+      - unit-test
       - build
     name: Juju cluster test
     runs-on: [self-hosted, xlarge]
@@ -222,6 +224,7 @@ jobs:
   juju-single-test:
     needs:
       - lint
+      - unit-test
       - build
     name: Juju single test
     runs-on: [self-hosted, xlarge]
@@ -305,6 +308,7 @@ jobs:
   juju-upgrade-test:
     needs:
       - lint
+      - unit-test
       - build
     name: Juju upgrade test
     runs-on: [self-hosted, xlarge]
@@ -434,6 +438,7 @@ jobs:
   juju-network-spaces-test:
     needs:
       - lint
+      - unit-test
       - build
     name: Juju Network spaces test
     runs-on: [self-hosted, xlarge]
@@ -476,6 +481,8 @@ jobs:
           mv ~/artifacts/microceph.charm ./tests/scripts/assets/
           juju deploy ./tests/scripts/assets/juju-spaces-bundle.yaml
           # wait for charm to bootstrap and OSD devices to enroll.
+          sleep 10m
+          juju status
           juju wait-for unit microceph/0 --query='workload-message=="(workload) charm is ready"' --timeout=20m
           bash ./tests/scripts/ci_helpers.sh check_osd_count microceph/0 3
           date
@@ -486,6 +493,7 @@ jobs:
   juju-mds-test:
     needs:
       - lint
+      - unit-test
       - build
     name: Juju mds test
     runs-on: [self-hosted, xlarge]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install sunbeam
         run: |
           date
-          sudo snap install openstack --channel 2023.2
+          sudo snap install openstack --channel 2024.1
           sunbeam prepare-node-script | bash -x
           sudo snap refresh juju --channel 3.4/stable
           sg snap_daemon "sunbeam cluster bootstrap --accept-defaults"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -120,11 +120,11 @@ jobs:
           ~/actionutils.sh wait_for_rgw 1
 
       - name: Collect logs
-        if: always()
+        if: failure()
         run: ./tests/scripts/ci_helpers.sh collect_sunbeam_and_microceph_logs
 
       - name: Upload logs
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: microceph_juju_functional_test_logs
@@ -206,11 +206,11 @@ jobs:
           fi
 
       - name: Collect logs
-        if: always()
+        if: failure()
         run: ./tests/scripts/ci_helpers.sh collect_microceph_logs
 
       - name: Upload logs
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: microceph_juju_cluster_test_logs
@@ -420,11 +420,11 @@ jobs:
           juju status blocked | egrep '^microceph/.*Cannot upgrade.*to quincy/stable'
 
       - name: Collect logs
-        if: always()
+        if: failure()
         run: ./tests/scripts/ci_helpers.sh collect_microceph_logs
 
       - name: Upload logs
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: microceph_juju_upgrade_test_logs
@@ -459,7 +459,7 @@ jobs:
         uses: canonical/setup-lxd@v0.1.1
         with:
           # pin lxd since there were some recurring issues in recent releases.
-          channel: 5.21/stable
+          channel: 5.0/stable
 
       - name: Seed preliminary LXD profile
         run: ./tests/scripts/ci_helpers.sh seed_lxd_profile ./tests/scripts/assets/lxd-preseed.yaml
@@ -489,6 +489,24 @@ jobs:
 
       - name: Validate the network configurations.
         run: ./tests/scripts/ci_helpers.sh verify_juju_spaces_config
+
+      - name: Collect logs
+        if: failure()
+        run: ./tests/scripts/ci_helpers.sh collect_microceph_logs
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: microceph_juju_network_spaces_test_logs
+          path: logs
+          retention-days: 30
+
+      - name: Setup tmate session
+        if: ${{ failure() && runner.debug }}
+        uses: canonical/action-tmate@main
+
+
 
   juju-mds-test:
     needs:
@@ -547,3 +565,20 @@ jobs:
           fi
           # check if the ceph-mds daemon is running
           juju ssh ceph-fs/0 -- 'sudo systemctl is-active ceph-mds@$HOSTNAME.service --quiet'
+
+      - name: Collect logs
+        if: failure()
+        run: ./tests/scripts/ci_helpers.sh collect_microceph_logs
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: microceph_juju_mds_test_logs
+          path: logs
+          retention-days: 30
+
+      - name: Setup tmate session
+        if: ${{ failure() && runner.debug }}
+        uses: canonical/action-tmate@main
+

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,13 +2,20 @@
 # See https://juju.is/docs/sdk/charmcraft-config for guidance.
 
 type: charm
-bases:
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-    run-on:
-    - name: ubuntu
-      channel: "22.04"
+base: ubuntu@24.04
+platforms:
+  amd64:
+    build-on: [amd64]
+    build-for: [amd64]
+  arm64:
+    build-on: [arm64]
+    build-for: [arm64]
+  ppc64el:
+    build-on: [ppc64el]
+    build-for: [ppc64el]
+  s390x:
+    build-on: [s390x]
+    build-for: [s390x]
 
 parts:
   charm:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   snap-channel:
-    default: "reef/stable"
+    default: "squid/edge"
     type: string
     description: |
       The snap-channel option determines the MicroCeph snap that is

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -54,7 +54,7 @@ storage:
     type: block
     multiple:
       range: 0-
-    minimum-size: 2G
+    minimum-size: 1G
 
   # Juju can provision storage, but charm will not perform any action.
   manual:

--- a/src/charm.py
+++ b/src/charm.py
@@ -117,6 +117,9 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
                 raise e
 
     def _on_peer_relation_created(self, event: ops.framework.EventBase) -> None:
+        # save self hostname in the unit databag
+        self.peers.set_unit_data({self.unit.name: str(gethostname())})
+
         public_address = self.model.get_binding(binding_key="public").network.bind_address
         if public_address:
             logger.debug("Setting peer unit data")

--- a/src/charm.py
+++ b/src/charm.py
@@ -91,7 +91,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         ]
 
         logger.debug(f'Running command {" ".join(cmd)}')
-        process = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=180)
+        process = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=900)
         logger.debug(f"Command finished. stdout={process.stdout}, " f"stderr={process.stderr}")
 
         cmd = ["sudo", "snap", "alias", "microceph.ceph", "ceph"]

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -46,7 +46,9 @@ class ClusterNodes(ops.framework.Object):
         if not event.unit:
             return
         # get hostname using unit name.
-        hostnames = self.charm.peers.get_all_unit_values(key=event.unit.name, include_local_unit=True)
+        hostnames = self.charm.peers.get_all_unit_values(
+            key=event.unit.name, include_local_unit=True
+        )
         if not hostnames:
             event.defer()
 
@@ -54,9 +56,7 @@ class ClusterNodes(ops.framework.Object):
         try:
             out = microceph._run_cmd(cmd)
             token = out.strip()
-            self.charm.peers.set_app_data(
-                {f"{event.unit.name}.join_token": token}
-            )
+            self.charm.peers.set_app_data({f"{event.unit.name}.join_token": token})
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.warning(e.stderr)
             error_node_already_exists = (

--- a/tests/scripts/assets/juju-spaces-bundle.yaml
+++ b/tests/scripts/assets/juju-spaces-bundle.yaml
@@ -1,11 +1,10 @@
-default-base: ubuntu@24.04/stable
+default-base: ubuntu@24.04
 applications:
   microceph:
     charm: ./microceph.charm
     num_units: 1
     to:
     - "0"
-    constraints: arch=amd64 virt-type=virtual-machine
     storage:
       osd-standalone: loop,3,2G
     bindings:
@@ -14,4 +13,4 @@ applications:
       public: alpha
 machines:
   "0":
-    constraints: arch=amd64 virt-type=virtual-machine root-disk=80G
+    constraints: arch=amd64 virt-type=virtual-machine root-disk=40G

--- a/tests/scripts/assets/juju-spaces-bundle.yaml
+++ b/tests/scripts/assets/juju-spaces-bundle.yaml
@@ -5,6 +5,8 @@ applications:
     num_units: 1
     to:
     - "0"
+    options:
+      snap-channel: squid/edge
     storage:
       osd-standalone: loop,3,2G
     bindings:
@@ -13,4 +15,4 @@ applications:
       public: alpha
 machines:
   "0":
-    constraints: arch=amd64 virt-type=virtual-machine root-disk=40G
+    constraints: arch=amd64 virt-type=virtual-machine root-disk=32G

--- a/tests/scripts/assets/juju-spaces-bundle.yaml
+++ b/tests/scripts/assets/juju-spaces-bundle.yaml
@@ -1,4 +1,4 @@
-default-base: ubuntu@22.04/stable
+default-base: ubuntu@24.04/stable
 applications:
   microceph:
     charm: ./microceph.charm


### PR DESCRIPTION
# Description
Cleaned up the patch for clustering issue with changes that could go alongside. Dropping the attempts to fix the failing spaces test on LXD. The patch changes the way charm-microceph enrolls microceph cluster members as microcluster LTS has restricted (unit based) loose naming.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Existing CI

## Contributor's Checklist

Please check that you have:

- [X] self-reviewed the code in this PR.
- [X] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
