### PR TITLE
fix: prevent active status leaks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -404,7 +404,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: microceph_juju_cluster_test_logs
+          name: microceph_juju_cluster_maintenance_test_logs
           path: logs
           retention-days: 30
 
@@ -894,7 +894,7 @@ jobs:
       - name: Deploy cos lite
         run: ./tests/scripts/ci_helpers.sh deploy_cos
 
-      - name: Deploy cos lite
+      - name: Check http endpoints
         run: ./tests/scripts/ci_helpers.sh check_http_endpoints_up
       
       - name: Deploy MicroCeph charm over LXD
@@ -919,7 +919,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: microceph_juju_storage_cluster_test_logs
+          name: microceph_cos_integration_logs
           path: logs
           retention-days: 30
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -433,6 +433,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
     def configure_app_leader(self, event: ops.framework.EventBase) -> None:
         """Configure the leader unit."""
         if not self.is_leader_ready():
+            logger.debug("Bootstrapping MicroCeph cluster")
             self.bootstrap_cluster(event)
             # mark bootstrap node also as joined
             self.peers.interface.state.joined = True
@@ -453,6 +454,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             self.cluster_upgrades.init_upgrade(snap_chan)
 
         if isinstance(event, MicroClusterNewNodeEvent):
+            logger.debug(f"Generating join token for {event.unit.name}")
             self.cluster_nodes.add_node_to_cluster(event)
 
     def configure_app_non_leader(self, event: ops.framework.EventBase) -> None:
@@ -461,6 +463,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
         # MicroClusterNodeAddedEvent triggered only when token is present.
         if isinstance(event, MicroClusterNodeAddedEvent):
+            logger.debug(f"Adding {event.unit.name} to cluster.")
             self.cluster_nodes.join_node_to_cluster(event)
 
         if not self.peers.interface.state.joined:
@@ -515,6 +518,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         """Bootstrap microceph cluster."""
         try:
             microceph.bootstrap_cluster(**self._get_bootstrap_params())
+            logger.debug(f"Successfully bootstrapped with params {self._get_bootstrap_params()}")
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.warning(e.stderr)
             error_already_exists = "Unable to initialize cluster: Database is online"

--- a/src/charm.py
+++ b/src/charm.py
@@ -464,7 +464,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             self.cluster_nodes.join_node_to_cluster(event)
 
         if not self.peers.interface.state.joined:
-            # deferral not needed as join token is not yet received. 
+            # deferral not needed as join token is not yet received.
             raise sunbeam_guard.WaitingExceptionError("waiting to join cluster")
 
         # Proceed with post join activities
@@ -522,7 +522,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
             if error_socket_not_exists in e.stderr:
                 event.defer()
-                return
+                raise sunbeam_guard.WaitingExceptionError("waiting for snap")
 
             if error_already_exists not in e.stderr:
                 raise e

--- a/src/charm.py
+++ b/src/charm.py
@@ -432,6 +432,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
     def configure_app_leader(self, event: ops.framework.EventBase) -> None:
         """Configure the leader unit."""
+        logger.debug(f"Configure leader for {event.__repr__}")
         if not self.is_leader_ready():
             logger.debug("Bootstrapping MicroCeph cluster")
             self.bootstrap_cluster(event)
@@ -461,9 +462,9 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         """Configure the non leader unit."""
         super().configure_app_non_leader(event)
 
+        logger.debug(f"Configure non leader for {event.__repr__}")
         # MicroClusterNodeAddedEvent triggered only when token is present.
         if isinstance(event, MicroClusterNodeAddedEvent):
-            logger.debug(f"Adding {event.unit.name} to cluster.")
             self.cluster_nodes.join_node_to_cluster(event)
 
         if not self.peers.interface.state.joined:

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -19,6 +19,7 @@ import json
 import logging
 import subprocess
 import uuid
+from socket import gethostname
 from typing import Tuple
 
 import ops.charm
@@ -69,18 +70,17 @@ class ClusterNodes(ops.framework.Object):
 
     def join_node_to_cluster(self, event: ops.framework.EventBase) -> None:
         """Join node to microceph cluster."""
+        logger.debug("handling {event}")
         if not event.unit:
-            return
-
-        token = self.charm.peers.get_app_data(f"{event.unit.name}.join_token")
-        if not token:
-            logger.info("Token not available, deferring join event.")
-            event.defer()
             return
 
         if self.charm.peers.interface.state.joined is True:
             logger.info("Unit has already joined the cluster")
             return
+
+        token = self.charm.peers.get_app_data(f"{event.unit.name}.join_token")
+        if not token:
+            raise sunbeam_guard.BlockedExceptionError(f"join token not found for {gethostname()}")
 
         try:
             microceph.join_cluster(token=token, **self.charm._get_bootstrap_params())

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -70,7 +70,6 @@ class ClusterNodes(ops.framework.Object):
 
     def join_node_to_cluster(self, event: ops.framework.EventBase) -> None:
         """Join node to microceph cluster."""
-        logger.debug("handling {event}")
         if not event.unit:
             return
 
@@ -86,6 +85,7 @@ class ClusterNodes(ops.framework.Object):
             microceph.join_cluster(token=token, **self.charm._get_bootstrap_params())
             self.charm.peers.interface.state.joined = True
             self.charm.peers.set_unit_data({"joined": json.dumps(True)})
+            logger.debug("Joined cluster successfully.")
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.warning(e.stderr)
             raise e

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -71,12 +71,14 @@ class ClusterNodes(ops.framework.Object):
     def join_node_to_cluster(self, event: ops.framework.EventBase) -> None:
         """Join node to microceph cluster."""
         if not event.unit:
+            logger.warning("Add node triggered for without unit information.")
             return
 
         if self.charm.peers.interface.state.joined is True:
             logger.info("Unit has already joined the cluster")
             return
 
+        logger.debug(f"Adding {event.unit.name} to cluster.")
         token = self.charm.peers.get_app_data(f"{event.unit.name}.join_token")
         if not token:
             raise sunbeam_guard.BlockedExceptionError(f"join token not found for {gethostname()}")

--- a/tests/scripts/ci_helpers.sh
+++ b/tests/scripts/ci_helpers.sh
@@ -84,7 +84,7 @@ function deploy_grafana_agent() {
   juju integrate grafana-agent k8s:cos.grafana
   juju integrate grafana-agent k8s:cos.loki
 
-  juju wait-for unit grafana-agent/0 --query='workload-message=="tracing: off"' --timeout=20m
+  juju wait-for unit grafana-agent/1 --query='workload-message=="tracing: off"' --timeout=20m
 }
 
 function check_http_endpoints_up() {


### PR DESCRIPTION
# Description

In the absence of a check for node join, inactivity may cause active status leaking into the unit status.

Fixes #160 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manual Testing

## Contributor's Checklist

- [X] self-reviewed the code in this PR.
- [X] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
