### PR TITLE
ceph-nfs: Fixes inconsistent ceph-nfs relation mon_hosts key

### DIFF
--- a/lib/charms/ceph_nfs_client/v0/ceph_nfs_client.py
+++ b/lib/charms/ceph_nfs_client/v0/ceph_nfs_client.py
@@ -82,6 +82,9 @@ LIBAPI = 0
 # to 0 if you are raising the major API version
 LIBPATCH = 1
 
+MON_HOSTS = "mon_hosts"
+CLUSTER_ID = "cluster-id"
+
 logger = logging.getLogger(__name__)
 
 
@@ -152,13 +155,13 @@ class CephNfsRequires(Object):
         if not relation_data:
             return {}
 
-        mon_hosts = json.loads(relation_data["mon-hosts"])
+        mon_hosts = json.loads(relation_data[MON_HOSTS])
 
         return {
             "client": relation_data["client"],
             "keyring": relation_data["keyring"],
-            "mon_hosts": mon_hosts,
-            "cluster-id": relation_data["cluster-id"],
+            MON_HOSTS: mon_hosts,
+            CLUSTER_ID: relation_data[CLUSTER_ID],
             "volume": relation_data["volume"],
             "fsid": relation_data["fsid"],
         }


### PR DESCRIPTION

# Description

The `CephNfsProvides` set the `mon_hosts` key, while the `CephNfsRequires` accesses `mon-hosts`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
