### PR TITLE
fix: only check mon quorum if on mon node

### DIFF
--- a/src/microceph.py
+++ b/src/microceph.py
@@ -18,6 +18,7 @@
 
 import json
 import logging
+import shlex
 import subprocess
 from socket import gethostname
 
@@ -48,7 +49,8 @@ def is_ready() -> bool:
         logger.warning("Microceph not bootstrapped yet.")
         return False
 
-    if not ceph.cluster_has_quorum():
+    mon_startup, _ = microceph_service_status("mon")
+    if mon_startup == "enabled" and not ceph.cluster_has_quorum():
         logger.debug("Ceph cluster not in quorum, not ready yet")
         return False
 
@@ -311,6 +313,18 @@ def microceph_has_service(service_name) -> bool:
     output = utils.run_cmd(cmd)
 
     return f"microceph.{service_name}" in output
+
+
+def microceph_service_status(service_name) -> tuple[str, str]:
+    """Returns the status of a microceph service."""
+    # shellquote to handle any special characters in service name
+    svc = shlex.quote(service_name)
+    cmd = ["snap", "services", f"microceph.{svc}"]
+    output = utils.run_cmd(cmd)
+    for line in output.splitlines():
+        if f"microceph.{svc}" in line:
+            return tuple(line.split()[1:3])  # startup, current status
+    return ("unknown", "unknown")
 
 
 # Disk CMDs and Helpers


### PR DESCRIPTION
# Description

Avoid false negative for readiness check -- only check quorum on mon nodes

Fixes #203

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
