### PR TITLE
Updates pydantic and ops requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 cryptography
-ops<3
+ops<3.4
 pyroute2
 netifaces
 jsonschema
 tenacity
 jinja2
-pydantic<2
+pydantic<2.12
 cosl==0.0.55
 requests<2.32 # https://github.com/psf/requests/issues/6707 (similar issue with http+unix)
 git+https://opendev.org/openstack/sunbeam-charms#egg=ops-sunbeam&subdirectory=ops-sunbeam

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,8 +8,8 @@ coverage
 mock
 flake8
 stestr
-ops
-pydantic < 2
+ops<3.4
+pydantic<2.12
 cosl==0.0.55
 
 git+https://github.com/canonical/ceph-charms#egg=charms_ceph&subdirectory=charms.ceph


### PR DESCRIPTION
# Description

Currently, the unit tests are failing due to an out-of-date `pydantic`. `ops_sunbeam` updated its requirements to `pydantic 2.11.9`, and it fails during an import because we're pinning it to version `< 2`.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
