### PR TITLE
fix: prevent active status leaks

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -433,6 +433,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
     def configure_app_leader(self, event: ops.framework.EventBase) -> None:
         """Configure the leader unit."""
         if not self.is_leader_ready():
+            logger.debug("Bootstrapping MicroCeph cluster")
             self.bootstrap_cluster(event)
             # mark bootstrap node also as joined
             self.peers.interface.state.joined = True
@@ -453,6 +454,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             self.cluster_upgrades.init_upgrade(snap_chan)
 
         if isinstance(event, MicroClusterNewNodeEvent):
+            logger.debug(f"Generating join token for {event.unit.name}")
             self.cluster_nodes.add_node_to_cluster(event)
 
     def configure_app_non_leader(self, event: ops.framework.EventBase) -> None:
@@ -461,6 +463,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
         # MicroClusterNodeAddedEvent triggered only when token is present.
         if isinstance(event, MicroClusterNodeAddedEvent):
+            logger.debug(f"Adding {event.unit.name} to cluster.")
             self.cluster_nodes.join_node_to_cluster(event)
 
         if not self.peers.interface.state.joined:
@@ -515,6 +518,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         """Bootstrap microceph cluster."""
         try:
             microceph.bootstrap_cluster(**self._get_bootstrap_params())
+            logger.debug(f"Successfully bootstrapped with params {self._get_bootstrap_params()}")
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.warning(e.stderr)
             error_already_exists = "Unable to initialize cluster: Database is online"

--- a/src/charm.py
+++ b/src/charm.py
@@ -464,7 +464,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             self.cluster_nodes.join_node_to_cluster(event)
 
         if not self.peers.interface.state.joined:
-            # deferral not needed as join token is not yet received. 
+            # deferral not needed as join token is not yet received.
             raise sunbeam_guard.WaitingExceptionError("waiting to join cluster")
 
         # Proceed with post join activities
@@ -522,7 +522,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
             if error_socket_not_exists in e.stderr:
                 event.defer()
-                return
+                raise sunbeam_guard.WaitingExceptionError("waiting for snap")
 
             if error_already_exists not in e.stderr:
                 raise e

--- a/src/charm.py
+++ b/src/charm.py
@@ -432,6 +432,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
     def configure_app_leader(self, event: ops.framework.EventBase) -> None:
         """Configure the leader unit."""
+        logger.debug(f"Configure leader for {event.__repr__}")
         if not self.is_leader_ready():
             logger.debug("Bootstrapping MicroCeph cluster")
             self.bootstrap_cluster(event)
@@ -461,9 +462,9 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         """Configure the non leader unit."""
         super().configure_app_non_leader(event)
 
+        logger.debug(f"Configure non leader for {event.__repr__}")
         # MicroClusterNodeAddedEvent triggered only when token is present.
         if isinstance(event, MicroClusterNodeAddedEvent):
-            logger.debug(f"Adding {event.unit.name} to cluster.")
             self.cluster_nodes.join_node_to_cluster(event)
 
         if not self.peers.interface.state.joined:

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -19,6 +19,7 @@ import json
 import logging
 import subprocess
 import uuid
+from socket import gethostname
 from typing import Tuple
 
 import ops.charm
@@ -69,18 +70,17 @@ class ClusterNodes(ops.framework.Object):
 
     def join_node_to_cluster(self, event: ops.framework.EventBase) -> None:
         """Join node to microceph cluster."""
+        logger.debug("handling {event}")
         if not event.unit:
-            return
-
-        token = self.charm.peers.get_app_data(f"{event.unit.name}.join_token")
-        if not token:
-            logger.info("Token not available, deferring join event.")
-            event.defer()
             return
 
         if self.charm.peers.interface.state.joined is True:
             logger.info("Unit has already joined the cluster")
             return
+
+        token = self.charm.peers.get_app_data(f"{event.unit.name}.join_token")
+        if not token:
+            raise sunbeam_guard.BlockedExceptionError(f"join token not found for {gethostname()}")
 
         try:
             microceph.join_cluster(token=token, **self.charm._get_bootstrap_params())

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -70,7 +70,6 @@ class ClusterNodes(ops.framework.Object):
 
     def join_node_to_cluster(self, event: ops.framework.EventBase) -> None:
         """Join node to microceph cluster."""
-        logger.debug("handling {event}")
         if not event.unit:
             return
 
@@ -86,6 +85,7 @@ class ClusterNodes(ops.framework.Object):
             microceph.join_cluster(token=token, **self.charm._get_bootstrap_params())
             self.charm.peers.interface.state.joined = True
             self.charm.peers.set_unit_data({"joined": json.dumps(True)})
+            logger.debug("Joined cluster successfully.")
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.warning(e.stderr)
             raise e

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -71,12 +71,14 @@ class ClusterNodes(ops.framework.Object):
     def join_node_to_cluster(self, event: ops.framework.EventBase) -> None:
         """Join node to microceph cluster."""
         if not event.unit:
+            logger.warning("Add node triggered for without unit information.")
             return
 
         if self.charm.peers.interface.state.joined is True:
             logger.info("Unit has already joined the cluster")
             return
 
+        logger.debug(f"Adding {event.unit.name} to cluster.")
         token = self.charm.peers.get_app_data(f"{event.unit.name}.join_token")
         if not token:
             raise sunbeam_guard.BlockedExceptionError(f"join token not found for {gethostname()}")


### PR DESCRIPTION
# Description

In the absence of a check for node join, inactivity may cause active status leaking into the unit status.

Fixes https://github.com/canonical/charm-microceph/issues/160

This is a re-upload of #172 as this one got caught in some rebase mixup
