### PR TITLE
Add logic to conditionally set bulk flag on broker requested pools.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,7 +57,7 @@ jobs:
       - unit-test
       - build
     name: Functional test
-    runs-on: [self-hosted, large, noble]
+    runs-on: [self-hosted, large, ubuntu-24.04, amd64]
     steps:
 
       - name: Download charm

--- a/src/ceph.py
+++ b/src/ceph.py
@@ -832,3 +832,12 @@ def is_quorum():
             return False
     else:
         return False
+
+
+# Ceph Config keys
+def ceph_config_set(ceph_service: str, key: str, value: str):
+    """Configure Ceph configurations for given ceph service.
+
+    :raises: CalledProcessError if config set op fails.
+    """
+    check_call(["ceph", "config", "set", ceph_service, key, value])

--- a/src/ceph.py
+++ b/src/ceph.py
@@ -372,8 +372,7 @@ class BasePool(object):
         :type name: str
         :param percent_data: The expected pool size in relation to all
                              available resources in the Ceph cluster. Will be
-                             used conditionally to set the ``target_size_ratio``
-                             or ``bulk`` pool property. (default: 10.0)
+                             used to set the ``bulk`` pool property. (default: 10.0)
         :type percent_data: Optional[float]
         :param app_name: Ceph application name, usually one of:
                          ('cephfs', 'rbd', 'rgw') (default: 'unknown')
@@ -433,17 +432,14 @@ class BasePool(object):
         one of the pool specific classes.
         """
         # conditionally configure bulk flag
-        key, value = ("target_size_ratio", str(self.percent_data / 100.0))
+        config = {}
         if self.percent_data >= 20:
-            key = "bulk"
-            value = "true"
+            config.update({"bulk": "true"})
 
         update_pool(
             client=self.service,
             pool=self.name,
-            settings={
-                key: value,
-            },
+            settings=config,
         )
         try:
             set_app_name_for_pool(client=self.service, pool=self.name, name=self.app_name)


### PR DESCRIPTION
# Description

1. Drops target_size_ratio parameter in favor of bulk flag.
2. Starts client pools with default pg count (32)
3. Increases `mon_max_pg_per_osd` value to 400.

Fixes #130 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Existing CI + manual tests + SQA sunbeam testing

## Contributor's Checklist

Please check that you have:

- [X] self-reviewed the code in this PR.
- [X] added code comments, particularly in hard-to-understand areas.
