### PR TITLE
chore: consume charms.ceph from monorepo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pydantic<2
 cosl==0.0.55
 requests<2.32 # https://github.com/psf/requests/issues/6707 (similar issue with http+unix)
 git+https://opendev.org/openstack/sunbeam-charms#egg=ops-sunbeam&subdirectory=ops-sunbeam
-git+https://github.com/openstack/charms.ceph#egg=charms_ceph
+git+https://github.com/canonical/ceph-charms#egg=charms_ceph&subdirectory=charms.ceph
 
 # Used for communication with snapd socket
 requests-unixsocket # Apache 2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,4 +12,4 @@ ops
 pydantic < 2
 cosl==0.0.55
 
-git+https://github.com/openstack/charms.ceph#egg=charms_ceph
+git+https://github.com/canonical/ceph-charms#egg=charms_ceph&subdirectory=charms.ceph


### PR DESCRIPTION
# Description

Charm MicroCeph consumes charms.ceph helpers from the openstack mirror repository. This PR moves to consuming the same from the Ceph-Charms mono-repo.

Fixes #NA

## Type of change

Please delete options that are not relevant.

- [X] CleanCode (Code refactor, test updates, does not introduce functional changes)


## How Has This Been Tested?

Switching dependency source, existing CI to verify functionality.

## Contributor's Checklist

- [X] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
