### PR TITLE
Fix: remove MONs in relation data on scale down

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -205,6 +205,17 @@ jobs:
             exit 1
           fi
 
+      - name: Test mon addresses
+        run: |
+          curl="sudo curl -s --unix-socket /var/snap/microceph/common/state/control.socket"
+          mons=$( ( juju ssh microceph/0 "$curl http://localhost/1.0/services/mon | \
+            jq -r '.metadata.addresses[]' | wc -l" ) )
+          if [[ $mons -ne 2 ]] ; then
+            echo "Expected 2 MONs, got $mons. MON status: "
+            $curl http://localhost/1.0/services/mon
+            exit 1
+          fi
+
       - name: Collect logs
         if: failure()
         run: ./tests/scripts/ci_helpers.sh collect_microceph_logs

--- a/src/charm.py
+++ b/src/charm.py
@@ -37,6 +37,7 @@ from ops.main import main
 import ceph
 import cluster
 import microceph
+import microceph_client
 from ceph_broker import get_named_key
 from microceph_client import ClusterServiceUnavailableException
 from radosgw import RadosGWHandler
@@ -388,7 +389,8 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
     def get_ceph_info_from_configs(self, service_name, caps=None) -> dict:
         """Update ceph info from configuration."""
         # public address should be updated once config public-network is supported
-        public_addrs = microceph.get_mon_public_addresses()
+        client = microceph_client.Client.from_socket()
+        public_addrs = client.cluster.get_mon_addresses()
         return {
             "auth": "cephx",
             "ceph-public-address": self._lookup_system_interfaces(public_addrs),

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -51,7 +51,6 @@ class ClusterNodes(ops.framework.Object):
         )
         if not hostnames:
             event.defer()
-            return
 
         cmd = ["microceph", "cluster", "add", hostnames[0]]
         try:
@@ -168,8 +167,8 @@ class ClusterUpgrades(ops.framework.Object):
         mc_snap.ensure(snap.SnapState.Present, channel=channel)
 
         @tenacity.retry(
-            wait=tenacity.wait_fixed(10),
-            stop=tenacity.stop_after_delay(1200),
+            wait=tenacity.wait_fixed(5),
+            stop=tenacity.stop_after_delay(600),
             retry=tenacity.retry_if_result(lambda b: not b),
         )
         def poll_ok():

--- a/src/microceph_client.py
+++ b/src/microceph_client.py
@@ -202,3 +202,8 @@ class ClusterService(BaseService):
         """Delete configuration in database if exists."""
         data = {"key": key, "wait": True}
         self._delete("/1.0/configs", data=json.dumps(data))
+
+    def get_mon_addresses(self) -> List[str]:
+        """Get mon addresses."""
+        mon_status = self._get("/1.0/services/mon").get("metadata")
+        return mon_status.get("addresses", [])

--- a/src/relation_handlers.py
+++ b/src/relation_handlers.py
@@ -421,8 +421,7 @@ class CephClientProvides(Object):
         self.framework.observe(
             charm.on[self.relation_name].relation_changed, self._on_relation_changed
         )
-        # React to ceph peers relation events
-        self.framework.observe(charm.on["peers"].relation_changed, self._on_ceph_peers)
+        # React to ceph peers relation departed
         self.framework.observe(charm.on["peers"].relation_departed, self._on_ceph_peers)
 
     def _on_relation_changed(self, event):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -197,6 +197,7 @@ class TestCharm(test_utils.CharmTestCase):
         # Assert RGW update configs is not called
         cclient.from_socket().cluster.update_config.assert_not_called()
 
+    @patch("relation_handlers.Client", MagicMock())
     @patch.object(microceph, "Client")
     @patch.object(microceph, "subprocess")
     @patch.object(Path, "chmod")
@@ -255,6 +256,7 @@ class TestCharm(test_utils.CharmTestCase):
             "rgw_keystone_verify_ssl", str(True).lower(), True
         )
 
+    @patch("relation_handlers.Client", MagicMock())
     @patch.object(microceph, "Client")
     @patch.object(microceph, "subprocess")
     @patch.object(Path, "chmod")
@@ -316,6 +318,7 @@ class TestCharm(test_utils.CharmTestCase):
             "rgw_keystone_verify_ssl", str(True).lower(), True
         )
 
+    @patch("relation_handlers.Client", MagicMock())
     @patch.object(microceph, "Client")
     @patch.object(microceph, "subprocess")
     @patch.object(Path, "chmod")
@@ -696,6 +699,7 @@ class TestCharm(test_utils.CharmTestCase):
         )
         action_event.fail.assert_called()
 
+    @patch("relation_handlers.Client", MagicMock())
     @patch.object(microceph, "Client")
     @patch.object(microceph, "subprocess")
     @patch("builtins.open", new_callable=mock_open, read_data="mon host dummy-ip")


### PR DESCRIPTION
# Description

Remove MON addresses in ceph client relations when scaling down a cluster by handling the relation departed hook, and check for MON address changes on rel changed runs too.

Also do not compute the MON addresses from ceph.conf as that changes too slowly for a scale down operation but use MicroCeph API for this.

Fixes: #121


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

Functest added

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
