### PR TITLE
Adds ceph-nfs provider relation

### DIFF
--- a/lib/charms/ceph_nfs_client/v0/ceph_nfs_client.py
+++ b/lib/charms/ceph_nfs_client/v0/ceph_nfs_client.py
@@ -1,0 +1,164 @@
+"""CephNfsRequires module.
+
+This library contains the Requires class for handling the ceph-nfs-client
+interface.
+
+Import `CephNfsRequires` in your charm, with the charm object and the relation
+name:
+    - self
+    - "ceph-nfs"
+
+Two events are also available to respond to:
+    - connected
+    - departed
+
+A basic example showing the usage of this relation follows:
+
+```
+import charms.ceph_nfs.v0.ceph_nfs as ceph_nfs
+
+
+class CephNfsClientCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        # CephNfsRequires
+        self._ceph_nfs = ceph_nfs.CephNfsRequires(
+            self, "ceph-nfs",
+        )
+        self.framework.observe(
+            self._ceph_nfs.on.connected,
+            self._on_ceph_nfs_connected,
+        )
+        self.framework.observe(
+            self._ceph_nfs.on.departed,
+            self._on_ceph_nfs_departed,
+        )
+
+    def _on_ceph_nfs_connected(self, event):
+        '''React to the CephNfsConnectedEvent event.
+
+        This event happens when the ceph-nfs relation is added to the
+        model before information has been provided.
+        '''
+        # Do something before the relation is complete.
+        pass
+
+    def _on_ceph_nfs_departed(self, event):
+        '''React to the CephNfsDepartedEvent event.
+
+        This event happens when ceph-nfs relation is removed.
+        '''
+        # ceph-nfs relation has departed. Shutdown services if needed.
+        pass
+```
+"""
+
+import json
+import logging
+
+from ops.charm import (
+    CharmBase,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationDepartedEvent,
+    RelationEvent,
+)
+from ops.framework import (
+    EventSource,
+    Object,
+    ObjectEvents,
+)
+from ops.model import (
+    Relation,
+)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "0fb2d24550d94d24868d3cefa784d5be"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+logger = logging.getLogger(__name__)
+
+
+class CephNfsConnectedEvent(RelationEvent):
+    """ceph-nfs connected event."""
+
+    pass
+
+
+class CephNfsDepartedEvent(RelationEvent):
+    """ceph-nfs relation departed event."""
+
+    pass
+
+
+class CephNfsEvents(ObjectEvents):
+    """Events class for `on`."""
+
+    ceph_nfs_connected = EventSource(CephNfsConnectedEvent)
+    ceph_nfs_departed = EventSource(CephNfsDepartedEvent)
+
+
+class CephNfsRequires(Object):
+    """CephNfsRequires class."""
+
+    on = CephNfsEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        super().__init__(charm, relation_name)
+
+        self.charm = charm
+        self.relation_name = relation_name
+
+        self.framework.observe(
+            self.charm.on[relation_name].relation_changed,
+            self._on_ceph_nfs_relation_changed,
+        )
+        self.framework.observe(
+            self.charm.on[relation_name].relation_departed,
+            self._on_ceph_nfs_relation_broken,
+        )
+        self.framework.observe(
+            self.charm.on[relation_name].relation_broken,
+            self._on_ceph_nfs_relation_broken,
+        )
+
+    def _on_ceph_nfs_relation_changed(self, event: RelationChangedEvent):
+        """Handle ceph-nfs relation changed."""
+        logging.debug("ceph-nfs relation changed")
+        self.on.ceph_nfs_connected.emit(event.relation)
+
+    def _on_ceph_nfs_relation_broken(self, event: RelationBrokenEvent):
+        """Handle ceph-nfs relation broken."""
+        logging.debug("ceph-nfs relation broken")
+        self.on.ceph_nfs_departed.emit(event.relation)
+
+    @property
+    def _ceph_nfs_rel(self) -> Relation | None:
+        """The ceph-nfs relation."""
+        return self.framework.model.get_relation(self.relation_name)
+
+    def get_relation_data(self) -> dict:
+        """Get the ceph-nfs relation data."""
+        if not self._ceph_nfs_rel:
+            return {}
+
+        relation_data = self._ceph_nfs_rel.data[self._ceph_nfs_rel.app]
+        if not relation_data:
+            return {}
+
+        mon_hosts = json.loads(relation_data["mon-hosts"])
+
+        return {
+            "client": relation_data["client"],
+            "keyring": relation_data["keyring"],
+            "mon_hosts": mon_hosts,
+            "cluster-id": relation_data["cluster-id"],
+            "volume": relation_data["volume"],
+            "fsid": relation_data["fsid"],
+        }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,6 +28,8 @@ extra-bindings:
 provides:
   ceph:
     interface: ceph-client
+  ceph-nfs:
+    interface: ceph-nfs-client
   radosgw:
     interface: ceph-radosgw
   mds:

--- a/src/ceph.py
+++ b/src/ceph.py
@@ -230,6 +230,26 @@ def get_named_key(name, caps=None, pool_list=None):
     return parse_key(str(check_output(cmd).decode("UTF-8")).strip())  # IGNORE:E1103
 
 
+def remove_named_key(name: str) -> None:
+    """Remove a specific named cephx key.
+
+    :param name: String Name of key to remove.
+    """
+    log(f"Removing key {name}", level=DEBUG)
+    cmd = [
+        "microceph.ceph",
+        "--name",
+        "mon.",
+        "--keyring",
+        f"{VAR_LIB_CEPH}/mon/ceph-{socket.gethostname()}/keyring",
+        "auth",
+        "del",
+        name,
+    ]
+
+    check_output(cmd)
+
+
 def is_leader():
     """Check if this node is ceph mon leader."""
     hostname = socket.gethostname()
@@ -1184,3 +1204,15 @@ def ceph_config_set(ceph_service: str, key: str, value: str):
     :raises: CalledProcessError if config set op fails.
     """
     check_call(["microceph.ceph", "config", "set", ceph_service, key, value])
+
+
+def create_fs_volume(volume_name: str) -> None:
+    """Create the FS volume."""
+    cmd = ["microceph.ceph", "fs", "volume", "create", volume_name]
+    utils.run_cmd(cmd)
+
+
+def list_fs_volumes() -> List[dict]:
+    """Returns a list of ceph fs volumes."""
+    cmd = ["microceph.ceph", "fs", "volume", "ls"]
+    return json.loads(utils.run_cmd(cmd))

--- a/src/ceph_nfs.py
+++ b/src/ceph_nfs.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Handle Charm's NFS Client Events."""
+
+import itertools
+import json
+import logging
+from typing import Callable
+
+import ops_sunbeam.compound_status as compound_status
+from ops.charm import CharmBase, RelationEvent
+from ops.framework import (
+    EventBase,
+    EventSource,
+    Object,
+    ObjectEvents,
+)
+from ops.model import ActiveStatus, BlockedStatus
+from ops_sunbeam.relation_handlers import RelationHandler
+
+import ceph
+import microceph
+import utils
+from microceph_client import Client
+
+logger = logging.getLogger(__name__)
+
+
+class CephNfsConnectedEvent(RelationEvent):
+    """ceph-nfs connected event."""
+
+    pass
+
+
+class CephNfsDepartedEvent(RelationEvent):
+    """ceph-nfs relation has departed event."""
+
+    pass
+
+
+class CephNfsReconcileEvent(RelationEvent):
+    """ceph-nfs relation reconciliation event."""
+
+    pass
+
+
+class CephNfsEvents(ObjectEvents):
+    """Events class for `on`."""
+
+    ceph_nfs_connected = EventSource(CephNfsConnectedEvent)
+    ceph_nfs_departed = EventSource(CephNfsDepartedEvent)
+    ceph_nfs_reconcile = EventSource(CephNfsReconcileEvent)
+
+
+class CephNfsProvides(Object):
+    """Interface for ceph-nfs-client provider."""
+
+    on = CephNfsEvents()
+
+    def __init__(self, charm, relation_name="ceph-nfs"):
+        super().__init__(charm, relation_name)
+
+        self.charm = charm
+        self.relation_name = relation_name
+
+        # React to ceph-nfs relations.
+        self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_changed)
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+        self.framework.observe(
+            charm.on[relation_name].relation_departed, self._on_relation_departed
+        )
+
+        # React to ceph peers relations.
+        self.framework.observe(charm.on["peers"].relation_departed, self._on_ceph_peers)
+        self.framework.observe(charm.on["peers"].relation_changed, self._on_ceph_peers)
+
+    def _on_relation_changed(self, event):
+        """Prepare relation for data from requiring side."""
+        if not self.model.unit.is_leader():
+            return
+
+        logger.info("_on_relation_changed event")
+
+        if not self.charm.ready_for_service():
+            logger.info("Not processing request as service is not yet ready")
+            event.defer()
+            return
+
+        if ceph.get_osd_count() == 0:
+            logger.info("Storage not available, deferring event.")
+            event.defer()
+            return
+
+        self.on.ceph_nfs_connected.emit(event.relation)
+
+    def _on_relation_departed(self, event):
+        """Cleanup relation after departure."""
+        if not self.model.unit.is_leader() or event.relation.app == self.charm.app:
+            return
+
+        logger.info("_on_relation_departed event")
+        self.on.ceph_nfs_departed.emit(event.relation)
+
+    def _on_ceph_peers(self, event):
+        """Handle ceph peers relation events."""
+        if not self.model.unit.is_leader():
+            return
+
+        if ceph.get_osd_count() == 0:
+            logger.info("Storage not available, deferring event.")
+            event.defer()
+            return
+
+        logger.info("_on_ceph_peers event")
+
+        # Mon addrs might have changed, update the relation data.
+        # Additionally, new nodes may have been added, which could be added to
+        # NFS clusters.
+        self.on.ceph_nfs_reconcile.emit(event.relation)
+
+
+class CephNfsProviderHandler(RelationHandler):
+    """Handler for the ceph-nfs relation."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+        callback_f: Callable,
+    ):
+        super().__init__(charm, relation_name, callback_f)
+
+    def setup_event_handler(self) -> Object:
+        """Configure event handlers for an ceph-nfs-client interface."""
+        logger.debug("Setting up ceph-nfs-client event handler")
+
+        ceph_nfs = CephNfsProvides(self.charm, self.relation_name)
+        self.framework.observe(ceph_nfs.on.ceph_nfs_connected, self._on_ceph_nfs_connected)
+        self.framework.observe(ceph_nfs.on.ceph_nfs_reconcile, self._on_ceph_nfs_reconcile)
+        self.framework.observe(ceph_nfs.on.ceph_nfs_departed, self._on_ceph_nfs_departed)
+
+        return ceph_nfs
+
+    @property
+    def ready(self) -> bool:
+        """Check if handler is ready."""
+        relations = self.model.relations[self.relation_name]
+        if not relations:
+            return True
+
+        if not microceph.microceph_has_service("nfs"):
+            logger.error("NFS relation found, but snap does not have NFS support.")
+            return False
+
+        return True
+
+    def set_status(self, status: compound_status.Status) -> None:
+        """Set the status based on current state."""
+        relations = self.model.relations[self.relation_name]
+        if not relations:
+            # If there are no ceph-nfs relations, no need to block this.
+            status.set(ActiveStatus(""))
+            return
+
+        if not microceph.microceph_has_service("nfs"):
+            logger.error("NFS relation found, but snap does not have NFS support.")
+            status.set(BlockedStatus("microceph snap does not have NFS support"))
+            return
+
+        status.set(ActiveStatus(""))
+
+    def _cluster_id(self, relation) -> str:
+        return relation.app.name
+
+    def _on_ceph_nfs_reconcile(self, event: EventBase) -> None:
+        if not self.model.unit.is_leader():
+            return
+
+        logger.info("Processing ceph-nfs reconcile event")
+
+        # Mon addrs might have changed, update the relation data if needed.
+        # Additionally, new nodes may have been added, which could be added to
+        # NFS clusters.
+        for relation in self.model.relations[self.relation_name]:
+            if not self._service_relation(relation):
+                logger.error("A ceph-nfs relation could not be serviced.")
+                self.status.set(
+                    BlockedStatus("A ceph-nfs relation could not be serviced. Check logs.")
+                )
+                event.defer()
+                return
+
+        self.status.set(ActiveStatus(""))
+
+    def _on_ceph_nfs_connected(self, event: EventBase) -> None:
+        if not self.model.unit.is_leader():
+            return
+
+        logger.info("Processing ceph-nfs connected")
+        if not self._service_relation(event.relation):
+            logger.error("An error occurred while handling the ceph-nfs relation, deferring.")
+            self.status.set(
+                BlockedStatus("A ceph-nfs relation could not be serviced. Check logs.")
+            )
+            event.defer()
+            return
+
+    def _service_relation(self, relation) -> bool:
+        cluster_id = self._cluster_id(relation)
+        relation_data = relation.data[self.model.app]
+
+        if not self._ensure_nfs_cluster(cluster_id):
+            # If we can't ensure even 1 node for the NFS cluster, clear the
+            # relation data, as it wouldn't be usable.
+            relation_data.clear()
+            return False
+
+        volume_name = f"{cluster_id}-vol"
+        self._ensure_fs_volume(volume_name)
+
+        client_name = f"client.{relation.app.name}"
+        caps = {"mon": ["allow r"], "mgr": ["allow rw"]}
+        client_key = ceph.get_named_key(client_name, caps)
+        addrs = utils.get_mon_addresses()
+
+        relation_data.update(
+            {
+                "client": client_name,
+                "keyring": client_key,
+                "mon_hosts": json.dumps(addrs),
+                "cluster-id": cluster_id,
+                "volume": volume_name,
+                "fsid": utils.get_fsid(),
+            }
+        )
+
+        return True
+
+    def _ensure_nfs_cluster(self, cluster_id) -> bool:
+        client = Client.from_socket()
+        services = client.cluster.list_services()
+
+        all_nfs_services = [s for s in services if s["service"] == "nfs"]
+        nfs_services = [s for s in all_nfs_services if s.get("group_id") == cluster_id]
+        nodes_in_cluster = len(nfs_services)
+
+        if nodes_in_cluster >= 3:
+            # We're only adding up to 3 nodes in the cluster.
+            logger.info(
+                "NFS Cluster '%s' already exists, and there are >= 3 nodes in it.", cluster_id
+            )
+            return True
+
+        # Find potential candidates for the NFS cluster. We can only enable
+        # NFS once per host.
+        exclude_hosts = [s["location"] for s in all_nfs_services]
+
+        all_hosts = set([s["location"] for s in services])
+        candidates = [h for h in all_hosts if h not in exclude_hosts]
+
+        for candidate in candidates:
+            try:
+                public_addr = self._get_public_address(candidate)
+                if not public_addr:
+                    logger.warning(
+                        "Could not find the public address of '%s' in the peer relation data.",
+                        candidate,
+                    )
+                    continue
+
+                microceph.enable_nfs(candidate, cluster_id, public_addr)
+
+                nodes_in_cluster += 1
+                if nodes_in_cluster == 3:
+                    break
+            except Exception as ex:
+                logger.error(
+                    "Could not enable nfs (cluster_id '%s') on host '%s': %s",
+                    cluster_id,
+                    candidate,
+                    ex,
+                )
+
+        if nodes_in_cluster == 0:
+            logger.error("Could not create NFS Cluster '%s' on any host", cluster_id)
+            return False
+
+        if nodes_in_cluster < 3:
+            logger.warning(
+                "NFS cluster '%s' is enabled only on %d / 3 nodes.", cluster_id, nodes_in_cluster
+            )
+            return True
+
+        logger.info("NFS cluster '%s' is enabled on 3 / 3 nodes.", cluster_id)
+        return True
+
+    def _get_public_address(self, hostname: str) -> str:
+        rel = self.model.get_relation("peers")
+        for unit in itertools.chain(rel.units, [self.model.unit]):
+            rel_data = rel.data[unit]
+            unit_hostname = rel_data.get(unit.name)
+
+            if hostname == unit_hostname:
+                return rel_data.get("public-address")
+
+        return ""
+
+    def _ensure_fs_volume(self, volume_name: str) -> None:
+        """Create the FS Volume if it doesn't exist."""
+        fs_volumes = ceph.list_fs_volumes()
+        for fs_volume in fs_volumes:
+            if fs_volume["name"] == volume_name:
+                return
+
+        ceph.create_fs_volume(volume_name)
+
+    def _on_ceph_nfs_departed(self, event: EventBase) -> None:
+        if not self.model.unit.is_leader():
+            return
+
+        logger.info("Processing ceph-nfs departed")
+
+        cluster_id = self._cluster_id(event.relation)
+        self._remove_nfs_cluster(cluster_id)
+
+        client_name = f"client.{event.relation.app.name}"
+        ceph.remove_named_key(client_name)
+
+        # Because a relation departed, that means the nodes associated with it
+        # are now free, which means that we can allocate them to the other NFS
+        # clusters as needed.
+        other_relations = [
+            r for r in self.model.relations[self.relation_name] if r != event.relation
+        ]
+
+        error = False
+        for relation in other_relations:
+            if not self._service_relation(relation):
+                logger.error("An error occurred while handling the ceph-nfs relation, deferring.")
+                self.status.set(
+                    BlockedStatus("A ceph-nfs relation could not be serviced. Check logs.")
+                )
+                error = True
+
+        if not error:
+            self.status.set(ActiveStatus(""))
+
+    def _remove_nfs_cluster(self, cluster_id):
+        client = Client.from_socket()
+        services = client.cluster.list_services()
+        nfs_services = [
+            s for s in services if s["service"] == "nfs" and s.get("group_id") == cluster_id
+        ]
+
+        for service in nfs_services:
+            host = service["location"]
+            try:
+                microceph.disable_nfs(host, cluster_id)
+            except Exception as ex:
+                logger.error(
+                    "Could not disable nfs (cluster_id '%s') on host '%s': %s",
+                    cluster_id,
+                    host,
+                    ex,
+                )
+                raise

--- a/src/charm.py
+++ b/src/charm.py
@@ -41,6 +41,7 @@ import cluster
 import maintenance
 import microceph
 import microceph_client
+from ceph_nfs import CephNfsProviderHandler
 from microceph_client import ClusterServiceUnavailableException
 from radosgw import RadosGWHandler
 from relation_handlers import (
@@ -347,6 +348,12 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             self.radosgw = CephRadosGWProviderHandler(self, self.handle_ceph)
         if self.can_add_handler("mds", handlers):
             self.mds = CephMdsProviderHandler(self, self.handle_ceph)
+        if self.can_add_handler("ceph-nfs", handlers):
+            self.ceph_nfs = CephNfsProviderHandler(
+                self,
+                "ceph-nfs",
+                self.handle_ceph_nfs,
+            )
         if self.can_add_handler("traefik-route-rgw", handlers):
             self.traefik_route_rgw = sunbeam_rhandlers.TraefikRouteHandler(
                 self,
@@ -410,6 +417,10 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
     def handle_ceph(self, event) -> None:
         """Callback for interface ceph."""
         logger.info("Callback for ceph interface, ignore")
+
+    def handle_ceph_nfs(self, event) -> None:
+        """Callback for interface ceph-nfs-client."""
+        logger.debug("Callback for ceph-nfs-client interface, ignore")
 
     def upgrade_dispatch(self, event: ops.framework.EventBase) -> None:
         """Dispatch upgrade events."""

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -219,6 +219,28 @@ def join_cluster(token: str, micro_ip: str = "", **kwargs):
     utils.run_cmd(cmd=cmd)
 
 
+def enable_nfs(target: str, cluster_id: str, bind_addr: str) -> None:
+    """Enable the NFS service on the target host with the given Cluster ID."""
+    cmd = [
+        "microceph",
+        "enable",
+        "nfs",
+        "--target",
+        target,
+        "--cluster-id",
+        cluster_id,
+        "--bind-address",
+        bind_addr,
+    ]
+    utils.run_cmd(cmd)
+
+
+def disable_nfs(target: str, cluster_id: str) -> None:
+    """Disable the NFS service on the target host with the given Cluster ID."""
+    cmd = ["microceph", "disable", "nfs", "--target", target, "--cluster-id", cluster_id]
+    utils.run_cmd(cmd)
+
+
 def enable_rgw() -> None:
     """Enable RGW service."""
     cmd = ["microceph", "enable", "rgw"]
@@ -229,6 +251,14 @@ def disable_rgw() -> None:
     """Disable RGW service."""
     cmd = ["microceph", "disable", "rgw"]
     utils.run_cmd(cmd)
+
+
+def microceph_has_service(service_name) -> bool:
+    """Returns whether the microceph snap has a service or not."""
+    cmd = ["snap", "services", "microceph"]
+    output = utils.run_cmd(cmd)
+
+    return f"microceph.{service_name}" in output
 
 
 # Disk CMDs and Helpers

--- a/tests/unit/test_ceph_nfs.py
+++ b/tests/unit/test_ceph_nfs.py
@@ -1,0 +1,397 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import call, patch
+
+import ops_sunbeam.test_utils as test_utils
+from ops.model import ActiveStatus, BlockedStatus
+from unit import testbase
+
+import ceph_nfs
+
+
+class TestCephNfsClientProvides(testbase.TestBaseCharm):
+
+    def setUp(self):
+        """Setup MicroCeph Charm tests."""
+        super().setUp(ceph_nfs, [])
+        with open("config.yaml", "r") as f:
+            config_data = f.read()
+        with open("metadata.yaml", "r") as f:
+            metadata = f.read()
+
+        self.harness = test_utils.get_harness(
+            testbase._MicroCephCharm,
+            container_calls=self.container_calls,
+            charm_config=config_data,
+            charm_metadata=metadata,
+        )
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+        patcher = patch.object(self.harness.charm, "ready_for_service")
+        self.ready_for_service = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patch_list = [
+            # (self.attr_name, thing_to_patch)
+            ("ceph_check_output", "ceph.check_output"),
+            ("create_fs_volume", "ceph.create_fs_volume"),
+            ("get_named_key", "ceph.get_named_key"),
+            ("remove_named_key", "ceph.remove_named_key"),
+            ("get_osd_count", "ceph.get_osd_count"),
+            ("list_fs_volumes", "ceph.list_fs_volumes"),
+            ("broker_check_output", "ceph_broker.check_output"),
+            ("enable_nfs", "microceph.enable_nfs"),
+            ("disable_nfs", "microceph.disable_nfs"),
+            ("microceph_has_service", "microceph.microceph_has_service"),
+            ("microceph_check_output", "microceph.subprocess.check_output"),
+            ("list_services", "microceph_client.ClusterService.list_services"),
+            ("get_fsid", "utils.get_fsid"),
+            ("get_mon_addresses", "utils.get_mon_addresses"),
+            ("run_cmd", "utils.run_cmd"),
+        ]
+
+        for attr_name, thing in patch_list:
+            patcher = patch(thing)
+            mock_obj = patcher.start()
+            setattr(self, attr_name, mock_obj)
+            self.addCleanup(patcher.stop)
+
+        self.get_named_key.return_value = "fa-key"
+        self.list_services.return_value = []
+        self.list_fs_volumes.return_value = []
+        self.get_fsid.return_value = "f00"
+        self.get_mon_addresses.return_value = ["foo.lish"]
+
+        def _add_service(candidate, cluster_id, _):
+            self.list_services.return_value.append(
+                {"service": "nfs", "group_id": cluster_id, "location": candidate}
+            )
+
+        self.enable_nfs.side_effect = _add_service
+
+        def _remove_service(candidate, cluster_id):
+            for svc in self.list_services.return_value:
+                if (
+                    svc["service"] == "nfs"
+                    and svc["group_id"] == cluster_id
+                    and svc["location"] == candidate
+                ):
+                    self.list_services.return_value.remove(svc)
+                    return
+
+        self.disable_nfs.side_effect = _remove_service
+
+        def _add_fs_volume(volume_name):
+            self.list_fs_volumes.return_value.append(
+                {
+                    "name": volume_name,
+                }
+            )
+
+        self.create_fs_volume.side_effect = _add_fs_volume
+
+    def _add_peer_unit(self, rel_id, number):
+        host = f"foo{number}"
+        unit_name = f"microceph/{number}"
+
+        self.list_services.return_value += [
+            {"service": "mon", "location": host},
+        ]
+
+        unit_data = {
+            "public-address": f"pub-addr-{number}",
+            unit_name: f"foo{number}",
+        }
+        self.add_unit(self.harness, rel_id, unit_name, unit_data)
+
+    def test_ceph_nfs_connected_not_emitted(self):
+        self.ready_for_service.return_value = False
+        self.get_osd_count.return_value = 0
+
+        self.harness.set_leader()
+        self.add_ceph_nfs_relation(self.harness)
+
+        # charm is not ready for service, and thus the relation doesn't change
+        # its status yet.
+        ceph_nfs_status = self.harness.charm.ceph_nfs.status
+        self.assertIsInstance(ceph_nfs_status.status, ActiveStatus)
+        self.get_osd_count.assert_not_called()
+
+        # The charm is now ready to service, but has no OSDs.
+        self.ready_for_service.return_value = True
+
+        self.add_ceph_nfs_relation(self.harness)
+
+        # _on_relation_changed is called on relation join and changed events.
+        self.get_osd_count.assert_has_calls([call()] * 2)
+
+    def test_ceph_nfs_servicability(self):
+        self.microceph_has_service.return_value = False
+        self.harness.set_leader()
+        ceph_nfs = self.harness.charm.ceph_nfs
+
+        ceph_nfs.set_status(ceph_nfs.status)
+
+        # No ceph-nfs relations, the status should be Active.
+        self.assertIsInstance(ceph_nfs.status.status, ActiveStatus)
+        self.microceph_has_service.assert_not_called()
+
+        self.add_ceph_nfs_relation(self.harness)
+        ceph_nfs.set_status(ceph_nfs.status)
+
+        # Has ceph-nfs relation, but has no NFS support.
+        self.assertIsInstance(ceph_nfs.status.status, BlockedStatus)
+        self.microceph_has_service.assert_called_once()
+        self.enable_nfs.assert_not_called()
+
+        # # The snap now has NFS support.
+        self.microceph_has_service.reset_mock()
+        self.microceph_has_service.return_value = True
+        unit_data = {
+            "public-address": "pub-addr-1",
+            "microceph/1": "foo1",
+        }
+
+        ceph_nfs.set_status(ceph_nfs.status)
+
+        self.assertIsInstance(ceph_nfs.status.status, ActiveStatus)
+
+        rel_id = self.add_complete_peer_relation(self.harness, unit_data)
+        self._add_peer_unit(rel_id, 1)
+
+        self.microceph_has_service.assert_called_once()
+        self.enable_nfs.assert_called_once()
+        self.assertIsInstance(ceph_nfs.status.status, ActiveStatus)
+
+    def test_ensure_nfs_cluster(self):
+        # No nodes.
+        self.list_services.return_value = []
+        self.harness.set_leader()
+
+        nfs_rel_id = self.add_ceph_nfs_relation(self.harness)
+
+        self.enable_nfs.assert_not_called()
+        self.create_fs_volume.assert_not_called()
+
+        ceph_nfs_status = self.harness.charm.ceph_nfs.status
+        self.assertIsInstance(ceph_nfs_status.status, BlockedStatus)
+
+        # Add a node, the NFS cluster should extend to it.
+        self.list_services.return_value = [
+            {"service": "mon", "location": "foo1"},
+            {"service": "mgr", "location": "foo1"},
+            {"service": "osd", "location": "foo1"},
+            {"service": "mds", "location": "foo1"},
+        ]
+
+        unit_data = {
+            "public-address": "pub-addr-1",
+            "microceph/1": "foo1",
+        }
+        rel_id = self.add_complete_peer_relation(self.harness, unit_data)
+        self._add_peer_unit(rel_id, 1)
+
+        self.enable_nfs.assert_called_once_with("foo1", "manila-cephfs", "pub-addr-1")
+        self.create_fs_volume.assert_called_once_with("manila-cephfs-vol")
+        caps = {"mon": ["allow r"], "mgr": ["allow rw"]}
+        self.get_named_key.assert_called_once_with("client.manila-cephfs", caps)
+
+        rel_data = self.harness.get_relation_data(nfs_rel_id, self.harness.model.app)
+        expected_data = {
+            "client": "client.manila-cephfs",
+            "keyring": "fa-key",
+            "mon_hosts": '["foo.lish"]',
+            "cluster-id": "manila-cephfs",
+            "volume": "manila-cephfs-vol",
+            "fsid": "f00",
+        }
+        self.assertEqual(expected_data, rel_data)
+        self.assertIsInstance(ceph_nfs_status.status, ActiveStatus)
+
+        # Add 2 more nodes, the NFS cluster should only enabled on the 3 nodes.
+        self.create_fs_volume.reset_mock()
+        self._add_peer_unit(rel_id, 2)
+        self._add_peer_unit(rel_id, 3)
+
+        self.enable_nfs.assert_has_calls(
+            [
+                call("foo1", "manila-cephfs", "pub-addr-1"),
+                call("foo2", "manila-cephfs", "pub-addr-2"),
+                call("foo3", "manila-cephfs", "pub-addr-3"),
+            ]
+        )
+        self.create_fs_volume.assert_not_called()
+        self.assertIsInstance(ceph_nfs_status.status, ActiveStatus)
+
+        # Add a 4th node, enable_nfs should not be called again.
+        self.enable_nfs.reset_mock()
+        self._add_peer_unit(rel_id, 4)
+
+        self.enable_nfs.assert_not_called()
+        self.create_fs_volume.assert_not_called()
+        self.assertIsInstance(ceph_nfs_status.status, ActiveStatus)
+
+        # Add a new relation, should use the 4th node.
+        another_nfs_rel_id = self.add_ceph_nfs_relation(self.harness, "another-app")
+
+        self.enable_nfs.assert_called_with("foo4", "another-app", "pub-addr-4")
+        self.create_fs_volume.assert_called_once_with("another-app-vol")
+        rel_data = self.harness.get_relation_data(another_nfs_rel_id, self.harness.model.app)
+        expected_data = {
+            "client": "client.another-app",
+            "keyring": "fa-key",
+            "mon_hosts": '["foo.lish"]',
+            "cluster-id": "another-app",
+            "volume": "another-app-vol",
+            "fsid": "f00",
+        }
+        self.assertEqual(expected_data, rel_data)
+        self.assertIsInstance(ceph_nfs_status.status, ActiveStatus)
+
+        # Add another relation, but this time there's no available node.
+        self.enable_nfs.reset_mock()
+        self.create_fs_volume.reset_mock()
+
+        self.add_ceph_nfs_relation(self.harness, "yet-another-app")
+
+        self.enable_nfs.assert_not_called()
+        self.create_fs_volume.assert_not_called()
+        self.assertIsInstance(ceph_nfs_status.status, BlockedStatus)
+
+    def test_peers_updated_rel_data(self):
+        self.get_mon_addresses.return_value = []
+        self.list_services.return_value = []
+        self.harness.set_leader()
+
+        rel_id = self.add_ceph_nfs_relation(self.harness)
+
+        rel_data = self.harness.get_relation_data(rel_id, self.harness.model.app)
+        self.assertIsNone(rel_data.get("mon_hosts"))
+
+        # Add a peer unit. mon-hosts should be updated.
+        self.get_mon_addresses.return_value = ["foo.lish"]
+
+        unit_data = {
+            "public-address": "pub-addr-1",
+            "microceph/1": "foo1",
+        }
+        rel_id = self.add_complete_peer_relation(self.harness, unit_data)
+        self._add_peer_unit(rel_id, 1)
+
+        self.assertEqual('["foo.lish"]', rel_data.get("mon_hosts"))
+
+    def test_relation_no_longer_servicable(self):
+        self.harness.set_leader()
+        unit_data = {
+            "public-address": "pub-addr-1",
+            "microceph/1": "foo1",
+        }
+        rel_id = self.add_complete_peer_relation(self.harness, unit_data)
+        self._add_peer_unit(rel_id, 1)
+
+        # Add the ceph-nfs relation. It should use the available node.
+        nfs_rel_id = self.add_ceph_nfs_relation(self.harness)
+
+        self.enable_nfs.assert_called_once_with("foo1", "manila-cephfs", "pub-addr-1")
+        self.create_fs_volume.assert_called_once_with("manila-cephfs-vol")
+        rel_data = self.harness.get_relation_data(nfs_rel_id, self.harness.model.app)
+        expected_data = {
+            "client": "client.manila-cephfs",
+            "keyring": "fa-key",
+            "mon_hosts": '["foo.lish"]',
+            "cluster-id": "manila-cephfs",
+            "volume": "manila-cephfs-vol",
+            "fsid": "f00",
+        }
+        self.assertEqual(expected_data, rel_data)
+        ceph_nfs_status = self.harness.charm.ceph_nfs.status
+        self.assertIsInstance(ceph_nfs_status.status, ActiveStatus)
+
+        # Remove the only microceph unit, the relation data should be cleared,
+        # as there is no node available to service it anymore.
+        self.list_services.return_value = []
+        self.harness.remove_relation_unit(rel_id, "microceph/1")
+
+        self.assertEqual({}, rel_data)
+        self.assertIsInstance(ceph_nfs_status.status, BlockedStatus)
+
+    def test_remove_relation_rebalance(self):
+        self.harness.set_leader()
+        unit_data = {
+            "public-address": "pub-addr-1",
+            "microceph/1": "foo1",
+        }
+        rel_id = self.add_complete_peer_relation(self.harness, unit_data)
+        self._add_peer_unit(rel_id, 1)
+        self._add_peer_unit(rel_id, 2)
+        self._add_peer_unit(rel_id, 3)
+
+        # Add the first ceph-nfs relation. It should use up all 3 available nodes.
+        ceph_rel_id = self.add_ceph_nfs_relation(self.harness)
+        self._add_peer_unit(ceph_rel_id, 1)
+
+        self.enable_nfs.assert_has_calls(
+            [
+                call("foo1", "manila-cephfs", "pub-addr-1"),
+                call("foo2", "manila-cephfs", "pub-addr-2"),
+                call("foo3", "manila-cephfs", "pub-addr-3"),
+            ],
+            any_order=True,
+        )
+        ceph_nfs_status = self.harness.charm.ceph_nfs.status
+        self.assertIsInstance(ceph_nfs_status.status, ActiveStatus)
+
+        # Add a new relation, it should not have any node available.
+        self.enable_nfs.reset_mock()
+        self.create_fs_volume.reset_mock()
+        self.get_named_key.reset_mock()
+
+        self.add_ceph_nfs_relation(self.harness, "another-app")
+
+        self.enable_nfs.assert_not_called()
+        self.create_fs_volume.assert_not_called()
+        self.get_named_key.assert_not_called()
+        self.assertIsInstance(ceph_nfs_status.status, BlockedStatus)
+
+        # Remove first relation, the second one should now use the nodes.
+        self.harness.remove_relation(ceph_rel_id)
+
+        self.disable_nfs.assert_has_calls(
+            [
+                call("foo1", "manila-cephfs"),
+                call("foo2", "manila-cephfs"),
+                call("foo3", "manila-cephfs"),
+            ],
+            any_order=True,
+        )
+        self.remove_named_key.assert_called_once_with("client.manila-cephfs")
+        self.enable_nfs.assert_has_calls(
+            [
+                call("foo1", "another-app", "pub-addr-1"),
+                call("foo2", "another-app", "pub-addr-2"),
+                call("foo3", "another-app", "pub-addr-3"),
+            ],
+            any_order=True,
+        )
+        self.create_fs_volume.assert_called_once_with("another-app-vol")
+        caps = {"mon": ["allow r"], "mgr": ["allow rw"]}
+        self.get_named_key.assert_called_once_with("client.another-app", caps)
+        self.assertIsInstance(ceph_nfs_status.status, ActiveStatus)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -102,6 +102,7 @@ class TestCharm(testbase.TestBaseCharm):
         self.add_complete_identity_relation(self.harness)
         self.add_complete_ingress_relation(self.harness)
         self.add_complete_certificate_transfer_relation(self.harness)
+        self.add_ceph_nfs_relation(self.harness)
 
         subprocess.run.assert_any_call(
             [
@@ -125,7 +126,7 @@ class TestCharm(testbase.TestBaseCharm):
         cclient.from_socket().cluster.update_config.assert_not_called()
 
     @patch.object(ceph_cos_agent, "ceph_utils")
-    @patch("relation_handlers.Client", MagicMock())
+    @patch("utils.Client", MagicMock())
     @patch.object(microceph, "Client")
     @patch("utils.subprocess")
     @patch.object(Path, "chmod")
@@ -143,6 +144,7 @@ class TestCharm(testbase.TestBaseCharm):
         self.add_complete_identity_relation(self.harness)
         self.add_complete_ingress_relation(self.harness)
         self.add_complete_certificate_transfer_relation(self.harness)
+        self.add_ceph_nfs_relation(self.harness)
 
         subprocess.run.assert_any_call(
             [
@@ -185,7 +187,7 @@ class TestCharm(testbase.TestBaseCharm):
         )
 
     @patch.object(ceph_cos_agent, "ceph_utils")
-    @patch("relation_handlers.Client", MagicMock())
+    @patch("utils.Client", MagicMock())
     @patch.object(microceph, "Client")
     @patch("utils.subprocess")
     @patch.object(Path, "chmod")
@@ -205,6 +207,7 @@ class TestCharm(testbase.TestBaseCharm):
         self.add_complete_identity_relation(self.harness)
         self.add_complete_ingress_relation(self.harness)
         self.add_complete_certificate_transfer_relation(self.harness)
+        self.add_ceph_nfs_relation(self.harness)
 
         subprocess.run.assert_any_call(
             [
@@ -248,7 +251,7 @@ class TestCharm(testbase.TestBaseCharm):
         )
 
     @patch.object(ceph_cos_agent, "ceph_utils")
-    @patch("relation_handlers.Client", MagicMock())
+    @patch("utils.Client", MagicMock())
     @patch.object(microceph, "Client")
     @patch("utils.subprocess")
     @patch.object(Path, "chmod")
@@ -630,7 +633,7 @@ class TestCharm(testbase.TestBaseCharm):
         action_event.fail.assert_called()
 
     @patch.object(ceph_cos_agent, "ceph_utils")
-    @patch("relation_handlers.Client", MagicMock())
+    @patch("utils.Client", MagicMock())
     @patch.object(microceph, "Client")
     @patch("utils.subprocess")
     @patch("builtins.open", new_callable=mock_open, read_data="mon host dummy-ip")

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -171,3 +171,44 @@ class TestMicroCeph(unittest.TestCase):
         run_cmd.assert_called_with(
             cmd=["microceph", "cluster", "join", "token", "--microceph-ip", "10.10.10.10"]
         )
+
+    @patch("utils.run_cmd")
+    def test_enable_nfs(self, run_cmd):
+        microceph.enable_nfs("foo", "lish", "addr")
+
+        run_cmd.assert_called_once_with(
+            [
+                "microceph",
+                "enable",
+                "nfs",
+                "--target",
+                "foo",
+                "--cluster-id",
+                "lish",
+                "--bind-address",
+                "addr",
+            ]
+        )
+
+    @patch("utils.run_cmd")
+    def test_disable_nfs(self, run_cmd):
+        microceph.disable_nfs("foo", "lish")
+
+        run_cmd.assert_called_once_with(
+            ["microceph", "disable", "nfs", "--target", "foo", "--cluster-id", "lish"]
+        )
+
+    @patch("utils.run_cmd")
+    def test_microceph_has_service(self, run_cmd):
+        output = """Service                  Startup   Current   Notes
+        microceph.nfs            enabled   active    -
+        """
+        run_cmd.return_value = output
+
+        result = microceph.microceph_has_service("foo")
+
+        self.assertFalse(result)
+        run_cmd.assert_called_once_with(["snap", "services", "microceph"])
+
+        result = microceph.microceph_has_service("nfs")
+        self.assertTrue(result)

--- a/tests/unit/testbase.py
+++ b/tests/unit/testbase.py
@@ -94,11 +94,10 @@ class TestBaseCharm(test_utils.CharmTestCase):
             app_data={"external_host": "dummy-ip", "scheme": "http"},
         )
 
-    def add_complete_peer_relation(self, harness: Harness) -> None:
+    def add_complete_peer_relation(self, harness: Harness, unit_data=None) -> None:
         """Add complete peer relation data."""
-        rel_id = harness.add_relation(
-            "peers", harness.charm.app.name, unit_data={"public-address": "dummy-ip"}
-        )
+        unit_data = unit_data or {"public-address": "dummy-ip"}
+        rel_id = harness.add_relation("peers", harness.charm.app.name, unit_data=unit_data)
         return rel_id
 
     def add_complete_certificate_transfer_relation(self, harness: Harness) -> None:
@@ -108,3 +107,11 @@ class TestBaseCharm(test_utils.CharmTestCase):
     def add_cos_agent_integration(self, harness: Harness) -> None:
         """Add cos agent integration."""
         harness.add_relation("cos-agent", harness.charm.app.name)
+
+    def add_ceph_nfs_relation(self, harness: Harness, app_name="manila-cephfs") -> int:
+        """Add ceph-nfs-client relation."""
+        return harness.add_relation("ceph-nfs", app_name, unit_data={"foo": "lish"})
+
+    def add_unit(self, harness: Harness, rel_id: int, unit_name: str, unit_data={}) -> None:
+        harness.add_relation_unit(rel_id, unit_name)
+        harness.update_relation_data(rel_id, unit_name, unit_data)


### PR DESCRIPTION
# Description

Through the ``ceph-nfs-client``, MicroCeph will now provision NFS clusters.

For a relation, the charm will create a NFS cluster (on up to 3 nodes), and sets the relevant relation data for it. If there are no available  nodes, the relation will not be serviced.

The charm will take into account new nodes joining / leaving, or if a ``ceph-nfs-client`` relation departs, provisioning nodes to the NFS clusters  as needed.

Adds `ceph-nfs-client` library, containing the `CephNfsProvides` and `CephNfsRequires` classes.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
