### PR TITLE
ceph-nfs: Enables microceph mgr module and orch backend

### DIFF
--- a/src/ceph.py
+++ b/src/ceph.py
@@ -511,6 +511,12 @@ def disable_mgr_module(module: str):
     utils.run_cmd(cmd=cmd)
 
 
+def set_orch_backend(backend_name: str):
+    """Set the given orch backend."""
+    cmd = ["microceph.ceph", "orch", "set", "backend", backend_name]
+    utils.run_cmd(cmd)
+
+
 def enable_ceph_monitoring():
     """Enable Monitoring for ceph cluster."""
     enable_mgr_module("prometheus")

--- a/src/ceph_nfs.py
+++ b/src/ceph_nfs.py
@@ -230,6 +230,16 @@ class CephNfsProviderHandler(RelationHandler):
             relation_data.clear()
             return False
 
+        try:
+            ceph.enable_mgr_module("microceph")
+            ceph.set_orch_backend("microceph")
+        except Exception as ex:
+            # If the following commands fail, some clients (e.g.: manila) may
+            # not be able to properly provision shares.
+            logger.error("Encountered exception: %s", ex)
+            relation_data.clear()
+            return False
+
         volume_name = f"{cluster_id}-vol"
         self._ensure_fs_volume(volume_name)
 


### PR DESCRIPTION
# Description

Manila runs the command `ceph nfs cluster info`, which fails if the orchestrator backend is not set.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
