### PR TITLE
fix: set peer data opportunistically as a tactical fix

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -53,6 +53,7 @@ from relation_handlers import (
     MicroClusterPeerHandler,
     UpgradeNodeDoneEvent,
     UpgradeNodeRequestEvent,
+    collect_peer_data,
 )
 from storage import StorageHandler
 
@@ -129,15 +130,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
     def _on_peer_relation_created(self, event: ops.framework.EventBase) -> None:
         logging.debug(f"Peer relation created: {event}")
-        # save self hostname in the unit databag
-        hostname = gethostname()
-        logging.debug(f"Peer rel created, hostname: {hostname}")
-        self.peers.set_unit_data({self.unit.name: str(hostname)})
-
-        public_address = self.model.get_binding(binding_key="public").network.bind_address
-        if public_address:
-            logger.debug("Setting peer unit data")
-            self.peers.set_unit_data({"public-address": str(public_address)})
+        self.peers.set_unit_data(collect_peer_data(self.model))
 
     def _on_peer_relation_departed(self, event: ops.framework.EventBase) -> None:
         self.handle_traefik_ready(event)

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -54,7 +54,7 @@ class ClusterNodes(ops.framework.Object):
         )
         logging.debug(f"Hostnames for {event}: {hostnames}")
         if not hostnames:
-            logging.info("Deferring: no hostname found for: {event}")
+            logging.info(f"Deferring: no hostname found for: {event}")
             event.defer()
             return
 

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -54,8 +54,7 @@ class ClusterNodes(ops.framework.Object):
         )
         logging.debug(f"Hostnames for {event}: {hostnames}")
         if not hostnames:
-            logging.info(f"Deferring: no hostname found for: {event}")
-            event.defer()
+            logging.info(f"No hostname found for: {event}")
             return
 
         cmd = ["microceph", "cluster", "add", hostnames[0]]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -20,49 +20,14 @@ from unittest.mock import MagicMock, PropertyMock, call, mock_open, patch
 
 import ops_sunbeam.test_utils as test_utils
 from charms.ceph_mon.v0 import ceph_cos_agent
-from ops.testing import Harness
+from unit import testbase
 
 import charm
 import microceph
 from microceph_client import MaintenanceOperationFailedException
 
-DUMMY_CA_CERT = """-----BEGIN CERTIFICATE-----
-MIIDdzCCAl+gAwIBAgIUexFR59kb53PwxGKCFFO32jHAGKwwDQYJKoZIhvcNAQEL
-BQAwSzELMAkGA1UEBhMCSU4xCzAJBgNVBAgMAkFQMQwwCgYDVQQHDANWVFoxITAf
-BgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDA2MjMwNTQ2Mjha
-Fw0yOTA2MjIwNTQ2MjhaMEsxCzAJBgNVBAYTAklOMQswCQYDVQQIDAJBUDEMMAoG
-A1UEBwwDVlRaMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEi
-MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCUmJ0xjPppm0YV8hPQjbZH9+LO
-LU8HXUb2EYU9yb+UEP24grGar2zsVUBXWGJAXIAYejyDapSRjYoCnPECRHfrCqs2
-vhZmQzPII+6Nllf3IpzS65TEfssfEtiSweN2sXLPymHaRKcq+rnmmpOM3vO396pc
-COJX7WG/+qDJUhJthdbA008sKulG4Qq7NGaUA6Y4IMlZsZFEMp17rvFWNRSZBPVd
-qrmW38v7rZfJwHrN4NL0me/1GZ+9ucnXnD5q/D1kRURt8J8cbFrPqGo4QwTzoNIi
-D8Q7yRHUIMDY2MGmtpwzluh1HYg97IRJO0ciVXGL1yKEpELJ2Q32jS4xx2GJAgMB
-AAGjUzBRMB0GA1UdDgQWBBSNg6SlHP06mM/vFPUoM9p37ZbUvzAfBgNVHSMEGDAW
-gBSNg6SlHP06mM/vFPUoM9p37ZbUvzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
-DQEBCwUAA4IBAQCGHlGuKr4L7nfZgFY1VZI14pSUvEZKPIXb4jPMvsVIdQY8wowM
-9TDFmsDps0W+XZDNq5wwRtWiVKoNO6zw9ZKVlsKas4hnhqnaWD101xI9xN/ADax1
-OHmBVcugXeYdWxmaz3JdiVKmwhiscmAiAWr4MS2FY/moZAl/U+YeIxbCxqKkZgJF
-sEygfjVGcGUYrPvBB3SIyL+n8N9anht7u6ZY1chw6dnlT79mcx4huNE+NCSRK+7t
-aU6GF5joUr0UWjFkoXpINM+ozet/bYvxa8MJ5OvSeU1ahHFeOmv0axs0JHvV0rW4
-I7bWFePvjNsCPUyBSGu3GCisT5/FaxcS/IOA
------END CERTIFICATE-----
-"""
 
-
-class _MicroCephCharm(charm.MicroCephCharm):
-    """MicroCeph test charm."""
-
-    def __init__(self, framework):
-        """Setup event logging."""
-        self.seen_events = []
-        super().__init__(framework)
-
-    def configure_ceph(self, event):
-        return True
-
-
-class TestCharm(test_utils.CharmTestCase):
+class TestCharm(testbase.TestBaseCharm):
     PATCHES = ["subprocess"]
 
     def setUp(self):
@@ -73,67 +38,13 @@ class TestCharm(test_utils.CharmTestCase):
         with open("metadata.yaml", "r") as f:
             metadata = f.read()
         self.harness = test_utils.get_harness(
-            _MicroCephCharm,
+            testbase._MicroCephCharm,
             container_calls=self.container_calls,
             charm_config=config_data,
             charm_metadata=metadata,
         )
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
-
-    def add_complete_identity_relation(self, harness: Harness) -> None:
-        """Add complete identity-service relation."""
-        credentials_content = {"username": "svcuser1", "password": "svcpass1"}
-        credentials_id = harness.add_model_secret("keystone", credentials_content)
-        app_data = {
-            "admin-domain-id": "admindomid1",
-            "admin-project-id": "adminprojid1",
-            "admin-user-id": "adminuserid1",
-            "api-version": "3",
-            "auth-host": "keystone.local",
-            "auth-port": "12345",
-            "auth-protocol": "http",
-            "internal-host": "keystone.internal",
-            "internal-port": "5000",
-            "internal-protocol": "http",
-            "internal-auth-url": "http://keystone.internal/v3",
-            "service-domain": "servicedom",
-            "service-domain_id": "svcdomid1",
-            "service-host": "keystone.service",
-            "service-port": "5000",
-            "service-protocol": "http",
-            "service-project": "svcproj1",
-            "service-project-id": "svcprojid1",
-            "service-credentials": credentials_id,
-        }
-
-        # Cannot use ops add_relation [1] directly due to secrets
-        # [1] https://ops.readthedocs.io/en/latest/#ops.testing.Harness.add_relation
-        rel_id = test_utils.add_base_identity_service_relation(harness)
-        harness.grant_secret(credentials_id, harness.charm.app.name)
-        harness.update_relation_data(rel_id, "keystone", app_data)
-
-    def add_complete_ingress_relation(self, harness: Harness) -> None:
-        """Add complete traefik-route relations."""
-        harness.add_relation(
-            "traefik-route-rgw",
-            "traefik",
-            app_data={"external_host": "dummy-ip", "scheme": "http"},
-        )
-
-    def add_complete_peer_relation(self, harness: Harness) -> None:
-        """Add complete peer relation data."""
-        harness.add_relation(
-            "peers", harness.charm.app.name, unit_data={"public-address": "dummy-ip"}
-        )
-
-    def add_complete_certificate_transfer_relation(self, harness: Harness) -> None:
-        """Add complete certificate_transfer relation."""
-        harness.add_relation("receive-ca-cert", "keystone", unit_data={"ca": DUMMY_CA_CERT})
-
-    def add_cos_agent_integration(self, harness: Harness) -> None:
-        """Add cos agent integration."""
-        harness.add_relation("cos-agent", harness.charm.app.name)
 
     @patch.object(ceph_cos_agent, "CephCOSAgentProvider")
     @patch.object(ceph_cos_agent, "ceph_utils")

--- a/tests/unit/test_relation_handlers.py
+++ b/tests/unit/test_relation_handlers.py
@@ -1,0 +1,67 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import ops_sunbeam.test_utils as test_utils
+from unit import testbase
+
+import relation_handlers
+
+
+class TestRelationHelpers(testbase.TestBaseCharm):
+    PATCHES = [
+        "gethostname",
+    ]
+
+    def setUp(self):
+        """Setup MicroCeph Charm tests."""
+        super().setUp(relation_handlers, self.PATCHES)
+        with open("config.yaml", "r") as f:
+            config_data = f.read()
+        with open("metadata.yaml", "r") as f:
+            metadata = f.read()
+        self.harness = test_utils.get_harness(
+            testbase._MicroCephCharm,
+            container_calls=self.container_calls,
+            charm_config=config_data,
+            charm_metadata=metadata,
+        )
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+    def test_collect_peer_data(self):
+        self.harness.set_leader()
+        rel_id = self.add_complete_peer_relation(self.harness)
+        unit_name = self.harness.model.unit.name
+        # set up some initial relation data
+        self.harness.update_relation_data(
+            rel_id,
+            "microceph/0",
+            {
+                unit_name: "test-hostname",
+            },
+        )
+        self.gethostname.return_value = "test-hostname"
+        change_data = relation_handlers.collect_peer_data(self.harness.model)
+        self.assertNotIn(unit_name, change_data)
+        self.assertEqual(change_data["public-address"], "10.0.0.10")
+        self.gethostname.return_value = "changed-hostname"
+        # assert that collect_peer_data raises an exception
+        with self.assertRaises(relation_handlers.HostnameChangeError):
+            relation_handlers.collect_peer_data(self.harness.model)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/testbase.py
+++ b/tests/unit/testbase.py
@@ -1,0 +1,110 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ops.testing import Harness
+from ops_sunbeam import test_utils
+
+import charm
+
+DUMMY_CA_CERT = """-----BEGIN CERTIFICATE-----
+MIIDdzCCAl+gAwIBAgIUexFR59kb53PwxGKCFFO32jHAGKwwDQYJKoZIhvcNAQEL
+BQAwSzELMAkGA1UEBhMCSU4xCzAJBgNVBAgMAkFQMQwwCgYDVQQHDANWVFoxITAf
+BgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDA2MjMwNTQ2Mjha
+Fw0yOTA2MjIwNTQ2MjhaMEsxCzAJBgNVBAYTAklOMQswCQYDVQQIDAJBUDEMMAoG
+A1UEBwwDVlRaMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCUmJ0xjPppm0YV8hPQjbZH9+LO
+LU8HXUb2EYU9yb+UEP24grGar2zsVUBXWGJAXIAYejyDapSRjYoCnPECRHfrCqs2
+vhZmQzPII+6Nllf3IpzS65TEfssfEtiSweN2sXLPymHaRKcq+rnmmpOM3vO396pc
+COJX7WG/+qDJUhJthdbA008sKulG4Qq7NGaUA6Y4IMlZsZFEMp17rvFWNRSZBPVd
+qrmW38v7rZfJwHrN4NL0me/1GZ+9ucnXnD5q/D1kRURt8J8cbFrPqGo4QwTzoNIi
+D8Q7yRHUIMDY2MGmtpwzluh1HYg97IRJO0ciVXGL1yKEpELJ2Q32jS4xx2GJAgMB
+AAGjUzBRMB0GA1UdDgQWBBSNg6SlHP06mM/vFPUoM9p37ZbUvzAfBgNVHSMEGDAW
+gBSNg6SlHP06mM/vFPUoM9p37ZbUvzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+DQEBCwUAA4IBAQCGHlGuKr4L7nfZgFY1VZI14pSUvEZKPIXb4jPMvsVIdQY8wowM
+9TDFmsDps0W+XZDNq5wwRtWiVKoNO6zw9ZKVlsKas4hnhqnaWD101xI9xN/ADax1
+OHmBVcugXeYdWxmaz3JdiVKmwhiscmAiAWr4MS2FY/moZAl/U+YeIxbCxqKkZgJF
+sEygfjVGcGUYrPvBB3SIyL+n8N9anht7u6ZY1chw6dnlT79mcx4huNE+NCSRK+7t
+aU6GF5joUr0UWjFkoXpINM+ozet/bYvxa8MJ5OvSeU1ahHFeOmv0axs0JHvV0rW4
+I7bWFePvjNsCPUyBSGu3GCisT5/FaxcS/IOA
+-----END CERTIFICATE-----
+"""
+
+
+class _MicroCephCharm(charm.MicroCephCharm):
+    """MicroCeph test charm."""
+
+    def __init__(self, framework):
+        """Setup event logging."""
+        self.seen_events = []
+        super().__init__(framework)
+
+    def configure_ceph(self, event):
+        return True
+
+
+class TestBaseCharm(test_utils.CharmTestCase):
+    def add_complete_identity_relation(self, harness: Harness) -> None:
+        """Add complete identity-service relation."""
+        credentials_content = {"username": "svcuser1", "password": "svcpass1"}
+        credentials_id = harness.add_model_secret("keystone", credentials_content)
+        app_data = {
+            "admin-domain-id": "admindomid1",
+            "admin-project-id": "adminprojid1",
+            "admin-user-id": "adminuserid1",
+            "api-version": "3",
+            "auth-host": "keystone.local",
+            "auth-port": "12345",
+            "auth-protocol": "http",
+            "internal-host": "keystone.internal",
+            "internal-port": "5000",
+            "internal-protocol": "http",
+            "internal-auth-url": "http://keystone.internal/v3",
+            "service-domain": "servicedom",
+            "service-domain_id": "svcdomid1",
+            "service-host": "keystone.service",
+            "service-port": "5000",
+            "service-protocol": "http",
+            "service-project": "svcproj1",
+            "service-project-id": "svcprojid1",
+            "service-credentials": credentials_id,
+        }
+
+        # Cannot use ops add_relation [1] directly due to secrets
+        # [1] https://ops.readthedocs.io/en/latest/#ops.testing.Harness.add_relation
+        rel_id = test_utils.add_base_identity_service_relation(harness)
+        harness.grant_secret(credentials_id, harness.charm.app.name)
+        harness.update_relation_data(rel_id, "keystone", app_data)
+
+    def add_complete_ingress_relation(self, harness: Harness) -> None:
+        """Add complete traefik-route relations."""
+        harness.add_relation(
+            "traefik-route-rgw",
+            "traefik",
+            app_data={"external_host": "dummy-ip", "scheme": "http"},
+        )
+
+    def add_complete_peer_relation(self, harness: Harness) -> None:
+        """Add complete peer relation data."""
+        rel_id = harness.add_relation(
+            "peers", harness.charm.app.name, unit_data={"public-address": "dummy-ip"}
+        )
+        return rel_id
+
+    def add_complete_certificate_transfer_relation(self, harness: Harness) -> None:
+        """Add complete certificate_transfer relation."""
+        harness.add_relation("receive-ca-cert", "keystone", unit_data={"ca": DUMMY_CA_CERT})
+
+    def add_cos_agent_integration(self, harness: Harness) -> None:
+        """Add cos agent integration."""
+        harness.add_relation("cos-agent", harness.charm.app.name)


### PR DESCRIPTION
# Description

we have seen peers-relation-created hooks not being fired, add more places to (conditionally) set peer data

https://github.com/juju/juju/issues/20041


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
