### PR TITLE
feat: add wipe flag for add-osd action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -493,6 +493,51 @@ jobs:
         if: ${{ failure() && runner.debug }}
         uses: canonical/action-tmate@main
 
+  juju-wipe-test:
+    needs:
+      - lint
+      - unit-test
+      - build
+    name: Juju wipe test
+    runs-on: self-hosted-linux-amd64-noble-xlarge
+    steps:
+      - name: Download charm
+        uses: actions/download-artifact@v4
+        with:
+          name: charms
+          path: ~/artifacts/
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: 5.21/stable
+
+      - name: Install dependencies
+        run: ./tests/scripts/ci_helpers.sh install_deps
+
+      - name: Run functional tests
+        run: |
+          set -eux
+          cp ~/artifacts/microceph.charm .
+          tox -e functional -- --keep-models
+
+      - name: Collect logs
+        if: failure()
+        run: ./tests/scripts/ci_helpers.sh collect_microceph_logs
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: microceph_juju_wipe_test_logs
+          path: logs
+          retention-days: 30
+
   juju-single-test:
     needs:
       - lint

--- a/actions.yaml
+++ b/actions.yaml
@@ -20,6 +20,12 @@ add-osd:
       description: |
         Device ID of the disk. Accepts comma separated
         device id's to specify multiple disks
+    wipe:
+      type: boolean
+      description: |
+        Wipe the disk before adding it.
+        Note: This will destroy all data on the disk.
+      default: false
   additionalProperties: false
 set-pool-size:
   description: |

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -270,13 +270,15 @@ def microceph_has_service(service_name) -> bool:
 
 
 # Disk CMDs and Helpers
-def add_osd_cmd(spec: str, wal_dev: str = None, db_dev: str = None) -> None:
+def add_osd_cmd(spec: str, wal_dev: str = None, db_dev: str = None, wipe: bool = False) -> None:
     """Executes MicroCeph add osd cmd with provided spec."""
     cmd = ["microceph", "disk", "add", spec]
     if wal_dev:
         cmd.extend(["--wal-device", wal_dev, "--wal-wipe"])
     if db_dev:
         cmd.extend(["--db-device", db_dev, "--db-wipe"])
+    if wipe:
+        cmd.append("--wipe")
     utils.run_cmd(cmd)
 
 

--- a/src/storage.py
+++ b/src/storage.py
@@ -142,11 +142,14 @@ class StorageHandler(Object):
         if device_ids is not None:
             add_osd_specs.extend(device_ids.split(","))
 
+        # fetch requested wipe flag.
+        wipe = event.params.get("wipe", False)
+
         error = False
         result = {"result": []}
         for spec in add_osd_specs:
             try:
-                microceph.add_osd_cmd(spec)
+                microceph.add_osd_cmd(spec, wipe=wipe)
                 result["result"].append({"spec": spec, "status": "success"})
             except (CalledProcessError, TimeoutExpired) as e:
                 logger.error(e.stderr)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,81 @@
+"""Pytest + jubilant fixtures for testing."""
+
+import subprocess
+from pathlib import Path
+from typing import Iterator
+
+import jubilant
+import pytest
+
+from tests import helpers
+
+REPO_ROOT = helpers.find_repo_root(Path(__file__).resolve())
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Add options."""
+    parser.addoption(
+        "--keep-models",
+        action="store_true",
+        default=False,
+        help="Do not destroy the temporary Juju models created for integration tests.",
+    )
+
+
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo) -> None:
+    """Abort the test session if an abort_on_fail test fails.
+
+    pytest-operator backwd. compat.
+    """
+    if call.when == "call" and call.excinfo and item.get_closest_marker("abort_on_fail"):
+        item.session.shouldstop = "abort_on_fail marker triggered"
+
+
+@pytest.fixture(scope="module")
+def juju(request: pytest.FixtureRequest) -> Iterator[jubilant.Juju]:
+    """Provide a temporary Juju model managed by Jubilant."""
+    keep_models = bool(request.config.getoption("--keep-models"))
+    with jubilant.temp_model(keep=keep_models) as juju:
+        juju.wait_timeout = 20 * 60
+        yield juju
+        if request.session.testsfailed:
+            log = juju.debug_log(limit=1000)
+            if log:
+                print(log, end="")
+
+
+def _build_charm(
+    charm_dir: Path,
+    *,
+    artifact_name: str,
+    rebuild: bool = True,
+) -> Path:
+    """Build a charm at *charm_dir* and return the resulting artifact."""
+    artifact = charm_dir / artifact_name
+    if not rebuild and artifact.exists():
+        return artifact.resolve()
+
+    subprocess.run(["charmcraft", "-v", "pack"], check=True, cwd=charm_dir)
+    built_charms = sorted(
+        charm_dir.glob("*.charm"), key=lambda charm: charm.stat().st_mtime, reverse=True
+    )
+    if not built_charms:
+        raise FileNotFoundError(f"No charm artifacts produced in {charm_dir}")
+
+    latest_artifact = built_charms[0]
+    if latest_artifact != artifact:
+        latest_artifact.rename(artifact)
+
+    if artifact.exists():
+        return artifact.resolve()
+    raise FileNotFoundError(f"Expected charm artifact {artifact} was not produced")
+
+
+@pytest.fixture(scope="session")
+def microceph_charm() -> Path:
+    """Return the built MicroCeph charm artifact."""
+    return _build_charm(
+        REPO_ROOT,
+        artifact_name="microceph.charm",
+        rebuild=False,
+    )

--- a/tests/functests/__init__.py
+++ b/tests/functests/__init__.py
@@ -1,0 +1,1 @@
+"""Functional tests package."""

--- a/tests/functests/test_wipe_osd.py
+++ b/tests/functests/test_wipe_osd.py
@@ -1,0 +1,78 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Functest for MicroCeph disk ops."""
+
+import logging
+from pathlib import Path
+
+import jubilant
+import pytest
+
+from tests import helpers
+from tests.helpers import lxd
+
+logger = logging.getLogger(__name__)
+
+APP_NAME = "microceph"
+
+
+@pytest.mark.abort_on_fail
+def test_add_osd_wipe(juju: jubilant.Juju, microceph_charm: Path):
+    """Deploy MicroCeph and verify add-osd action with wipe=True on a dirty disk."""
+    logger.info("Deploying MicroCeph")
+    juju.deploy(
+        str(microceph_charm),
+        APP_NAME,
+        config={"snap-channel": "squid/edge"},
+        constraints={
+            "virt-type": "virtual-machine",
+            "root-disk": "16G",
+            "mem": "4G",
+        },
+    )
+
+    with helpers.fast_forward(juju):
+        helpers.wait_for_apps(juju, APP_NAME, timeout=3600)
+
+    unit_name = helpers.first_unit_name(juju.status(), APP_NAME)
+
+    # Prepare lxd vol to add as bdev
+    inst_id = lxd.get_instance_id(juju, APP_NAME, unit_name)
+    logger.info(f"Instance ID: {inst_id}")
+
+    chosen_pool = lxd.get_lxd_storage_pool()
+    logger.info(f"Using LXD storage pool: {chosen_pool}")
+
+    model_name = juju.status().model.name
+    vol_name = f"wipe-test-{model_name}"
+
+    try:
+        lxd.create_and_attach_volume(chosen_pool, vol_name, inst_id)
+
+        disk_path = lxd.wait_for_disk(juju, unit_name)
+        logger.info(f"Found disk at {disk_path}")
+
+        logger.info("Formatting disk to make it dirty")
+        juju.ssh(unit_name, f"sudo mkfs.ext4 -F {disk_path}")
+
+        logger.info("Running add-osd action with wipe=true")
+        action = juju.run(unit_name, "add-osd", {"device-id": disk_path, "wipe": True}, wait=1200)
+        action.raise_on_failure()
+
+        logger.info("Verifying OSD count")
+        helpers.assert_osd_count(juju, APP_NAME, expected_osds=1)
+
+    finally:
+        lxd.cleanup_volume(chosen_pool, vol_name, inst_id)

--- a/tests/helpers/lxd.py
+++ b/tests/helpers/lxd.py
@@ -1,0 +1,86 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LXD helper functions for functional tests."""
+
+import json
+import logging
+import subprocess
+import time
+
+import jubilant
+
+logger = logging.getLogger(__name__)
+
+
+def get_instance_id(juju: jubilant.Juju, app_name: str, unit_name: str) -> str:
+    """Get the LXD instance for a given Juju unit."""
+    model_name = juju.status().model.name
+    cmd = ["juju", "machines", "--format=json", "-m", model_name]
+    out = subprocess.check_output(cmd)
+    machines = json.loads(out)
+
+    status = juju.status()
+    machine_id = status.apps[app_name].units[unit_name].machine
+    return machines["machines"][machine_id]["instance-id"]
+
+
+def get_lxd_storage_pool() -> str:
+    """Find a LXD storage pool or use default."""
+    pool_output = subprocess.check_output(["lxc", "storage", "list", "--format=json"])
+    pools = json.loads(pool_output)
+    for pool in pools:
+        if pool["driver"] in ["zfs", "btrfs", "lvm"]:
+            return pool["name"]
+    return "default"
+
+
+def create_and_attach_volume(
+    pool: str, vol_name: str, instance_id: str, size: str = "1GB"
+) -> None:
+    """Create a block volume and attach it to an instance."""
+    logger.info(f"Creating volume {vol_name}")
+    subprocess.run(
+        ["lxc", "storage", "volume", "create", pool, vol_name, "--type=block", f"size={size}"],
+        check=True,
+    )
+
+    logger.info(f"Attaching volume {vol_name} to {instance_id}")
+    subprocess.run(["lxc", "storage", "volume", "attach", pool, vol_name, instance_id], check=True)
+
+
+def cleanup_volume(pool: str, vol_name: str, instance_id: str) -> None:
+    """Detach and delete volume."""
+    logger.info("Cleaning up volume")
+    subprocess.run(
+        ["lxc", "storage", "volume", "detach", pool, vol_name, instance_id], check=False
+    )
+    subprocess.run(["lxc", "storage", "volume", "delete", pool, vol_name], check=False)
+
+
+def wait_for_disk(juju: jubilant.Juju, unit_name: str, size_pattern: str = "1G|953.7M") -> str:
+    """Wait for a disk matching the size pattern to appear in the unit."""
+    logger.info("Waiting for disk to appear")
+    for _ in range(30):
+        # Look for disk with specific size
+        cmd = f"lsblk -d -o NAME,SIZE,TYPE | grep -E '{size_pattern}' | grep 'disk' | awk '{{print \"/dev/\" $1}}' | head -n1"
+        try:
+            disk_path = juju.ssh(unit_name, cmd).strip()
+            if disk_path:
+                return disk_path
+        except Exception as e:
+            logger.warning(f"SSH failed: {e}")
+        time.sleep(5)
+
+    raise TimeoutError("Attached disk not found in VM")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,82 +1,13 @@
 """Pytest + jubilant fixtures for integration testing."""
 
-import subprocess
 from pathlib import Path
-from typing import Iterator
 
-import jubilant
 import pytest
 
-REPO_ROOT = Path(__file__).parent.parent.parent
+from tests import helpers
+from tests.conftest import _build_charm
 
-
-def pytest_addoption(parser: pytest.Parser) -> None:
-    """Add options."""
-    parser.addoption(
-        "--keep-models",
-        action="store_true",
-        default=False,
-        help="Do not destroy the temporary Juju models created for integration tests.",
-    )
-
-
-def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo) -> None:
-    """Abort the test session if an abort_on_fail test fails.
-
-    pytest-operator backwd. compat.
-    """
-    if call.when == "call" and call.excinfo and item.get_closest_marker("abort_on_fail"):
-        item.session.shouldstop = "abort_on_fail marker triggered"
-
-
-@pytest.fixture(scope="module")
-def juju(request: pytest.FixtureRequest) -> Iterator[jubilant.Juju]:
-    """Provide a temporary Juju model managed by Jubilant."""
-    keep_models = bool(request.config.getoption("--keep-models"))
-    with jubilant.temp_model(keep=keep_models) as juju:
-        juju.wait_timeout = 20 * 60
-        yield juju
-        if request.session.testsfailed:
-            log = juju.debug_log(limit=1000)
-            if log:
-                print(log, end="")
-
-
-def _build_charm(
-    charm_dir: Path,
-    *,
-    artifact_name: str,
-    rebuild: bool = True,
-) -> Path:
-    """Build a charm at *charm_dir* and return the resulting artifact."""
-    artifact = charm_dir / artifact_name
-    if not rebuild and artifact.exists():
-        return artifact.resolve()
-
-    subprocess.run(["charmcraft", "-v", "pack"], check=True, cwd=charm_dir)
-    built_charms = sorted(
-        charm_dir.glob("*.charm"), key=lambda charm: charm.stat().st_mtime, reverse=True
-    )
-    if not built_charms:
-        raise FileNotFoundError(f"No charm artifacts produced in {charm_dir}")
-
-    latest_artifact = built_charms[0]
-    if latest_artifact != artifact:
-        latest_artifact.rename(artifact)
-
-    if artifact.exists():
-        return artifact.resolve()
-    raise FileNotFoundError(f"Expected charm artifact {artifact} was not produced")
-
-
-@pytest.fixture(scope="session")
-def microceph_charm() -> Path:
-    """Return the built MicroCeph charm artifact."""
-    return _build_charm(
-        REPO_ROOT,
-        artifact_name="microceph.charm",
-        rebuild=False,
-    )
+REPO_ROOT = helpers.find_repo_root(Path(__file__).resolve())
 
 
 @pytest.fixture(scope="session")

--- a/tests/scripts/ci_helpers.sh
+++ b/tests/scripts/ci_helpers.sh
@@ -24,7 +24,7 @@ function check_osd_count() {
 
 function install_deps() {
     date
-    sudo apt-get -qq install jq
+    sudo apt-get -qq install jq tox
     sudo snap install juju
     mkdir -p ~/.local/share/juju
     juju bootstrap localhost lxd

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -389,6 +389,27 @@ class TestCharm(testbase.TestBaseCharm):
             timeout=180,
         )
 
+    @patch("utils.subprocess")
+    @patch("ceph.check_output")
+    def test_add_osds_action_with_wipe(self, _chk, subprocess):
+        """Test action add_osds with wipe flag."""
+        test_utils.add_complete_peer_relation(self.harness)
+        self.harness._charm.peers.interface.state.joined = True
+
+        action_event = MagicMock()
+        action_event.params = {"device-id": "/dev/sdb", "wipe": True}
+        self.harness.charm.storage._add_osd_action(action_event)
+
+        action_event.set_results.assert_called()
+        action_event.fail.assert_not_called()
+        subprocess.run.assert_called_with(
+            ["microceph", "disk", "add", "/dev/sdb", "--wipe"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=180,
+        )
+
     def test_add_osds_action_node_not_bootstrapped(self):
         """Test action add_osds when node not bootstrapped."""
         test_utils.add_complete_peer_relation(self.harness)

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -212,3 +212,51 @@ class TestMicroCeph(unittest.TestCase):
 
         result = microceph.microceph_has_service("nfs")
         self.assertTrue(result)
+
+    @patch("utils.run_cmd")
+    def test_add_osd_cmd(self, run_cmd):
+        # Test default call
+        microceph.add_osd_cmd("loop,4G,3")
+        run_cmd.assert_called_with(["microceph", "disk", "add", "loop,4G,3"])
+
+    @patch("utils.run_cmd")
+    def test_add_osd_cmd_with_wal(self, run_cmd):
+        # Test with WAL device
+        microceph.add_osd_cmd("loop,4G,3", wal_dev="/dev/sdb")
+        run_cmd.assert_called_with(
+            ["microceph", "disk", "add", "loop,4G,3", "--wal-device", "/dev/sdb", "--wal-wipe"]
+        )
+
+    @patch("utils.run_cmd")
+    def test_add_osd_cmd_with_db(self, run_cmd):
+        # Test with DB device
+        microceph.add_osd_cmd("loop,4G,3", db_dev="/dev/sdc")
+        run_cmd.assert_called_with(
+            ["microceph", "disk", "add", "loop,4G,3", "--db-device", "/dev/sdc", "--db-wipe"]
+        )
+
+    @patch("utils.run_cmd")
+    def test_add_osd_cmd_with_wipe(self, run_cmd):
+        # Test with wipe flag
+        microceph.add_osd_cmd("loop,4G,3", wipe=True)
+        run_cmd.assert_called_with(["microceph", "disk", "add", "loop,4G,3", "--wipe"])
+
+    @patch("utils.run_cmd")
+    def test_add_osd_cmd_all_options(self, run_cmd):
+        # Test with all options
+        microceph.add_osd_cmd("loop,4G,3", wal_dev="/dev/sdb", db_dev="/dev/sdc", wipe=True)
+        run_cmd.assert_called_with(
+            [
+                "microceph",
+                "disk",
+                "add",
+                "loop,4G,3",
+                "--wal-device",
+                "/dev/sdb",
+                "--wal-wipe",
+                "--db-device",
+                "/dev/sdc",
+                "--db-wipe",
+                "--wipe",
+            ]
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -92,6 +92,15 @@ deps =
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {[vars]tst_path}/integration {posargs}
 
+[testenv:functional]
+description = Run functional tests
+deps =
+    pytest
+    jubilant~=1.0
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native --log-cli-level=INFO -s {[vars]tst_path}/functests {posargs}
+
 [testenv:pep8]
 description = Alias for lint
 deps = {[testenv:lint]deps}


### PR DESCRIPTION
# Description

Add flag to wipe disks when running the add-osd action

Also add pytest/jubilant based functests

Fixes #201 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

functests

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] added tests to verify effectiveness of this change.
