### PR TITLE
fix: adapts the new error string from microcluster

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -511,8 +511,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             microceph.bootstrap_cluster(**self._get_bootstrap_params())
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.warning(e.stderr)
-            hostname = gethostname()
-            error_already_exists = f'Failed to initialize local remote entry: A remote with name "{hostname}" already exists'
+            error_already_exists = "Unable to initialize cluster: Database is online"
             error_socket_not_exists = "dial unix /var/snap/microceph/common/state/control.socket: connect: no such file or directory"
 
             if error_socket_not_exists in e.stderr:


### PR DESCRIPTION
# Description

Issuing bootstrap on an already bootstrapped microceph node returns a new error message. This change adapts the new error message to catch such errors.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Existing tests

## Contributor's Checklist

- [X] self-reviewed the code in this PR.
