### PR TITLE
Changed the release runner to Noble

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,7 +33,7 @@ jobs:
     needs:
       - lint
       - unit-test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Failure [ref](https://github.com/canonical/charm-microceph/actions/runs/11799445431/job/32867992085)
```
Ubuntu 24.04 builds cannot be performed on this Ubuntu 22.04 system.
Recommended resolution: Run a managed build, or run on a compatible host.
```

Fixes #CI

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Cannot test locally as the release flow gets executed on merge.
