### PR TITLE
Feat: ceph-admin interface for adopting an external ceph cluster

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -968,20 +968,23 @@ jobs:
       - name: Install dependencies
         run: ./tests/scripts/ci_helpers.sh install_deps
 
-      - name: Install MicroCeph charm
+      - name: Install Primary Charmed Ceph + MicroCeph cluster and a secondary MicroCeph cluster
         run: |
           set -eux
           date
           juju deploy ./tests/bundles/noble-caracal.yaml
           juju wait-for application ceph-mon --query='forEach(units, unit => unit.workload-status=="active" && unit.agent-status=="idle")' --timeout=30m
           juju wait-for application secondary --query='forEach(units, unit => unit.workload-status=="active" && unit.agent-status=="idle")' --timeout=30m
+          # The primary charm is expected to be in maintenance mode as the service is still not bootstrapped.
+          juju wait-for application primary --query='forEach(units, unit => unit.workload-status=="maintenance" && unit.agent-status=="idle")' --timeout=30m
           date
 
-      - name: Adopt the charmed ceph cluster using primary microcpeh application
+      - name: Adopt the primary charmed ceph cluster using primary microceph application
         run: |
           set -eux
           date
-          juju integrate ceph-mon primary
+          juju integrate ceph-mon:admin primary:adopt
+          # Charm microceph goes to active state once the bootstrap source (adopt) is available.
           juju wait-for unit primary/0 --query='workload-status=="active"' --timeout=15m
           juju status --relations
           date

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -121,7 +121,6 @@ jobs:
       - name: Setup tmate session
         if: ${{ failure() && runner.debug }}
         uses: canonical/action-tmate@main
-          
 
   functional-test:
     needs:
@@ -887,6 +886,104 @@ jobs:
           juju wait-for unit secondary/0 --timeout '15m' --query='workload-message=="(workload) charm is ready"'
           bash ./tests/scripts/ci_helpers.sh check_osd_count primary/0 3
           bash ./tests/scripts/ci_helpers.sh check_osd_count secondary/0 3
+          date
+
+      - name: Add remote integration
+        run: |
+          set -eux
+          juju integrate primary:remote-provider secondary:remote-requirer
+
+          # wait for the applications to go to blocked state
+          juju wait-for unit primary/0 --query='workload-status=="blocked"' --timeout=10m
+          juju wait-for unit secondary/0 --query='workload-status=="blocked"' --timeout=10m
+
+          juju config primary site-name="primary"
+          juju config secondary site-name="secondary"
+
+
+          juju wait-for unit primary/0 --query='workload-status=="active"' --timeout=10m
+          juju wait-for unit secondary/0 --query='workload-status=="active"' --timeout=10m
+
+          juju status --relations
+
+      - name: Wait for token exchange and remote enlisting
+        run: |
+          set -eux
+          bash ./tests/scripts/remote_integration_helpers.sh wait_for_remote_enlistment primary/0 secondary
+          bash ./tests/scripts/remote_integration_helpers.sh wait_for_remote_enlistment secondary/0 primary
+
+      - name: Scale up the primary cluster
+        run: |
+          set -eux
+          juju add-unit primary -n 1
+          # wait for new unit to be active/idle
+          juju wait-for unit primary/1 --query='workload-status=="active"' --timeout=20m
+
+      - name: Re-verify remote listings
+        run: |
+          set -eux
+          bash ./tests/scripts/remote_integration_helpers.sh wait_for_remote_enlistment primary/0 secondary
+          bash ./tests/scripts/remote_integration_helpers.sh wait_for_remote_enlistment primary/1 secondary
+          bash ./tests/scripts/remote_integration_helpers.sh wait_for_remote_enlistment secondary/0 primary
+
+      - name: Collect logs
+        if: failure()
+        run: ./tests/scripts/ci_helpers.sh collect_microceph_logs
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: microceph_juju_mds_test_logs
+          path: logs
+          retention-days: 30
+
+      - name: Setup tmate session
+        if: ${{ failure() && runner.debug }}
+        uses: canonical/action-tmate@main
+
+  juju-adopt-ceph-test:
+    needs:
+      - build
+    name: Adopt Charmed ceph cluster test
+    runs-on: self-hosted-linux-amd64-noble-xlarge
+    steps:
+      - name: Download charm
+        uses: actions/download-artifact@v4
+        with:
+          name: charms
+          path: ~/artifacts/
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          # pin lxd to LTS release.
+          channel: 5.21/stable
+
+      - name: Install dependencies
+        run: ./tests/scripts/ci_helpers.sh install_deps
+
+      - name: Install MicroCeph charm
+        run: |
+          set -eux
+          date
+          juju deploy ./tests/bundles/noble-caracal.yaml
+          juju wait-for application ceph-mon --query='forEach(units, unit => unit.workload-status=="active" && unit.agent-status=="idle")' --timeout=30m
+          juju wait-for application secondary --query='forEach(units, unit => unit.workload-status=="active" && unit.agent-status=="idle")' --timeout=30m
+          date
+
+      - name: Adopt the charmed ceph cluster using primary microcpeh application
+        run: |
+          set -eux
+          date
+          juju integrate ceph-mon primary
+          juju wait-for application primary --query=`workload-status=="active"` --timeout=10m
+          juju status --relations
           date
 
       - name: Add remote integration

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -982,7 +982,7 @@ jobs:
           set -eux
           date
           juju integrate ceph-mon primary
-          juju wait-for application primary --query=`workload-status=="active"` --timeout=10m
+          juju wait-for unit primary/0 --query='workload-status=="active"' --timeout=15m
           juju status --relations
           date
 
@@ -992,15 +992,15 @@ jobs:
           juju integrate primary:remote-provider secondary:remote-requirer
 
           # wait for the applications to go to blocked state
-          juju wait-for unit primary/0 --query='workload-status=="blocked"' --timeout=10m
-          juju wait-for unit secondary/0 --query='workload-status=="blocked"' --timeout=10m
+          juju wait-for unit primary/0 --query='workload-status=="blocked"' --timeout=15m
+          juju wait-for unit secondary/0 --query='workload-status=="blocked"' --timeout=15m
 
           juju config primary site-name="primary"
           juju config secondary site-name="secondary"
 
 
-          juju wait-for unit primary/0 --query='workload-status=="active"' --timeout=10m
-          juju wait-for unit secondary/0 --query='workload-status=="active"' --timeout=10m
+          juju wait-for unit primary/0 --query='workload-status=="active"' --timeout=15m
+          juju wait-for unit secondary/0 --query='workload-status=="active"' --timeout=15m
 
           juju status --relations
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -983,7 +983,7 @@ jobs:
         run: |
           set -eux
           date
-          juju integrate ceph-mon:admin primary:adopt
+          juju integrate ceph-mon:admin primary:adopt-ceph
           # Charm microceph goes to active state once the bootstrap source (adopt) is available.
           juju wait-for unit primary/0 --query='workload-status=="active"' --timeout=15m
           juju status --relations

--- a/config.yaml
+++ b/config.yaml
@@ -55,3 +55,9 @@ options:
     default: ""
     description: |
       The local site name. This should be unique amongst the connected remote microceph clusters.
+  wait-to-adopt:
+    type: boolean
+    default: False
+    description: |
+      Whether charm microceph should wait for an external ceph cluster to yield for adoption or
+      bootstrap a new ceph cluster.

--- a/config.yaml
+++ b/config.yaml
@@ -59,5 +59,5 @@ options:
     type: boolean
     default: False
     description: |
-      Whether charm microceph should wait for an external ceph cluster to yield for adoption or
-      bootstrap a new ceph cluster.
+      Whether charm microceph should wait for an external ceph cluster to yield admin credentials using which microceph will
+      adopt the external cluster rather than bootstrapping a new ceph cluster on microceph bootstrap.

--- a/lib/charms/ceph_mon/v0/ceph_cos_agent.py
+++ b/lib/charms/ceph_mon/v0/ceph_cos_agent.py
@@ -57,7 +57,7 @@ class CephCOSAgentProvider(cos_agent.COSAgentProvider):
 
         if self._is_ready_cb and not self._is_ready_cb():
             # do not proceed if the charm is not ready
-            logger.debug("charm not ready, to process COS events")
+            logger.debug("charm not ready to process COS events")
             return
 
         if callable(self._refresh_cb):

--- a/lib/charms/ceph_mon/v0/ceph_cos_agent.py
+++ b/lib/charms/ceph_mon/v0/ceph_cos_agent.py
@@ -30,8 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 class CephCOSAgentProvider(cos_agent.COSAgentProvider):
-
-    def __init__(self, charm, refresh_cb = None, departed_cb = None):
+    def __init__(self, charm, refresh_cb=None, departed_cb=None, is_ready_cb=None):
         super().__init__(
             charm,
             metrics_rules_dir="./files/prometheus_alert_rules",
@@ -41,6 +40,7 @@ class CephCOSAgentProvider(cos_agent.COSAgentProvider):
         )
         self._refresh_cb = refresh_cb
         self._departed_cb = departed_cb
+        self._is_ready_cb = is_ready_cb
 
         events = self._charm.on[cos_agent.DEFAULT_RELATION_NAME]
         self.framework.observe(
@@ -50,9 +50,14 @@ class CephCOSAgentProvider(cos_agent.COSAgentProvider):
     def _on_refresh(self, event):
         """Enable prometheus on relation change"""
         super()._on_refresh(event)
-        
+
         if not self._charm.unit.is_leader():
             logger.debug("Not the charm leader, skipping refresh cb.")
+            return
+
+        if self._is_ready_cb and not self._is_ready_cb():
+            # do not proceed if the charm is not ready
+            logger.debug("charm not ready, to process COS events")
             return
 
         if callable(self._refresh_cb):

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -54,6 +54,9 @@ requires:
   remote-requirer:
     interface: microceph-remote
     optional: true
+  adopt-ceph:
+    interface: ceph-admin
+    optional: true
 
 peers:
   peers:

--- a/src/ceph.py
+++ b/src/ceph.py
@@ -1054,7 +1054,7 @@ class ErasurePool(BasePool):
 
         # Check for errors
         if erasure_profile is None:
-            msg = "Failed to discover erasure profile named " "{}".format(
+            msg = "Failed to discover erasure profile named {}".format(
                 self.erasure_code_profile
             )
             log(msg, level=ERROR)
@@ -1200,8 +1200,8 @@ def ceph_user():
 def has_quorum() -> bool:
     """Check if the ceph cluster has quorum.
 
-    In adopted ceph environements, microceph may not have a local mon up.
-    Thus, this method checks if the accesible ceph cluster has some quorum.
+    In adopted ceph environments, microceph may not have a local mon up.
+    Thus, this method checks if the accessible ceph cluster has some quorum.
     """
     cmd = ["ceph", "status", "--format=json"]
     try:

--- a/src/ceph.py
+++ b/src/ceph.py
@@ -1195,7 +1195,7 @@ def ceph_user():
     return "microceph.ceph"
 
 
-def has_quorum() -> bool:
+def cluster_has_quorum() -> bool:
     """Check if the ceph cluster has quorum.
 
     In adopted ceph environments, microceph may not have a local mon up.

--- a/src/ceph.py
+++ b/src/ceph.py
@@ -1054,9 +1054,7 @@ class ErasurePool(BasePool):
 
         # Check for errors
         if erasure_profile is None:
-            msg = "Failed to discover erasure profile named {}".format(
-                self.erasure_code_profile
-            )
+            msg = "Failed to discover erasure profile named {}".format(self.erasure_code_profile)
             log(msg, level=ERROR)
             raise PoolCreationError(msg)
         if "k" not in erasure_profile or "m" not in erasure_profile:

--- a/src/ceph_rgw.py
+++ b/src/ceph_rgw.py
@@ -42,7 +42,8 @@ class CephRgwProviderHandler(ServiceReadinessProviderHandler):
         """Set service readiness on ceph-rgw-ready related units."""
         logger.debug("Set service readiness on all connected placement relations")
         ready = self.rgw_ready
-        for relation in self.framework.model.relations[CEPH_RGW_READY_RELATION]:
+        for relation in self.model.relations.get(CEPH_RGW_READY_RELATION, []):
+            logger.debug(f"Setting rgw readiness to {ready} on relation {relation.id}")
             self.interface.set_service_status(relation, ready)
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -687,7 +687,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
     ##### Callbacks for relation handlers
     def handle_ceph_adopt(self, event) -> None:
-        """Callback for inteface ceph-admin."""
+        """Callback for interface ceph-admin."""
         # Handle post bootstrap
         logger.debug(f"Handle ceph adopt for {event.__repr__}")
         if self.ready_for_service():

--- a/src/charm.py
+++ b/src/charm.py
@@ -679,6 +679,8 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             self.traefik_route_rgw.interface.submit_to_traefik(config=self.traefik_config)
 
             if self.traefik_route_rgw.ready:
+                if self.model.config.get("enable-rgw") == "*":
+                    self.configure_rgw_service(event)
                 self._update_service_endpoints()
 
     def post_config_setup(self):

--- a/src/charm.py
+++ b/src/charm.py
@@ -738,7 +738,14 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             event.defer()
             return
 
-        default_rf = int(self.model.config.get("default-pool-size"))
+        try:
+            default_rf = int(self.model.config.get("default-pool-size"))
+        except (TypeError, ValueError) as e:
+            logger.error("Invalid value for 'default-pool-size': %s", e)
+            raise sunbeam_guard.BlockedExceptionError(
+                "Invalid configuration: 'default-pool-size' must be an integer"
+            )
+
         try:
             microceph.set_pool_size("", default_rf)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -687,7 +687,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         """Configuration steps after services have been setup."""
         super().post_config_setup()
 
-    ##### Callbacks for relation handlers
+    # Callbacks for relation handlers
     def handle_ceph_adopt(self, event) -> None:
         """Callback for interface ceph-admin."""
         # Handle post bootstrap
@@ -714,7 +714,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         """Callback for interface ceph-nfs-client."""
         logger.debug("Callback for microceph-remote interface, ignore")
 
-    ##### Helpers for charm configuration logic
+    # Helpers for charm configuration logic
     def handle_config_leader_set_ready(self):
         """Configure leader as ready."""
         logger.debug("Configuring leader as ready")

--- a/src/charm.py
+++ b/src/charm.py
@@ -326,30 +326,22 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         }
         return config
 
-    def get_relation_handlers(
-        self, handlers=None
-    ) -> List[sunbeam_rhandlers.RelationHandler]:
+    def get_relation_handlers(self, handlers=None) -> List[sunbeam_rhandlers.RelationHandler]:
         """Relation handlers for the service."""
         handlers = handlers or []
 
         relation_handlers = {
             "adopt-ceph": (
                 "adopt_ceph",
-                lambda: AdoptCephRequiresHandler(
-                    self, "adopt-ceph", self.handle_ceph_adopt
-                ),
+                lambda: AdoptCephRequiresHandler(self, "adopt-ceph", self.handle_ceph_adopt),
             ),
             "remote-provider": (
                 "remote_provider",
-                lambda: MicroCephRemoteHandler(
-                    self, "remote-provider", self.handle_rh_cb_noop
-                ),
+                lambda: MicroCephRemoteHandler(self, "remote-provider", self.handle_rh_cb_noop),
             ),
             "remote-requirer": (
                 "remote_requirer",
-                lambda: MicroCephRemoteHandler(
-                    self, "remote-requirer", self.handle_rh_cb_noop
-                ),
+                lambda: MicroCephRemoteHandler(self, "remote-requirer", self.handle_rh_cb_noop),
             ),
             "peers": (
                 "peers",
@@ -374,9 +366,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             ),
             "ceph-nfs": (
                 "ceph_nfs",
-                lambda: CephNfsProviderHandler(
-                    self, "ceph-nfs", self.handle_rh_cb_noop
-                ),
+                lambda: CephNfsProviderHandler(self, "ceph-nfs", self.handle_rh_cb_noop),
             ),
             CEPH_RGW_READY_RELATION: (
                 "ceph_rgw",

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -47,7 +47,7 @@ def is_ready() -> bool:
         logger.warning("Microceph not bootstrapped yet.")
         return False
 
-    if not ceph.has_quorum():
+    if not ceph.cluster_has_quorum():
         logger.debug("Ceph cluster not in quorum, not ready yet")
         return False
 
@@ -217,7 +217,7 @@ def adopt_ceph_cluster(
     if not fsid or not mon_hosts or not admin_key:
         raise ValueError("fsid, mon_hosts and admin_key are required to adopt a cluster")
 
-    logger.debug(
+    logger.info(
         f"Got fsid: {fsid}, mon_hosts: {mon_hosts} and is_admin_key_provided: {admin_key is not None}"
     )
 

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -47,10 +47,11 @@ def is_ready() -> bool:
         logger.warning("Microceph not bootstrapped yet.")
         return False
 
-    if not ceph.is_quorum():
+    if not ceph.has_quorum():
         logger.debug("Ceph cluster not in quorum, not ready yet")
         return False
 
+    logger.debug("microceph cluster is bootstrapped and ready")
     return True
 
 
@@ -129,7 +130,7 @@ def is_rgw_enabled(hostname: str) -> bool:
     Raises ClusterServiceUnavailableException if cluster is not available.
     """
     client = Client.from_socket()
-    services = client.cluster.list_services()
+    services = client.cluster.list_services() or []
     for service in services:
         if service["service"] == "rgw" and service["location"] == hostname:
             return True
@@ -143,7 +144,7 @@ def list_cluster_configs():
     Raises ClusterServiceUnavailableException
     """
     client = Client.from_socket()
-    configs = client.cluster.get_config()
+    configs = client.cluster.get_config() or []
     return {config.get("key"): config.get("value") for config in configs}
 
 
@@ -202,6 +203,49 @@ def bootstrap_cluster(micro_ip: str = None, public_net: str = None, cluster_net:
         cmd.extend(["--microceph-ip", micro_ip])
 
     utils.run_cmd(cmd=cmd)
+
+
+def adopt_ceph_cluster(
+    fsid: str = "",
+    mon_hosts: list = [],
+    admin_key: str = "",
+    micro_ip: str = "",
+    public_net: str = "",
+    cluster_net: str = "",
+):
+    """Bootstrap Microceph by adopting an existing Ceph cluster."""
+
+    if not fsid or not mon_hosts or not admin_key:
+        raise ValueError("fsid, mon_hosts and admin_key are required to adopt a cluster")
+
+    logger.debug(
+        f"Got fsid: {fsid}, mon_hosts: {mon_hosts} and is_admin_key_provided: {admin_key is not None}"
+    )
+
+    cmd = [
+        "microceph",
+        "cluster",
+        "adopt",
+        "-",  # "-" signifies that admin key will be provided via stdin
+        "--fsid",
+        fsid,
+        "--mon-hosts",
+        ",".join(mon_hosts),
+    ]
+
+    if public_net:
+        logger.debug(f"Using public network {public_net} for cluster")
+        cmd.extend(["--public-network", public_net])
+
+    if cluster_net:
+        logger.debug(f"Using cluster network {cluster_net} for cluster")
+        cmd.extend(["--cluster-network", cluster_net])
+
+    if micro_ip:
+        logger.debug(f"Using ip {micro_ip} for microceph cluster")
+        cmd.extend(["--microceph-ip", micro_ip])
+
+    utils.run_cmd_with_input(cmd=cmd, input_data=admin_key)
 
 
 def join_cluster(token: str, micro_ip: str = "", **kwargs):

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -214,7 +214,6 @@ def adopt_ceph_cluster(
     cluster_net: str = "",
 ):
     """Bootstrap Microceph by adopting an existing Ceph cluster."""
-
     if not fsid or not mon_hosts or not admin_key:
         raise ValueError("fsid, mon_hosts and admin_key are required to adopt a cluster")
 

--- a/src/microceph_adopt_ceph.py
+++ b/src/microceph_adopt_ceph.py
@@ -16,18 +16,18 @@
 
 """Handle Charm's Adopt Ceph Integration Events."""
 
-from enum import Enum
 import logging
+from enum import Enum
 from typing import Callable
 
 import ops_sunbeam.guard as sunbeam_guard
 from ops.charm import CharmBase, RelationEvent
-from ops.model import ActiveStatus
 from ops.framework import (
     EventSource,
     Object,
     ObjectEvents,
 )
+from ops.model import ActiveStatus
 from ops_sunbeam.relation_handlers import RelationHandler
 
 logger = logging.getLogger(__name__)

--- a/src/microceph_adopt_ceph.py
+++ b/src/microceph_adopt_ceph.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 class AdoptCephRelationDataKeys(Enum):
-    """Relation Data keys"""
+    """Relation Data keys."""
 
     mon_hosts = "mon_hosts"
     admin_key = "key"
@@ -42,19 +42,19 @@ class AdoptCephRelationDataKeys(Enum):
 
 
 class AdoptCephBootstrapEvent(RelationEvent):
-    """adopt-ceph bootstrap event"""
+    """adopt-ceph bootstrap event."""
 
     pass
 
 
 class AdoptCephEvents(ObjectEvents):
-    """Events for adopt-ceph relation handler"""
+    """Events for adopt-ceph relation handler."""
 
     adopt_ceph_bootstrap = EventSource(AdoptCephBootstrapEvent)
 
 
 class AdoptCephRequires(Object):
-    """Interface for ceph-admin interface"""
+    """Interface for ceph-admin interface."""
 
     on = AdoptCephEvents()
 
@@ -73,7 +73,7 @@ class AdoptCephRequires(Object):
         self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_changed)
 
     def _on_relation_changed(self, event) -> None:
-        """On relation changed"""
+        """On relation changed."""
         if not self.model.unit.is_leader():
             logger.debug("Unit is not leader, skipping adopt-ceph changed event")
             return
@@ -87,7 +87,7 @@ class AdoptCephRequires(Object):
         self.on.adopt_ceph_bootstrap.emit(event.relation)
 
     def _on_relation_broken(self, event) -> None:
-        """On relation departed"""
+        """On relation departed."""
         if not self.model.unit.is_leader():
             logger.debug("Unit is not leader, skipping adopt-ceph departed event")
             return
@@ -102,7 +102,7 @@ class AdoptCephRequires(Object):
 
 
 class AdoptCephRequiresHandler(RelationHandler):
-    """Handler for adopt-ceph relation events"""
+    """Handler for adopt-ceph relation events."""
 
     def __init__(
         self,
@@ -114,6 +114,7 @@ class AdoptCephRequiresHandler(RelationHandler):
 
     @property
     def ready(self) -> bool:
+        """Check if adopt-ceph relation is ready."""
         logger.info(f"Report {self.relation_name} as ready")
         return True
 
@@ -126,7 +127,7 @@ class AdoptCephRequiresHandler(RelationHandler):
         self.framework.observe(self.adopt_ceph.on.adopt_ceph_bootstrap, self._on_bootstrap)
 
     def _on_bootstrap(self, relation):
-        """Bootstrap MicroCeph cluster using adopted ceph cluster"""
+        """Bootstrap MicroCeph cluster using adopted ceph cluster."""
         logger.info("Handling adopt-ceph bootstrap event")
         with sunbeam_guard.guard(self.charm, self.relation_name):
             for relation in self.model.relations.get(self.relation_name, []):

--- a/src/microceph_adopt_ceph.py
+++ b/src/microceph_adopt_ceph.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Handle Charm's Adopt Ceph Integration Events."""
+
+from enum import Enum
+import logging
+from typing import Callable
+
+import ops_sunbeam.guard as sunbeam_guard
+from ops.charm import CharmBase, RelationEvent
+from ops.model import ActiveStatus
+from ops.framework import (
+    EventSource,
+    Object,
+    ObjectEvents,
+)
+from ops_sunbeam.relation_handlers import RelationHandler
+
+logger = logging.getLogger(__name__)
+
+
+class AdoptCephRelationDataKeys(Enum):
+    """Relation Data keys"""
+
+    mon_hosts = "mon_hosts"
+    admin_key = "key"
+    fsid = "fsid"
+
+
+class AdoptCephBootstrapEvent(RelationEvent):
+    """adopt-ceph bootstrap event"""
+
+    pass
+
+
+class AdoptCephEvents(ObjectEvents):
+    """Events for adopt-ceph relation handler"""
+
+    adopt_ceph_bootstrap = EventSource(AdoptCephBootstrapEvent)
+
+
+class AdoptCephRequires(Object):
+    """Interface for ceph-admin interface"""
+
+    on = AdoptCephEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = "adopt-ceph",
+    ):
+        super().__init__(charm, relation_name)
+
+        self.charm = charm
+        self.relation_name = relation_name
+
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+        self.framework.observe(charm.on[relation_name].relation_broken, self._on_relation_broken)
+        self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_changed)
+
+    def _on_relation_changed(self, event) -> None:
+        """On relation changed"""
+        if not self.model.unit.is_leader():
+            logger.debug("Unit is not leader, skipping adopt-ceph changed event")
+            return
+
+        # Do nothing if already bootstrapped
+        if self.charm.ready_for_service():
+            logger.debug("Not processing adopt relation event, microceph already bootstrapped.")
+            return
+
+        logger.debug("Emitting adopt-ceph reconcile event")
+        self.on.adopt_ceph_bootstrap.emit(event.relation)
+
+    def _on_relation_broken(self, event) -> None:
+        """On relation departed"""
+        if not self.model.unit.is_leader():
+            logger.debug("Unit is not leader, skipping adopt-ceph departed event")
+            return
+
+        with sunbeam_guard.guard(self.charm, self.relation_name):
+            if not self.charm.ready_for_service():
+                raise sunbeam_guard.BlockedExceptionError(
+                    "Adopt relation removed before cluster bootstrap could be performed"
+                )
+
+        logger.debug("Ignoring adopt-ceph departed event")
+
+
+class AdoptCephRequiresHandler(RelationHandler):
+    """Handler for adopt-ceph relation events"""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+        callback_f: Callable,
+    ):
+        super().__init__(charm, relation_name, callback_f)
+
+    @property
+    def ready(self) -> bool:
+        logger.info(f"Report {self.relation_name} as ready")
+        return True
+
+    def setup_event_handler(self) -> Object:
+        """Configure event handlers for a ceph-admin interface."""
+        logger.debug("Setting up adopt-ceph event handler")
+
+        self.adopt_ceph = AdoptCephRequires(self.charm, self.relation_name)
+
+        self.framework.observe(self.adopt_ceph.on.adopt_ceph_bootstrap, self._on_bootstrap)
+
+    def _on_bootstrap(self, relation):
+        """Bootstrap MicroCeph cluster using adopted ceph cluster"""
+        logger.info("Handling adopt-ceph bootstrap event")
+        with sunbeam_guard.guard(self.charm, self.relation_name):
+            for relation in self.model.relations.get(self.relation_name, []):
+                if not relation.units:
+                    logger.debug("No units in adopt-ceph relation, cannot reconcile")
+                    return
+
+                remote_ceph_data = relation.data.get(next(iter(relation.units)), {})
+                logger.debug(f"Adopt-ceph relation data: IsEmpty({remote_ceph_data is None})")
+
+                # fetched mon hosts value is a space separated string of host addresses.
+                mon_hosts = remote_ceph_data.get(AdoptCephRelationDataKeys.mon_hosts.value, None)
+                fsid = remote_ceph_data.get(AdoptCephRelationDataKeys.fsid.value, None)
+                admin_key = remote_ceph_data.get(AdoptCephRelationDataKeys.admin_key.value, None)
+
+                logger.debug(
+                    f"Adopt-ceph relation data fetched: fsid({fsid}), mon_hosts({mon_hosts}), admin_key({admin_key is not None})"
+                )
+
+                if not mon_hosts or not fsid or not admin_key:
+                    logger.debug("Incomplete data from adopt-ceph relation, cannot reconcile")
+                    raise sunbeam_guard.BlockedExceptionError(
+                        f"Waiting for fsid({fsid}), mon_hosts({mon_hosts}) and admin_key({admin_key is not None}) from adopt-ceph relation"
+                    )
+
+                logger.debug(
+                    "All required data from adopt-ceph relation present, proceeding with adoption"
+                )
+                self.charm.adopt_cluster(fsid, mon_hosts.split(), admin_key)
+                self.callback_f(event=relation)
+                self.charm.status.set(ActiveStatus("charm is ready"))
+                return

--- a/src/microceph_adopt_ceph.py
+++ b/src/microceph_adopt_ceph.py
@@ -130,20 +130,20 @@ class AdoptCephRequiresHandler(RelationHandler):
 
         self.framework.observe(self.adopt_ceph.on.adopt_ceph_bootstrap, self._on_bootstrap)
 
-    def _on_bootstrap(self, relation):
+    def _on_bootstrap(self, relation_event):
         """Bootstrap MicroCeph cluster using adopted ceph cluster."""
         logger.info("Handling adopt-ceph bootstrap event")
         with sunbeam_guard.guard(self.charm, self.relation_name):
             for relation in self.model.relations.get(self.relation_name, []):
-                if not relation.units:
+                if not relation_event.units:
                     logger.debug("No units in adopt-ceph relation, cannot reconcile")
                     return
 
-                unit = next(iter(relation.units), None)
+                unit = next(iter(relation_event.units), None)
                 if unit is None:
                     logger.debug("No units available in adopt-ceph relation after check")
                     return
-                remote_ceph_data = relation.data.get(unit, {})
+                remote_ceph_data = relation_event.data.get(unit, {})
                 logger.debug(f"Adopt-ceph relation data: IsEmpty({remote_ceph_data is None})")
 
                 # fetched mon hosts value is a space separated string of host addresses.

--- a/src/microceph_adopt_ceph.py
+++ b/src/microceph_adopt_ceph.py
@@ -91,7 +91,7 @@ class AdoptCephRequires(Object):
         self.on.adopt_ceph_bootstrap.emit(event.relation)
 
     def _on_relation_broken(self, _event) -> None:
-        """Mark the status as blocked if adopt relation is removed before microceph could be bootstrapped."""
+        """Mark status blocked if adopt relation removed before bootstrap."""
         if not self.model.unit.is_leader():
             logger.debug("Unit is not leader, skipping adopt-ceph broken event")
             return

--- a/src/microceph_adopt_ceph.py
+++ b/src/microceph_adopt_ceph.py
@@ -27,7 +27,6 @@ from ops.framework import (
     Object,
     ObjectEvents,
 )
-from ops.model import ActiveStatus
 from ops_sunbeam.relation_handlers import RelationHandler
 
 logger = logging.getLogger(__name__)
@@ -158,5 +157,4 @@ class AdoptCephRequiresHandler(RelationHandler):
                 )
                 self.charm.adopt_cluster(fsid, mon_hosts.split(), admin_key)
                 self.callback_f(event=relation)
-                self.charm.status.set(ActiveStatus("charm is ready"))
                 return

--- a/src/microceph_remote.py
+++ b/src/microceph_remote.py
@@ -172,7 +172,7 @@ class MicroCephRemote(Object):
             logger.debug("site name not set, skipping remote update due to peer update")
             return
 
-        for remote_rel in self.charm.model.relations[self.relation_name]:
+        for remote_rel in self.charm.model.relations.get(self.relation_name, []):
             logger.debug("Emit: Remote update remote remote due to peer update")
             self.on.microceph_remote_update_remote.emit(remote_rel)
 

--- a/src/relation_handlers.py
+++ b/src/relation_handlers.py
@@ -19,6 +19,7 @@
 
 This charm deploys and manages microceph.
 """
+
 import json
 import logging
 from socket import gethostname
@@ -26,7 +27,14 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 import ops
 from ops.charm import CharmBase, RelationEvent
-from ops.framework import EventBase, EventSource, Handle, Object, ObjectEvents, StoredState
+from ops.framework import (
+    EventBase,
+    EventSource,
+    Handle,
+    Object,
+    ObjectEvents,
+    StoredState,
+)
 from ops_sunbeam.interfaces import OperatorPeers
 from ops_sunbeam.relation_handlers import BasePeerHandler, RelationHandler
 
@@ -525,7 +533,7 @@ class CephClientProvides(Object):
                     req_key = json.loads(request)["request-id"]
                 except (TypeError, json.decoder.JSONDecodeError):
                     logger.warning(
-                        "Not able to decode request " "id for broker request {}".format(request)
+                        "Not able to decode request id for broker request {}".format(request)
                     )
                     req_key = None
             else:
@@ -618,7 +626,7 @@ class CephClientProvides(Object):
         mon_key = "ceph-mon-public-addresses"
         addrs = utils.get_mon_addresses()
 
-        for relation in self.framework.model.relations[self.relation_name]:
+        for relation in self.framework.model.relations.get(self.relation_name, []):
             relation.data[self.model.app][mon_key] = json.dumps(addrs)
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -27,12 +27,30 @@ from microceph_client import Client
 logger = logging.getLogger(__name__)
 
 
-def run_cmd(cmd: list) -> str:
+def run_cmd(cmd: list, timeout: int = 180) -> str:
     """Execute provided command via subprocess."""
     try:
-        process = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=180)
+        process = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=timeout)
         logger.debug(f"Command {' '.join(cmd)} finished; Output: {process.stdout}")
         return process.stdout
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed executing cmd: {cmd}, error: {e.stderr}")
+        raise e
+
+
+def run_cmd_with_input(cmd: list, input_data: str) -> str:
+    """Execute provided command with input to stdin"""
+    try:
+        output = subprocess.run(
+            cmd,
+            input=input_data,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=180,
+        )
+        logger.debug(f"Command {' '.join(cmd)} finished; Output: {output.stdout}")
+        return output.stdout
     except subprocess.CalledProcessError as e:
         logger.error(f"Failed executing cmd: {cmd}, error: {e.stderr}")
         raise e

--- a/src/utils.py
+++ b/src/utils.py
@@ -39,7 +39,7 @@ def run_cmd(cmd: list, timeout: int = 180) -> str:
 
 
 def run_cmd_with_input(cmd: list, input_data: str) -> str:
-    """Execute provided command with input to stdin"""
+    """Execute provided command with input to stdin."""
     try:
         output = subprocess.run(
             cmd,

--- a/tests/bundles/noble-caracal.yaml
+++ b/tests/bundles/noble-caracal.yaml
@@ -41,7 +41,7 @@ applications:
       - "5"
 
   primary:
-    charm: ../../microceph.charm
+    charm: ./microceph.charm
     num_units: 1
     base: ubuntu@24.04
     options:
@@ -52,7 +52,7 @@ applications:
       - "6"
 
   secondary:
-    charm: ../../microceph.charm
+    charm: ./microceph.charm
     num_units: 1
     base: ubuntu@24.04
     storage:

--- a/tests/bundles/noble-caracal.yaml
+++ b/tests/bundles/noble-caracal.yaml
@@ -41,7 +41,7 @@ applications:
       - "5"
 
   primary:
-    charm: ./microceph.charm
+    charm: /home/ubuntu/artifacts/microceph.charm
     num_units: 1
     base: ubuntu@24.04
     options:
@@ -52,7 +52,7 @@ applications:
       - "6"
 
   secondary:
-    charm: ./microceph.charm
+    charm: /home/ubuntu/artifacts/microceph.charm
     num_units: 1
     base: ubuntu@24.04
     storage:

--- a/tests/bundles/noble-caracal.yaml
+++ b/tests/bundles/noble-caracal.yaml
@@ -1,0 +1,65 @@
+series: &series noble
+
+machines:
+  "0":
+  "1":
+  "2":
+  "3":
+    constraints: cores=2 mem=6G root-disk=25G virt-type=virtual-machine
+  "4":
+    constraints: cores=2 mem=6G root-disk=25G virt-type=virtual-machine
+  "5":
+    constraints: cores=2 mem=6G root-disk=25G virt-type=virtual-machine
+  "6":
+    constraints: cores=2 mem=6G root-disk=25G virt-type=virtual-machine
+  "7":
+    constraints: cores=2 mem=6G root-disk=40G virt-type=virtual-machine
+
+applications:
+  ceph-mon:
+    charm: ch:ceph-mon
+    channel: squid/stable
+    num_units: 3
+    base: ubuntu@24.04
+    options:
+      monitor-count: 3
+    to:
+      - "0"
+      - "1"
+      - "2"
+
+  ceph-osd:
+    charm: ch:ceph-osd
+    num_units: 3
+    channel: squid/stable
+    base: ubuntu@24.04
+    storage:
+      osd-devices: "loop,5G"
+    to:
+      - "3"
+      - "4"
+      - "5"
+
+  primary:
+    charm: ../../microceph.charm
+    num_units: 1
+    base: ubuntu@24.04
+    options:
+      wait-to-adopt: True
+      # TODO: drop this once the change is available in the snap stable
+      snap-channel: latest/edge/test
+    to:
+      - "6"
+
+  secondary:
+    charm: ../../microceph.charm
+    num_units: 1
+    base: ubuntu@24.04
+    storage:
+      osd-standalone: "loop,5G,3"
+    to:
+      - "7"
+
+relations:
+  - - "ceph-osd:mon"
+    - "ceph-mon:osd"

--- a/tests/unit/test_ceph.py
+++ b/tests/unit/test_ceph.py
@@ -42,9 +42,9 @@ class TestCeph(unittest.TestCase):
         check_output.assert_called_once_with(cmd)
 
     @patch("ceph.check_output")
-    def test_has_quorum(self, check_output):
+    def test_cluster_has_quorum(self, check_output):
         check_output.return_value = b'{"quorum": [ 0 ]}'
-        self.assertTrue(ceph.has_quorum())
+        self.assertTrue(ceph.cluster_has_quorum())
 
     @patch("utils.run_cmd")
     def test_create_fs_volume(self, run_cmd):

--- a/tests/unit/test_ceph.py
+++ b/tests/unit/test_ceph.py
@@ -22,7 +22,6 @@ import ceph
 
 
 class TestCeph(unittest.TestCase):
-
     @patch.object(ceph, "check_output")
     @patch("socket.gethostname")
     def test_remove_named_key(self, gethostname, check_output):
@@ -42,13 +41,10 @@ class TestCeph(unittest.TestCase):
         ]
         check_output.assert_called_once_with(cmd)
 
-    @patch("ceph.os")
-    @patch("ceph.socket")
     @patch("ceph.check_output")
-    def test_is_quorum(self, check_output, _skt, os):
-        check_output.return_value = b'{"state": "peon"}'
-        os.path.exists.return_value = True
-        self.assertTrue(ceph.is_quorum())
+    def test_has_quorum(self, check_output):
+        check_output.return_value = b'{"quorum": [ 0 ]}'
+        self.assertTrue(ceph.has_quorum())
 
     @patch("utils.run_cmd")
     def test_create_fs_volume(self, run_cmd):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -930,11 +930,13 @@ class TestCharm(testbase.TestBaseCharm):
             ]
         )
 
+    @patch.object(ceph_cos_agent, "ceph_utils")
+    @patch("ceph.enable_mgr_module")
     @patch("microceph.is_ready")
     @patch("microceph.set_pool_size")
     @patch("ceph.ceph_config_set")
     def test_handle_ceph_adopt_marks_leader_ready(
-        self, mock_ceph_config_set, mock_set_pool_size, mock_is_ready
+        self, mock_ceph_config_set, mock_set_pool_size, mock_is_ready, mock_enable_mgr_module, mock_ceph_utils
     ):
         """Test that handle_ceph_adopt marks leader as ready after adoption."""
         # Setup: cluster is ready (adopted) but leader not yet marked ready

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -929,3 +929,49 @@ class TestCharm(testbase.TestBaseCharm):
                 call("mgr/prometheus/exclude_perf_counters", "False"),
             ]
         )
+
+    @patch("microceph.is_ready")
+    @patch("microceph.set_pool_size")
+    @patch("ceph.ceph_config_set")
+    def test_handle_ceph_adopt_marks_leader_ready(
+        self, mock_ceph_config_set, mock_set_pool_size, mock_is_ready
+    ):
+        """Test that handle_ceph_adopt marks leader as ready after adoption."""
+        # Setup: cluster is ready (adopted) but leader not yet marked ready
+        mock_is_ready.return_value = True
+        self.harness.set_leader()
+        self.add_complete_peer_relation(self.harness)
+
+        # Ensure leader is not marked as ready initially
+        self.harness.charm.leader_set({"leader-ready": "false"})
+
+        # Create a mock event
+        event = MagicMock()
+
+        # Call handle_ceph_adopt
+        self.harness.charm.handle_ceph_adopt(event)
+
+        # Verify that charm is bootstrapped using the same method sunbeam uses
+        self.assertTrue(self.harness.charm.bootstrapped())
+
+    @patch("microceph.is_ready")
+    def test_handle_ceph_adopt_skips_when_leader_already_ready(self, mock_is_ready):
+        """Test that handle_ceph_adopt skips post-bootstrap if leader already ready."""
+        # Setup: cluster is ready and leader is already marked ready
+        mock_is_ready.return_value = True
+        self.harness.set_leader()
+        self.add_complete_peer_relation(self.harness)
+
+        # Mark leader as ready
+        self.harness.charm.set_leader_ready()
+
+        # Create a mock event
+        event = MagicMock()
+
+        # Mock the post-bootstrap configuration methods
+        with patch.object(self.harness.charm, "handle_config_leader_set_ready") as mock_set_ready:
+            # Call handle_ceph_adopt
+            self.harness.charm.handle_ceph_adopt(event)
+
+            # Verify that handle_config_leader_set_ready was NOT called
+            mock_set_ready.assert_not_called()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -936,7 +936,12 @@ class TestCharm(testbase.TestBaseCharm):
     @patch("microceph.set_pool_size")
     @patch("ceph.ceph_config_set")
     def test_handle_ceph_adopt_marks_leader_ready(
-        self, mock_ceph_config_set, mock_set_pool_size, mock_is_ready, mock_enable_mgr_module, mock_ceph_utils
+        self,
+        mock_ceph_config_set,
+        mock_set_pool_size,
+        mock_is_ready,
+        mock_enable_mgr_module,
+        mock_ceph_utils,
     ):
         """Test that handle_ceph_adopt marks leader as ready after adoption."""
         # Setup: cluster is ready (adopted) but leader not yet marked ready

--- a/tests/unit/testbase.py
+++ b/tests/unit/testbase.py
@@ -65,6 +65,10 @@ class _MicroCephCharm(charm.MicroCephCharm):
         self._cos_agent_patch.start()
         super().__init__(framework)
 
+    def tearDown(self):
+        """Stop the patches."""
+        self._cos_agent_patch.stop()
+
     def configure_ceph(self, event):
         return
 

--- a/tests/unit/testbase.py
+++ b/tests/unit/testbase.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import patch
+
+from charms.ceph_mon.v0 import ceph_cos_agent
 from ops.testing import Harness
 from ops_sunbeam import test_utils
 
@@ -47,6 +50,19 @@ class _MicroCephCharm(charm.MicroCephCharm):
     def __init__(self, framework):
         """Setup event logging."""
         self.seen_events = []
+        # Patch CephCOSAgentProvider to mock is_ready_cb
+        original_init = ceph_cos_agent.CephCOSAgentProvider.__init__
+
+        def patched_init(provider_self, charm_instance, **kwargs):
+            # Replace is_ready_cb with a mock that always returns True
+            if "is_ready_cb" in kwargs:
+                kwargs["is_ready_cb"] = lambda: True
+            return original_init(provider_self, charm_instance, **kwargs)
+
+        self._cos_agent_patch = patch.object(
+            ceph_cos_agent.CephCOSAgentProvider, "__init__", patched_init
+        )
+        self._cos_agent_patch.start()
         super().__init__(framework)
 
     def configure_ceph(self, event):


### PR DESCRIPTION
## Normal Bootstrap Workflow

### Configuration
- No special configuration required
- `wait-to-adopt` config defaults to `False`

### Process Flow

1. **Charm Initialization**
   ```
   __init__() → __post_init__()
   ```
   - Checks `bootstrapped()` → returns False
   - Sets `bootstrap_status` to `MaintenanceStatus("Service not bootstrapped")`

2. **Event Triggers `configure_charm()`**
   ```
   configure_charm(event)
   └── configure_unit(event)
       └── super().configure_unit(event)
           └── Sets _state.unit_bootstrapped = True
   └── configure_app(event)
       └── configure_app_leader(event)  [if leader]
           └── bootstrap_cluster(event)
               └── microceph.bootstrap_cluster()
           └── handle_config_leader_set_ready()
               └── set_leader_ready()
           └── handle_config_leader_ceph_pool_pgs(event)
           └── handle_config_rgw_service(event)
           └── handle_config_leader_charm_upgrade()
           └── handle_config_leader_new_node(event)
   └── bootstrap_status.set(ActiveStatus())
   └── post_config_setup()
   ```

3. **Bootstrap State Flags Set**
   - `_state.unit_bootstrapped = True` (set in `configure_unit()`)
   - `leader_ready` flag set (set in `configure_app_leader()`)
   - `bootstrap_status` set to Active
   - `peers.interface.state.joined = True`

4. **Status Transition**
   ```
   MaintenanceStatus("Service not bootstrapped")
   → ActiveStatus()
   ```
---

## Adopt Bootstrap Workflow

### Configuration
- Requires `wait-to-adopt: True` in charm config
- Requires `adopt-ceph` relation with external Ceph cluster

### Process Flow

1. **Charm Initialization**
   ```
   __init__() → __post_init__()
   ```
   - Checks `bootstrapped()` → returns False
   - Sets `bootstrap_status` to `MaintenanceStatus("Service not bootstrapped")`

2. **Leader Waits for Adoption** (bypasses normal bootstrap)
   ```
   configure_charm(event)
   └── configure_unit(event)
       └── Does NOT set _state.unit_bootstrapped (bypassed)
   └── configure_app(event)
       └── configure_app_leader(event)  [if leader]
           └── if wait-to-adopt:
               └── return early  (no bootstrap)
   ```
   - Leader unit skips bootstrap and waits
   - Status remains: `MaintenanceStatus("Service not bootstrapped")`

3. **Adopt Relation Data Arrives**
   ```
   adopt-ceph relation-changed event
   └── AdoptCephRequires._on_relation_changed()
       └── emit adopt_ceph_bootstrap event
           └── AdoptCephRequiresHandler._on_bootstrap()
               └── Validate relation data (fsid, mon_hosts, admin_key)
               └── charm.adopt_cluster(fsid, mon_hosts, admin_key)
                   └── microceph.adopt_ceph_cluster()
                       └── Sets peers.interface.state.joined = True
               └── callback_f(event)  [handle_ceph_adopt()]
   ```

4. **Post-Adoption Configuration** (handle_ceph_adopt)
   ```
   handle_ceph_adopt(event)
   └── Check is_leader_ready() → False (proceed)
   └── _state.unit_bootstrapped = True  [MANUAL SET]
   └── handle_config_leader_set_ready()
       └── set_leader_ready()
   └── handle_config_leader_ceph_pool_pgs(event)
   └── handle_config_rgw_service(event)
   └── handle_config_leader_charm_upgrade()
   └── handle_config_leader_new_node(event)
   └── bootstrap_status.set(ActiveStatus())  [MANUAL SET]
   └── status.set(ActiveStatus("charm is ready"))  [MANUAL SET]
   ```

5. **Bootstrap State Flags Set**
   - `_state.unit_bootstrapped = True` (set manually in `handle_ceph_adopt()`)
   - `leader_ready` flag set (via `handle_config_leader_set_ready()`)
   - `bootstrap_status` set to Active (manually)
   - `status` (workload status) set to Active (manually)
   - `peers.interface.state.joined = True` (set in `adopt_cluster()`)

6. **Status Transition**
   ```
   MaintenanceStatus("Service not bootstrapped")
   → BlockedStatus("Waiting for fsid, mon_hosts...") [if data incomplete]
   → ActiveStatus("charm is ready")
   ```