### PR TITLE
ci: Change the self-hosted runner runs-on from ubuntu-24.04 to noble

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,7 +57,7 @@ jobs:
       - unit-test
       - build
     name: Functional test
-    runs-on: [self-hosted, large, ubuntu-24.04]
+    runs-on: [self-hosted, large, noble]
     steps:
 
       - name: Download charm


### PR DESCRIPTION
# Description

Change the runs-on label from `ubuntu-24.04` to `noble` since the correct label is `noble`

Fixes # (issue)

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

The functional test should be able to find the available runner.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
