### PR TITLE
Add host-only param to list-disks action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -2,6 +2,10 @@ list-disks:
   description: |
     List OSDs on the cluster and unpartitioned disks on the
     node.
+  params:
+    host-only:
+      type: boolean
+      description: List OSDs on the node instead of cluster.
 add-osd:
   description: |
     Add ceph disks (OSD) to cluster

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -223,9 +223,11 @@ def get_snap_info(snap_name):
     return response.json()
 
 
-def list_disk_cmd() -> dict:
+def list_disk_cmd(host_only: bool = False) -> dict:
     """Fetches MicroCeph configured and unpartitioned disks as a dict."""
     cmd = ["microceph", "disk", "list", "--json"]
+    if host_only:
+        cmd.append("--host-only")
     return json.loads(_run_cmd(cmd))
 
 


### PR DESCRIPTION
# Description

Currently list-disks action returns OSDs on
the cluster and unpartitioned disks on the
host. Microceph snap supports --host-only
flag to disks list command to list OSDs on
the cluster [1]

Add param to list-disks action host-only.
If this param is set to True, list only the
OSD disks on the host instead of on the cluster.

[1] https://github.com/canonical/microceph/commit/5a944d53179a92f2c7aa851fca77199bed8ca5fb

Fixes # https://bugs.launchpad.net/snap-openstack/+bug/2098626

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has been verified on snap-openstack sunbeam single node deployment

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
