### PR TITLE
fix: use get-or-create to authenticate cephfs clients

### DIFF
--- a/src/ceph_broker.py
+++ b/src/ceph_broker.py
@@ -1094,32 +1094,32 @@ def handle_create_cephfs_client(request, service):
     """
     fs_name = request.get("fs_name")
     client_id = request.get("client_id")
-    # TODO: fs allows setting write permissions for a list of paths.
     path = request.get("path")
     perms = request.get("perms")
+
     # Need all parameters
     if not fs_name or not client_id or not path or not perms:
         msg = "Missing fs_name, client_id, path or perms params"
         log(msg, level=ERROR)
         return {"exit-code": 1, "stderr": msg}
 
-    client = "client.{}".format(client_id)
-
     # Try to authorize the client.
-    # `ceph fs authorize` already returns the correct error
-    # message if the filesystem doesn't exist or if the client
-    # already exists.
+    # `ceph auth get-or-create` should correctly
+    # handle if the user already exists.
     try:
         cmd = [
             "microceph.ceph",
             "--id",
             service,
-            "fs",
-            "authorize",
-            fs_name,
-            client,
-            path,
-            perms,
+            "auth",
+            "get-or-create",
+            "client.{}".format(client_id),
+            "mds",
+            f"allow {perms} fsname={fs_name} path={path}",
+            "mon",
+            f"allow r fsname={fs_name}",
+            "osd",
+            f"allow {perms} tag cephfs data={fs_name}",
             "-f",
             "json",
         ]

--- a/tests/scripts/ci_helpers.sh
+++ b/tests/scripts/ci_helpers.sh
@@ -5,7 +5,7 @@ function check_osd_count() {
     local count="${2?missing}"
 
     echo $USER
-    for i in $(seq 1 20); do
+    for i in $(seq 1 50); do
       osd_count=$(juju exec --unit ${unit} -- microceph disk list --json | jq '.ConfiguredDisks | length')
       if [[ $osd_count -ne $count ]] ; then
           echo "Expected OSDs $count, Actual ${osd_count}. waiting..."
@@ -207,11 +207,11 @@ function remove_unit_wait() {
 
   juju remove-unit $unit_name --no-prompt
   # wait and check if the unit is still present.
-  for i in $(seq 1 40); do
+  for i in $(seq 1 50); do
     res=$( ( juju status | grep -cF "$unit_name" ) || true )
     if [[ $res -gt 0 ]] ; then
       echo -n '.'
-      sleep 5
+      sleep 10
     else
       echo "Unit removed successfully"
       break
@@ -317,8 +317,8 @@ function wait_for_vms() {
     # echo $vm
     start=$SECONDS
     until lxc exec "$vm" -- true &>/dev/null; do
-      (( SECONDS - start >= timeout )) && { 
-        echo "timeout waiting for agent on $vm"; return 1; 
+      (( SECONDS - start >= timeout )) && {
+        echo "timeout waiting for agent on $vm"; return 1;
       }
       sleep $interval
     done


### PR DESCRIPTION
# Description

A change of behaviour in the Ceph CLI made it so that authenticating a CephFS client again doesn't return its key again. This PR restores the correct behaviour in `handle_create_cephfs_client` by authenticating using `get-or-create` instead.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

- Adjusted unit tests for the new behaviour.
- Deployed and integrated the microceph charm with the ceph-fs charm. The logs should show if the request `create_cephfs_client` ran successfully.

There is already a test [here](https://github.com/canonical/charm-microceph/blob/e9f883202f12a866ff2a79739b7e21e5bf7332c2/.github/workflows/build-and-test.yml#L742-L758) that integrates both charms, but I think `ceph-fs` does not block if the response returns an error, so some more improvements need to be made in `ceph-fs` to properly reflect the responses sent by Microceph.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
