### PR TITLE
Use full path for Ceph commands

### DIFF
--- a/src/microceph.py
+++ b/src/microceph.py
@@ -399,7 +399,7 @@ def list_mgr_modules() -> dict:
        2. always_on_modules
        3. enabled_modules
     """
-    cmd = ["ceph", "mgr", "module", "ls", "--format", "json"]
+    cmd = ["microceph.ceph", "mgr", "module", "ls", "--format", "json"]
     return json.loads(_run_cmd(cmd=cmd))
 
 
@@ -412,7 +412,7 @@ def enable_mgr_module(module: str):
         logger.info("nothing to do, %s module is not disabled", module)
         return
 
-    cmd = ["ceph", "mgr", "module", "enable", module]
+    cmd = ["microceph.ceph", "mgr", "module", "enable", module]
     _run_cmd(cmd=cmd)
 
 
@@ -423,7 +423,7 @@ def disable_mgr_module(module: str):
         logger.info("nothing to do, %s module is not enabled or is always on", module)
         return
 
-    cmd = ["ceph", "mgr", "module", "disable", module]
+    cmd = ["microceph.ceph", "mgr", "module", "disable", module]
     _run_cmd(cmd=cmd)
 
 

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -207,7 +207,7 @@ class TestBroker(test_utils.CharmTestCase):
         def mock_check_output(*args, **kwargs):
             cmd = args[0]
             if cmd[:9] == [
-                "ceph",
+                "microceph.ceph",
                 "--id",
                 "admin",
                 "fs",


### PR DESCRIPTION
Favours the snap alias command for Ceph interactions, to avoid the charm to use the wrong ceph binary if ceph-common gets installed locally on the unit

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
https://github.com/canonical/charm-microceph/issues/157

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

* Deployed a base bundle with k8s, ceph-csi and microceph colocated on the same units successfully in the same scenario case from the issue
* Updated the unit test cephfs creation to reflect the call to the ceph binary with the full path

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
