### PR TITLE
Fixes cluster join retry failures

### DIFF
--- a/src/microceph.py
+++ b/src/microceph.py
@@ -217,8 +217,13 @@ def bootstrap_cluster(micro_ip: str = None, public_net: str = None, cluster_net:
     _run_cmd(cmd=cmd)
 
 
-def join_cluster(token: str, micro_ip: str = None, **kwargs):
+def join_cluster(token: str, micro_ip: str = "", **kwargs):
     """Join node to MicroCeph cluster."""
+    hostname = gethostname()
+    if is_cluster_member(hostname):
+        logger.debug("microceph unit host %s already a microcluster member", hostname)
+        return
+
     cmd = ["microceph", "cluster", "join", token]
 
     if micro_ip:

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -15,7 +15,6 @@
 """Tests for Microceph helper functions."""
 
 import unittest
-from socket import gethostname
 from unittest.mock import patch
 
 import microceph
@@ -158,9 +157,11 @@ class TestMicroCeph(unittest.TestCase):
         assert "rgw_keystone_accepted_roles" in configs_deleted
 
     @patch("microceph._run_cmd")
-    def test_join_cluster(self, run_cmd):
+    @patch("microceph.gethostname")
+    def test_join_cluster(self, gethn, run_cmd):
         """Test if cluster join is idempotent."""
-        run_cmd.return_value = gethostname()
+        gethn.return_value = "host"
+        run_cmd.return_value = "long status that contains host"
         microceph.join_cluster("token", "10.10.10.10")
         run_cmd.assert_called_with(["microceph", "status"])
 


### PR DESCRIPTION
# Description

Makes `join_cluster` idempotent by checking if host is already a member of micro cluster.

Fixes #LP:2109486

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Unit tests 
- [ ] Verification in SQA environments 

## Contributor's Checklist

- [X] self-reviewed the code in this PR.