### PR TITLE
Scale down fix

### DIFF
--- a/src/microceph.py
+++ b/src/microceph.py
@@ -239,6 +239,9 @@ def remove_disk_cmd(osd_num: int, force: bool = False) -> None:
         # The flag below prevents automatic scaledown of failure domain to OSD
         # as it makes the storage cluster unsafe against host failures.
         cmd.append("--prohibit-crush-scaledown")
+    else:
+        # This isn't always needed, but it doesn't hurt to set it.
+        cmd.append("--confirm-failure-domain-downgrade")
     _run_cmd(cmd)
 
 

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -240,7 +240,9 @@ def remove_disk_cmd(osd_num: int, force: bool = False) -> None:
         # as it makes the storage cluster unsafe against host failures.
         cmd.append("--prohibit-crush-scaledown")
     else:
-        # This isn't always needed, but it doesn't hurt to set it.
+        # In Microceph, operators need to specify this flag manually. On Juju,
+        # and thus, the charms, we need a more hands-off approach, and so
+        # failure domains changes are enabled by default.
         cmd.append("--confirm-failure-domain-downgrade")
     _run_cmd(cmd)
 


### PR DESCRIPTION
This patchset adds the necessary flag when removing charm-microceph units if there's storage attached for them.

Fixes https://github.com/canonical/charm-microceph/issues/123

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)