### PR TITLE
Fix: remove MONs in relation data on scale down

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -205,6 +205,17 @@ jobs:
             exit 1
           fi
 
+      - name: Test mon addresses
+        run: |
+          curl="curl -s --unix-socket /var/snap/microceph/common/state/control.socket"
+          mons=$( ( $curl http://localhost/1.0/services/mon | \
+            jq -r '.metadata.addresses[]' | wc -l ) )
+          if [[ $mons -ne 2 ]] ; then
+            echo "Expected 2 MONs, got $mons. MON status: "
+            $curl http://localhost/1.0/services/mon
+            exit 1
+          fi
+
       - name: Collect logs
         if: failure()
         run: ./tests/scripts/ci_helpers.sh collect_microceph_logs

--- a/src/charm.py
+++ b/src/charm.py
@@ -37,6 +37,7 @@ from ops.main import main
 import ceph
 import cluster
 import microceph
+import microceph_client
 from ceph_broker import get_named_key
 from microceph_client import ClusterServiceUnavailableException
 from radosgw import RadosGWHandler
@@ -388,7 +389,8 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
     def get_ceph_info_from_configs(self, service_name, caps=None) -> dict:
         """Update ceph info from configuration."""
         # public address should be updated once config public-network is supported
-        public_addrs = microceph.get_mon_public_addresses()
+        client = microceph_client.Client.from_socket()
+        public_addrs = client.cluster.get_mon_addresses()
         return {
             "auth": "cephx",
             "ceph-public-address": self._lookup_system_interfaces(public_addrs),

--- a/src/microceph_client.py
+++ b/src/microceph_client.py
@@ -202,3 +202,8 @@ class ClusterService(BaseService):
         """Delete configuration in database if exists."""
         data = {"key": key, "wait": True}
         self._delete("/1.0/configs", data=json.dumps(data))
+
+    def get_mon_addresses(self) -> List[str]:
+        """Get mon addresses."""
+        mon_status = self._get("/1.0/services/mon").get("metadata")
+        return mon_status.get("addresses", [])

--- a/src/relation_handlers.py
+++ b/src/relation_handlers.py
@@ -28,6 +28,7 @@ from ops.framework import EventBase, EventSource, Handle, Object, ObjectEvents, 
 from ops_sunbeam.interfaces import OperatorPeers
 from ops_sunbeam.relation_handlers import BasePeerHandler, RelationHandler
 
+import microceph_client
 from ceph import get_osd_count
 from ceph_broker import Capabilities
 from ceph_broker import is_leader as is_ceph_mon_leader
@@ -418,6 +419,9 @@ class CephClientProvides(Object):
         self.framework.observe(
             charm.on[self.relation_name].relation_changed, self._on_relation_changed
         )
+        # React to ceph peers relation events
+        self.framework.observe(charm.on["peers"].relation_changed, self._on_ceph_peers)
+        self.framework.observe(charm.on["peers"].relation_departed, self._on_ceph_peers)
 
     def _on_relation_changed(self, event):
         """Prepare relation for data from requiring side."""
@@ -567,6 +571,17 @@ class CephClientProvides(Object):
         for k, v in data.items():
             relation.data[self.this_unit][k] = str(v)
 
+    def _on_ceph_peers(self, _event):
+        """Handle ceph peers relation events."""
+        # Mon addrs might have changed, update the relation data
+        if not self.model.unit.is_leader():
+            return
+        mon_key = "ceph-mon-public-addresses"
+        client = microceph_client.Client.from_socket()
+        addrs = client.cluster.get_mon_addresses()
+        for relation in self.framework.model.relations[self.relation_name]:
+            relation.data[self.model.app][mon_key] = json.dumps(addrs)
+
 
 class CephClientProviderHandler(RelationHandler):
     """Handler for ceph client relation."""
@@ -638,6 +653,11 @@ class CephClientProviderHandler(RelationHandler):
             data,
         )
         # Ignore the callback function??
+
+    def notify_all(self):
+        """Notify clients of a change."""
+        for relation in self.charm.framework.model.relations[self.relation_name]:
+            relation.data[self.charm.framework.model.unit].clear()
 
 
 class CephRadosGWProviderHandler(CephClientProviderHandler):


### PR DESCRIPTION
# Description

Remove MON addresses in ceph client relations when scaling down a cluster by handling the relation departed hook, and check for MON address changes on rel changed runs too.

Also do not compute the MON addresses from ceph.conf as that changes too slowly for a scale down operation but use MicroCeph API for this.

Fixes: #121 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

Functest has been added

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
