### PR TITLE
Pin snap payload to Squid Stable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 options:
   snap-channel:
-    default: "squid/edge"
+    default: "squid/stable"
     type: string
     description: |
       The snap-channel option determines the MicroCeph snap that is


### PR DESCRIPTION
# Description

Change the default microceph snap risk level to stable.

Fixes # NA

## Type of change

Charm config default change

## How Has This Been Tested?

Existing CI

## Contributor's Checklist

Please check that you have:

- [X] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
