### PR TITLE
Exit when calling defer

### DIFF
--- a/src/cluster.py
+++ b/src/cluster.py
@@ -51,6 +51,7 @@ class ClusterNodes(ops.framework.Object):
         )
         if not hostnames:
             event.defer()
+            return
 
         cmd = ["microceph", "cluster", "add", hostnames[0]]
         try:


### PR DESCRIPTION
# Description

Adding nodes can fail when there's no hostname yet, microceph did try to handle the case by calling defer, but did not exit, which in turned stucked the charm in an error loop.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?
I refreshed a failed unit with this new rev.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
