### PR TITLE
Fixed incorrect OSD removal from Juju storage

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -186,24 +186,7 @@ jobs:
       - name: Remove Unit
         run: |
           set -x
-          juju remove-unit microceph/2 --no-prompt
-          # wait and check if the unit is still present.
-          for i in $(seq 1 40); do
-            res=$( ( juju status | grep -cF "microceph/2" ) || true )
-            if [[ $res -gt 0 ]] ; then
-              echo -n '.'
-              sleep 5
-            else
-              echo "Unit removed successfully"
-              break
-            fi
-          done
-          # fail if unit still present.
-          if [[ $res -gt 0 ]] ; then
-            echo "Unit still present"
-            juju status
-            exit 1
-          fi
+          ./tests/scripts/ci_helpers.sh remove_unit_wait "microceph/2"
 
       - name: Test mon addresses
         run: |
@@ -638,42 +621,14 @@ jobs:
       - name: Remove Unit microceph/2
         run: |
           set -x
-          disk_list=$(juju ssh microceph/leader -- "sudo microceph disk list --json")
-          osd_count=$(echo $disk_list | jq '.ConfiguredDisks[].location' | grep -c "\-2")
-          if [[ $osd_count -ne 3 ]] ; then
-            echo "Unexpected OSD count on node microceph/2 $osd_count"
-            exit 1
-          fi
-
-          juju remove-unit microceph/2 --no-prompt
-          # wait and check if the unit is still present.
-          for i in $(seq 1 40); do
-            res=$( ( juju status | grep -cF "microceph/2" ) || true )
-            if [[ $res -gt 0 ]] ; then
-              echo -n '.'
-              sleep 5
-            else
-              echo "Unit removed successfully"
-              break
-            fi
-          done
-          # fail if unit still present.
-          if [[ $res -gt 0 ]] ; then
-            echo "Unit still present"
-            juju status
-            exit 1
-          fi
+          ./tests/scripts/ci_helpers.sh ensure_osd_count_on_host "juju.*\-2" 3
+          ./tests/scripts/ci_helpers.sh remove_unit_wait "microceph/2"
 
           # sleep for some time
           sleep 1m
 
-          disk_list=$(juju ssh microceph/leader -- "sudo microceph disk list --json")
-          new_osd_count=$(echo $disk_list | jq '.ConfiguredDisks[].location' | grep -c "\-2" || true)
-          if [[ $new_osd_count -gt 0 ]] ; then
-            echo "Unexpected OSD count on node microceph/2 $osd_count"
-            exit 1
-          fi
-      
+          ./tests/scripts/ci_helpers.sh ensure_osd_count_on_host "juju.*\-2" 0
+
       - name: Add another unit
         run: |
           set -x
@@ -695,7 +650,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: microceph_juju_cluster_test_logs
+          name: microceph_juju_storage_cluster_test_logs
           path: logs
           retention-days: 30
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -664,20 +664,25 @@ jobs:
             exit 1
           fi
 
-          new_osd_count=$(echo $disk_list | jq '.ConfiguredDisks[].location' | grep -c "\-2")
-          if [[ $osd_count -gt 0 ]] ; then
+          # sleep for some time
+          sleep 1m
+
+          disk_list=$(juju ssh microceph/leader -- "sudo microceph disk list --json")
+          new_osd_count=$(echo $disk_list | jq '.ConfiguredDisks[].location' | grep -c "\-2" || true)
+          if [[ $new_osd_count -gt 0 ]] ; then
             echo "Unexpected OSD count on node microceph/2 $osd_count"
             exit 1
           fi
       
       - name: Add another unit
         run: |
+          set -x
           juju add-unit microceph -n 1
           sleep 60s
           juju wait-for unit microceph/3 --query='workload-message=="(workload) charm is ready"' --timeout=20m
           disk_list=$(juju ssh microceph/1 -- "sudo microceph disk list --json")
           total_osd_count=$(echo $disk_list | jq '.ConfiguredDisks[].location' | grep -c "juju")
-          if [[ $osd_count -gt 9 ]] ; then
+          if [[ $total_osd_count -ne 9 ]] ; then
             echo "Unexpected total OSD count on $osd_count"
             exit 1
           fi

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -635,12 +635,9 @@ jobs:
           juju add-unit microceph -n 1
           sleep 60s
           juju wait-for unit microceph/3 --query='workload-message=="(workload) charm is ready"' --timeout=20m
-          disk_list=$(juju ssh microceph/1 -- "sudo microceph disk list --json")
-          total_osd_count=$(echo $disk_list | jq '.ConfiguredDisks[].location' | grep -c "juju")
-          if [[ $total_osd_count -ne 9 ]] ; then
-            echo "Unexpected total OSD count on $osd_count"
-            exit 1
-          fi
+          
+           # "juju" substring is a part of all hosts, so it will fetch total OSD count 
+          ./tests/scripts/ci_helpers.sh ensure_osd_count_on_host "juju" 9
 
       - name: Collect logs
         if: failure()

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -639,7 +639,7 @@ jobs:
         run: |
           set -x
           disk_list=$(juju ssh microceph/leader -- "sudo microceph disk list --json")
-          osd_count=$(echo $disk_list | jq '.ConfiguredDisks.[].location' | grep -c "\-2")
+          osd_count=$(echo $disk_list | jq '.ConfiguredDisks[].location' | grep -c "\-2")
           if [[ $osd_count -ne 3 ]] ; then
             echo "Unexpected OSD count on node microceph/2 $osd_count"
             exit 1
@@ -664,7 +664,7 @@ jobs:
             exit 1
           fi
 
-          new_osd_count=$(echo $disk_list | jq '.ConfiguredDisks.[].location' | grep -c "\-2")
+          new_osd_count=$(echo $disk_list | jq '.ConfiguredDisks[].location' | grep -c "\-2")
           if [[ $osd_count -gt 0 ]] ; then
             echo "Unexpected OSD count on node microceph/2 $osd_count"
             exit 1
@@ -675,7 +675,8 @@ jobs:
           juju add-unit microceph -n 1
           sleep 60s
           juju wait-for unit microceph/3 --query='workload-message=="(workload) charm is ready"' --timeout=20m
-          total_osd_count=$(echo $disk_list | jq '.ConfiguredDisks.[].location' | grep -c "juju")
+          disk_list=$(juju ssh microceph/1 -- "sudo microceph disk list --json")
+          total_osd_count=$(echo $disk_list | jq '.ConfiguredDisks[].location' | grep -c "juju")
           if [[ $osd_count -gt 9 ]] ; then
             echo "Unexpected total OSD count on $osd_count"
             exit 1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@v0.1.1
         with:
-          channel: 5.20/stable
+          channel: 5.21/stable
       - name: Build charm(s)
         id: builder
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -593,3 +593,107 @@ jobs:
         if: ${{ failure() && runner.debug }}
         uses: canonical/action-tmate@main
 
+  juju-storage-cluster-test:
+    needs:
+      - lint
+      - unit-test
+      - build
+    name: Juju multi node storage test 
+    runs-on: [self-hosted, xlarge]
+    steps:
+      - name: Download charm
+        uses: actions/download-artifact@v3
+        with:
+          name: charms
+          path: ~/artifacts/
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          # pin lxd to LTS release.
+          channel: 5.21/stable
+
+      - name: Install dependencies
+        run: ./tests/scripts/ci_helpers.sh install_deps
+
+      - name: Install MicroCeph charm
+        run: |
+          date
+          mv ~/artifacts/microceph.charm ./microceph.charm
+          juju deploy ./tests/bundles/multi_node_juju_storage.yaml 
+          # wait for charm to bootstrap and OSD devices to enroll.
+          ./tests/scripts/ci_helpers.sh wait_for_microceph_bootstrap
+          date
+
+      - name: Show Juju status
+        run: |
+          set -eux
+          juju status
+
+      - name: Remove Unit microceph/2
+        run: |
+          set -x
+          disk_list=$(juju ssh microceph/leader -- "sudo microceph disk list --json")
+          osd_count=$(echo $disk_list | jq '.ConfiguredDisks.[].location' | grep -c "\-2")
+          if [[ $osd_count -ne 3 ]] ; then
+            echo "Unexpected OSD count on node microceph/2 $osd_count"
+            exit 1
+          fi
+
+          juju remove-unit microceph/2 --no-prompt
+          # wait and check if the unit is still present.
+          for i in $(seq 1 40); do
+            res=$( ( juju status | grep -cF "microceph/2" ) || true )
+            if [[ $res -gt 0 ]] ; then
+              echo -n '.'
+              sleep 5
+            else
+              echo "Unit removed successfully"
+              break
+            fi
+          done
+          # fail if unit still present.
+          if [[ $res -gt 0 ]] ; then
+            echo "Unit still present"
+            juju status
+            exit 1
+          fi
+
+          new_osd_count=$(echo $disk_list | jq '.ConfiguredDisks.[].location' | grep -c "\-2")
+          if [[ $osd_count -gt 0 ]] ; then
+            echo "Unexpected OSD count on node microceph/2 $osd_count"
+            exit 1
+          fi
+      
+      - name: Add another unit
+        run: |
+          juju add-unit microceph -n 1
+          sleep 60s
+          juju wait-for unit microceph/3 --query='workload-message=="(workload) charm is ready"' --timeout=20m
+          total_osd_count=$(echo $disk_list | jq '.ConfiguredDisks.[].location' | grep -c "juju")
+          if [[ $osd_count -gt 9 ]] ; then
+            echo "Unexpected total OSD count on $osd_count"
+            exit 1
+          fi
+
+      - name: Collect logs
+        if: failure()
+        run: ./tests/scripts/ci_helpers.sh collect_microceph_logs
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: microceph_juju_cluster_test_logs
+          path: logs
+          retention-days: 30
+
+      - name: Setup tmate session
+        if: ${{ failure() && runner.debug }}
+        uses: canonical/action-tmate@main
+

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -51,6 +51,7 @@ class ClusterNodes(ops.framework.Object):
         )
         if not hostnames:
             event.defer()
+            return
 
         cmd = ["microceph", "cluster", "add", hostnames[0]]
         try:

--- a/src/storage.py
+++ b/src/storage.py
@@ -229,8 +229,8 @@ class StorageHandler(Object):
                 self._clean_stale_osd_data()
             raise e
 
-    def _save_osd_data(self, disk_name: str, db_name: str = None):
-        """Save OSD data using juju storage names."""
+    def _save_osd_data(self, disk_name: str):
+        """Save OSD data to stored state mapping with juju storage names."""
         logger.debug(f"Entry stored state: {dict(self._stored.osd_data)}")
         disk_path = self.juju_storage_get(storage_id=disk_name, attribute="location")
         hostname = gethostname()

--- a/src/storage.py
+++ b/src/storage.py
@@ -18,6 +18,7 @@
 
 import json
 import logging
+from socket import gethostname
 from subprocess import CalledProcessError, TimeoutExpired, run
 
 import ops_sunbeam.guard as sunbeam_guard
@@ -37,8 +38,8 @@ class StorageHandler(Object):
     Observes the following events:
     1) *_storage_attached
     2) *_storage_detaching
-    3).add_osd_action
-    4).list_disks_action
+    3) add_osd_action
+    4) list_disks_action
     """
 
     name = "storage"
@@ -49,7 +50,6 @@ class StorageHandler(Object):
     charm = None
     # _stored: per unit stored state for storage class. Contains:
     #  osd_data: dict of dicts with int (osd num) key
-    #    disk_by_id: OSD disk by id (unique)
     #    disk: OSD disk storage name (unique)
     _stored = StoredState()
 
@@ -86,10 +86,15 @@ class StorageHandler(Object):
         self._clean_stale_osd_data()
 
         enroll = []
+
+        logger.debug(f"storage on unit: {self._fetch_filtered_storages([self.standalone])}")
+
         for storage in self._fetch_filtered_storages([self.standalone]):
+            logger.debug(f"Processing {storage}")
             if not self._get_osd_id(name=storage):
                 enroll.append(storage)
 
+        logger.debug(f"Enroll list {enroll}")
         with sunbeam_guard.guard(self.charm, self.name):
             self.charm.status.set(MaintenanceStatus("Enrolling OSDs"))
             self._enroll_disks_in_batch(enroll)
@@ -99,8 +104,10 @@ class StorageHandler(Object):
         """Unified storage detaching handler."""
         # check if the detaching device (of the form directive/index)
         # is being used as or with an OSD.
+        logger.debug(f"Detach event received for : {event.storage.full_id}")
         osd_num = self._get_osd_id(event.storage.full_id)
 
+        logger.debug(f"OSD ID for: {event.storage.full_id} is {osd_num}")
         if osd_num is None:
             return
 
@@ -203,6 +210,7 @@ class StorageHandler(Object):
         disk_paths = map(
             lambda name: self.juju_storage_get(storage_id=name, attribute="location"), disks
         )
+        logger.debug(f"Disk paths {disk_paths}")
         microceph.enroll_disks_as_osds(disk_paths)
 
         # Save OSD data using storage names.
@@ -223,6 +231,7 @@ class StorageHandler(Object):
 
     def _save_osd_data(self, disk_name: str, db_name: str = None):
         """Save OSD data using juju storage names."""
+        logger.debug(f"Entry stored state: {dict(self._stored.osd_data)}")
         disk_path = self.juju_storage_get(storage_id=disk_name, attribute="location")
 
         for osd in microceph.list_disk_cmd()["ConfiguredDisks"]:
@@ -233,13 +242,14 @@ class StorageHandler(Object):
             if not local_device:
                 continue
 
-            # e.g. check 'vdd' in '/dev/vdd'
-            if local_device["name"] in disk_path:
+            # e.g. check 'vdd' in '/dev/vdd' and is for a local device
+            if local_device["name"] in disk_path and osd["location"] in gethostname():
                 logger.debug(f"Added OSD {osd['osd']} with Disk {disk_name}.")
                 self._stored.osd_data[osd["osd"]] = {
-                    "disk_by_id": osd["path"],  # /dev/disk-by-id/ for OSD device.
                     "disk": disk_name,  # storage name for OSD device.
                 }
+
+        logger.debug(f"Exit stored state: {dict(self._stored.osd_data)}")
 
     def _get_osd_id(self, name: str):
         """Fetch the OSD number of consuming OSD, None is not used as OSD."""

--- a/src/storage.py
+++ b/src/storage.py
@@ -244,7 +244,7 @@ class StorageHandler(Object):
             local_device = microceph._get_disk_info(osd["path"])
 
             # e.g. check 'vdd' in '/dev/vdd' and is for a local device
-            if local_device["name"] in disk_path: 
+            if local_device["name"] in disk_path:
                 logger.debug(f"Added OSD {osd['osd']} with Disk {disk_name}.")
                 self._stored.osd_data[osd["osd"]] = {
                     "disk": disk_name,  # storage name for OSD device.

--- a/tests/bundles/multi_node_juju_storage.yaml
+++ b/tests/bundles/multi_node_juju_storage.yaml
@@ -1,0 +1,11 @@
+applications:
+  microceph:
+    charm: ./../../microceph.charm
+    base: ubuntu@24.04
+    arch: amd64
+    constraints: mem=4G cores=2 root-disk=32G virt-type=virtual-machine
+    scale: 3
+    options:
+      snap-channel: squid/stable
+    storage:
+      osd-standalone: loop,3,2G

--- a/tests/scripts/ci_helpers.sh
+++ b/tests/scripts/ci_helpers.sh
@@ -46,7 +46,7 @@ function ensure_osd_count_on_host() {
   local count="${2?missing}"
 
   disk_list=$(juju ssh microceph/leader -- "sudo microceph disk list --json")
-  osd_count=$(echo $disk_list | jq '.ConfiguredDisks[].location' | grep -c $location)
+  osd_count=$(echo $disk_list | jq '.ConfiguredDisks[].location' | grep -c $location || true)
   if [[ $osd_count -ne $count ]] ; then
     echo "Unexpected OSD count on node microceph/2 $osd_count"
     exit 1

--- a/tests/scripts/ci_helpers.sh
+++ b/tests/scripts/ci_helpers.sh
@@ -40,6 +40,43 @@ function setup_juju_spaces() {
     juju move-to-space cluster 10.85.4.0/24
 }
 
+function ensure_osd_count_on_host() {
+  set -ex
+  local location="${1?missing}"
+  local count="${2?missing}"
+
+  disk_list=$(juju ssh microceph/leader -- "sudo microceph disk list --json")
+  osd_count=$(echo $disk_list | jq '.ConfiguredDisks[].location' | grep -c $location)
+  if [[ $osd_count -ne $count ]] ; then
+    echo "Unexpected OSD count on node microceph/2 $osd_count"
+    exit 1
+  fi
+}
+
+function remove_unit_wait() {
+  set -ex
+  local unit_name="${1?missing}"
+
+  juju remove-unit $unit_name --no-prompt
+  # wait and check if the unit is still present.
+  for i in $(seq 1 40); do
+    res=$( ( juju status | grep -cF "microceph/2" ) || true )
+    if [[ $res -gt 0 ]] ; then
+      echo -n '.'
+      sleep 5
+    else
+      echo "Unit removed successfully"
+      break
+    fi
+  done
+  # fail if unit still present.
+  if [[ $res -gt 0 ]] ; then
+    echo "Unit still present"
+    juju status
+    exit 1
+  fi
+}
+
 function verify_juju_spaces_config() {
     set -ex
     date


### PR DESCRIPTION
# Description

Due to the missing location filter, each non-unique loop path matches with the first occurence of the storage instance is written over for the same. This patch adds an additional filter to match against local devices only.

Fixes #124 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
CI, possible discussions about adding new tests.

## Contributor's Checklist

Please check that you have:

- [X] self-reviewed the code in this PR.
- [X] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
