### PR TITLE
Modifies pool_create operation to rely more on Autoscalar.

### DIFF
--- a/src/ceph.py
+++ b/src/ceph.py
@@ -432,14 +432,6 @@ class BasePool(object):
         Do not add calls for a specific pool type here, those should go into
         one of the pool specific classes.
         """
-        # Ensure we set the expected pool ratio
-        update_pool(
-            client=self.service,
-            pool=self.name,
-            settings={
-                "target_size_ratio": str(self.percent_data / 100.0),
-            },
-        )
         try:
             set_app_name_for_pool(client=self.service, pool=self.name, name=self.app_name)
         except CalledProcessError:


### PR DESCRIPTION
# Description

Disable setting `target_size_ratio` and `pg_num` for data pools (weightage more than 10%)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?
[ ] Add a new test to verify pool creation is optimal for charm clients (multiple).

## Contributor's Checklist

Please check that you have:

- [X] self-reviewed the code in this PR.
- [X] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
