### PR TITLE
feat: osd configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,39 @@ Ceph cluster with [Juju](https://juju.is/).
 Please visit [charmhub](https://charmhub.io/microceph) for documentation and instructions
 on consuming charmed MicroCeph.
 
+## OSD device configuration
+
+The charm can automatically enroll OSDs based on a declarative match expression.
+Set the `osd-devices` config option with a DSL expression that the MicroCeph snap
+uses to find block devices on each unit. 
+
+Note: for safety reasons the matching is additive only. That is,
+changes in this config option will only ever add new OSDs, existing
+OSDs will never be removed as a result of config changes (or clearing
+of configs).
+
+For full DSL details, see the MicroCeph reference documentation:
+https://canonical-microceph.readthedocs-hosted.com/latest/reference/commands/disk/#dsl-based-device-selection
+
+Examples:
+
+```
+juju config microceph osd-devices="eq(@type,'nvme')"
+juju config microceph osd-devices="and(eq(@type,'ssd'), ge(@size,100GiB))"
+juju config microceph osd-devices="eq(@devnode,'/dev/sdb')"
+```
+
+To control device enrollment behavior, set `device-add-flags`:
+
+- `wipe:osd` wipes non-pristine devices before enrollment.
+- `encrypt:osd` enables encryption for matched devices.
+
+Example:
+
+```
+juju config microceph device-add-flags="wipe:osd,encrypt:osd"
+```
+
 ## Terraform module
 
 A reusable Terraform + Terragrunt module for deploying the `microceph` charm can be found in `terraform/microceph/`. See the module README for usage instructions.

--- a/config.yaml
+++ b/config.yaml
@@ -61,3 +61,32 @@ options:
     description: |
       Whether charm microceph should wait for an external ceph cluster to yield admin credentials using which microceph will
       adopt the external cluster rather than bootstrapping a new ceph cluster on microceph bootstrap.
+  osd-devices:
+    type: string
+    default: ""
+    description: |
+      DSL expression to match block devices for OSD enrollment.
+      The DSL uses functional syntax with predicates and variables.
+
+      Supported predicates: and(), or(), not(), eq(), ne(), gt(), ge(), lt(), le(), in(), re()
+      Supported variables: @type, @vendor, @model, @size, @devnode, @host
+
+      Examples:
+        eq(@type,'nvme')
+        and(eq(@type,'ssd'), ge(@size,100GiB))
+        or(eq(@type,'ssd'), eq(@type,'nvme'))
+
+      When set, the charm evaluates this expression against available
+      block devices on each unit and enrolls matching devices as OSDs.
+      This is additive to action-based and Juju storage-based OSDs.
+  device-add-flags:
+    type: string
+    default: ""
+    description: |
+      Comma-separated list of flags controlling device addition.
+
+      Supported flags:
+        wipe:osd    - Wipe non-pristine OSD devices before enrollment
+        encrypt:osd - Encrypt OSD devices
+
+      Example: wipe:osd,encrypt:osd

--- a/src/device_flags.py
+++ b/src/device_flags.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validators for OSD device configuration options."""
+
+from dataclasses import dataclass
+
+# Valid device-add-flags for Phase 1
+VALID_FLAGS = frozenset(["wipe:osd", "encrypt:osd"])
+
+
+@dataclass
+class DeviceAddFlags:
+    """Parsed device-add-flags."""
+
+    wipe_osd: bool = False
+    encrypt_osd: bool = False
+
+
+def parse_device_add_flags(flags_str: str) -> DeviceAddFlags:
+    """Parse the device-add-flags config option.
+
+    Args:
+        flags_str: Comma-separated flags like "wipe:osd,encrypt:osd"
+
+    Returns:
+        DeviceAddFlags with parsed boolean fields.
+
+    Raises:
+        ValueError: If an unknown flag is encountered.
+    """
+    result = DeviceAddFlags()
+
+    if not flags_str or not flags_str.strip():
+        return result
+
+    for flag in flags_str.split(","):
+        flag = flag.strip().lower()
+        if not flag:
+            continue
+        if flag not in VALID_FLAGS:
+            raise ValueError(
+                f"Unknown flag: '{flag}'. Valid flags: {', '.join(sorted(VALID_FLAGS))}"
+            )
+        if flag == "wipe:osd":
+            result.wipe_osd = True
+        elif flag == "encrypt:osd":
+            result.encrypt_osd = True
+
+    return result

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -339,6 +339,33 @@ def add_batch_osds(disks: list) -> None:
     utils.run_cmd(cmd)
 
 
+def add_osd_match_cmd(
+    osd_match: str,
+    wipe: bool = False,
+    encrypt: bool = False,
+    dry_run: bool = False,
+) -> str:
+    """Execute MicroCeph disk add with DSL-based OSD matching.
+
+    Args:
+        osd_match: DSL expression for matching OSD devices
+        wipe: If True, wipe non-pristine devices before enrollment
+        encrypt: If True, encrypt matched devices
+        dry_run: If True, report matches without adding devices
+
+    Returns:
+        Command output (useful for dry-run results)
+    """
+    cmd = ["microceph", "disk", "add", "--osd-match", osd_match]
+    if wipe:
+        cmd.append("--wipe")
+    if encrypt:
+        cmd.append("--encrypt")
+    if dry_run:
+        cmd.append("--dry-run")
+    return utils.run_cmd(cmd)
+
+
 def get_snap_info(snap_name):
     """Get snap info from the charm store."""
     url = f"https://api.snapcraft.io/v2/snaps/info/{snap_name}"

--- a/tests/integration/test_osd_devices_config.py
+++ b/tests/integration/test_osd_devices_config.py
@@ -1,0 +1,436 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for osd-devices config option (CE127 Phase 1).
+
+These tests verify that the charm correctly processes the osd-devices
+configuration option, which allows declarative device selection via
+a DSL expression.
+
+All tests in this module run in VMs with LXD block devices attached
+for OSD enrollment testing.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Iterator
+
+import jubilant
+import pytest
+
+from tests import helpers
+from tests.helpers import lxd
+
+logger = logging.getLogger(__name__)
+
+APP_NAME = "microceph"
+
+
+def _wait_for_active(juju_vm: jubilant.Juju, timeout: int = 300) -> None:
+    """Wait for app to reach active/idle."""
+    with helpers.fast_forward(juju_vm):
+        helpers.wait_for_apps(juju_vm, APP_NAME, timeout=timeout)
+
+
+def _set_osd_config(
+    juju_vm: jubilant.Juju,
+    osd_devices: str,
+    device_add_flags: str = "",
+) -> None:
+    """Set osd-devices related config options."""
+    juju_vm.config(
+        APP_NAME,
+        {
+            "osd-devices": osd_devices,
+            "device-add-flags": device_add_flags,
+        },
+    )
+
+
+def _apply_osd_config_and_wait(
+    juju_vm: jubilant.Juju,
+    osd_devices: str,
+    device_add_flags: str = "",
+    timeout: int = 300,
+) -> None:
+    """Apply osd-devices config and wait for active status."""
+    _set_osd_config(juju_vm, osd_devices=osd_devices, device_add_flags=device_add_flags)
+    _wait_for_active(juju_vm, timeout=timeout)
+
+
+def _clear_osd_config_and_wait(juju_vm: jubilant.Juju, timeout: int = 300) -> None:
+    """Clear osd-devices related config and wait for active status."""
+    _set_osd_config(juju_vm, osd_devices="", device_add_flags="")
+    _wait_for_active(juju_vm, timeout=timeout)
+
+
+@pytest.fixture(scope="module")
+def juju_vm(request: pytest.FixtureRequest) -> Iterator[jubilant.Juju]:
+    """Provide a temporary Juju model with VM constraints for OSD testing."""
+    keep_models = bool(request.config.getoption("--keep-models"))
+    with jubilant.temp_model(keep=keep_models) as juju:
+        juju.wait_timeout = 60 * 60  # 1 hour for VM deployments
+        # Set model constraints for VMs
+        juju.cli("set-model-constraints", "virt-type=virtual-machine", "mem=4G", "root-disk=16G")
+        yield juju
+        if request.session.testsfailed:
+            log = juju.debug_log(limit=1000)
+            if log:
+                print(log, end="")
+
+
+@pytest.fixture(scope="module")
+def deployed_microceph(juju_vm: jubilant.Juju, microceph_charm: Path):
+    """Deploy MicroCeph in a VM for config testing."""
+    logger.info("Deploying MicroCeph (VM)")
+    juju_vm.deploy(
+        str(microceph_charm),
+        APP_NAME,
+        config={"snap-channel": "latest/edge"},
+    )
+
+    _wait_for_active(juju_vm, timeout=3600)
+
+    return APP_NAME
+
+
+@pytest.fixture(scope="module")
+def attached_block_device(juju_vm: jubilant.Juju, deployed_microceph) -> Iterator[str]:
+    """Create and attach an LXD block volume to the deployed VM.
+
+    The volume must be >2GB as MicroCeph's AvailableDisks ignores devices
+    smaller than MinOSDSize (2,147,483,648 bytes / 2GB).
+
+    Yields the disk path inside the VM. Cleaned up after the module.
+    """
+    unit_name = helpers.first_unit_name(juju_vm.status(), APP_NAME)
+    inst_id = lxd.get_instance_id(juju_vm, APP_NAME, unit_name)
+    logger.info(f"Instance ID: {inst_id}")
+
+    pool = lxd.get_lxd_storage_pool()
+    logger.info(f"Using LXD storage pool: {pool}")
+
+    model_name = juju_vm.status().model.name
+    vol_name = f"osd-cfg-test-{model_name}"
+
+    lxd.create_and_attach_volume(pool, vol_name, inst_id, size="3GB")
+    try:
+        disk_path = lxd.wait_for_disk(juju_vm, unit_name, size_pattern="3G|2.8G|2.9G")
+        logger.info(f"Block device available at {disk_path}")
+        yield disk_path
+    finally:
+        lxd.cleanup_volume(pool, vol_name, inst_id)
+
+
+@pytest.mark.abort_on_fail
+def test_osd_devices_config_invalid_flags(juju_vm: jubilant.Juju, deployed_microceph):
+    """Verify that invalid device-add-flags cause a blocked status."""
+    logger.info("Testing invalid device-add-flags detection")
+
+    # Set an invalid flag
+    juju_vm.config(
+        APP_NAME,
+        {
+            "osd-devices": "eq(@type,'disk')",
+            "device-add-flags": "invalid:flag",
+        },
+    )
+
+    with helpers.fast_forward(juju_vm):
+        helpers.wait_for_status(juju_vm, APP_NAME, ("blocked", "error"), timeout=120)
+
+    # Reset config to unblock
+    _set_osd_config(juju_vm, osd_devices="", device_add_flags="")
+
+    # Resolve the error state so the unit can recover (if needed).
+    status = juju_vm.status()
+    unit_name = helpers.first_unit_name(status, APP_NAME)
+    unit_status = status.apps[APP_NAME].units[unit_name]
+    if (
+        unit_status.juju_status.current == "error"
+        or unit_status.workload_status.current == "error"
+    ):
+        juju_vm.cli("resolved", unit_name)
+
+    _wait_for_active(juju_vm, timeout=300)
+
+
+@pytest.mark.abort_on_fail
+def test_osd_devices_config_no_match(juju_vm: jubilant.Juju, deployed_microceph):
+    """Test that a DSL expression matching no devices doesn't cause errors.
+
+    When osd-devices is set but no devices match, the charm should
+    remain active (this is a valid scenario).
+    """
+    logger.info("Testing DSL expression with no matching devices")
+
+    # Use a DSL that won't match any devices (non-existent vendor)
+    _apply_osd_config_and_wait(
+        juju_vm,
+        osd_devices="eq(@vendor,'nonexistent-vendor-xyz')",
+        timeout=300,
+    )
+
+    # Reset config
+    _clear_osd_config_and_wait(juju_vm, timeout=300)
+
+
+@pytest.mark.abort_on_fail
+def test_osd_devices_config_snap_has_osd_match(juju_vm: jubilant.Juju, deployed_microceph):
+    """Verify that the MicroCeph snap supports the --osd-match flag.
+
+    This confirms the snap version installed by the charm has the
+    --osd-match CLI flag available, which is required for the
+    osd-devices config feature.
+    """
+    logger.info("Verifying snap --osd-match CLI support")
+
+    unit_name = helpers.first_unit_name(juju_vm.status(), APP_NAME)
+
+    help_output = juju_vm.ssh(unit_name, "sudo", "microceph", "disk", "add", "--help")
+    assert (
+        "--osd-match" in help_output
+    ), f"Snap does not support --osd-match flag. Help output:\n{help_output}"
+    assert (
+        "--dry-run" in help_output
+    ), f"Snap does not support --dry-run flag. Help output:\n{help_output}"
+    logger.info("Snap --osd-match and --dry-run flags confirmed")
+
+
+@pytest.mark.abort_on_fail
+def test_osd_devices_config_reapply_stays_active(juju_vm: jubilant.Juju, deployed_microceph):
+    """Test that re-applying osd-devices config doesn't cause errors.
+
+    Toggling the config off and on should not cause the charm to
+    enter an error state. This verifies idempotency of the
+    config-changed handler.
+    """
+    logger.info("Testing idempotent config re-application")
+
+    dsl_expr = "eq(@type,'nvme')"
+
+    # First application
+    _apply_osd_config_and_wait(juju_vm, osd_devices=dsl_expr, timeout=300)
+
+    # Clear config
+    _clear_osd_config_and_wait(juju_vm, timeout=300)
+
+    # Re-apply same config
+    _apply_osd_config_and_wait(juju_vm, osd_devices=dsl_expr, timeout=300)
+
+    # Cleanup
+    _clear_osd_config_and_wait(juju_vm, timeout=300)
+
+
+@pytest.mark.abort_on_fail
+def test_osd_devices_config_enrolls_disk(
+    juju_vm: jubilant.Juju, deployed_microceph, attached_block_device: str
+):
+    """Verify OSD enrollment via config, then dirty-disk rejection without wipe.
+
+    Steps:
+    1. Enroll the attached block device as an OSD via osd-devices config (with wipe).
+    2. Remove the OSD, leaving leftover metadata on the disk.
+    3. Re-apply osd-devices config *without* wipe — the snap should reject the
+       dirty disk and the charm should block/error.
+    4. Re-apply with wipe:osd — enrollment should succeed again.
+    """
+    unit_name = helpers.first_unit_name(juju_vm.status(), APP_NAME)
+    logger.info(f"Testing OSD enrollment with block device at {attached_block_device}")
+
+    # --- Step 1: Enroll with wipe ---
+    _apply_osd_config_and_wait(
+        juju_vm,
+        osd_devices="eq(@type,'scsi')",
+        device_add_flags="wipe:osd",
+        timeout=600,
+    )
+
+    helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=1)
+
+    # --- Step 2: Remove OSD to leave the disk dirty ---
+    logger.info("Removing OSD to leave dirty disk")
+    _set_osd_config(juju_vm, osd_devices="", device_add_flags="")
+
+    # Query the actual OSD number (not necessarily 0)
+    osd_list_raw = juju_vm.ssh(
+        unit_name,
+        "sudo",
+        "microceph",
+        "disk",
+        "list",
+        "--json",
+    )
+    osd_list = json.loads(osd_list_raw)
+    osd_num = str(osd_list["ConfiguredDisks"][0]["osd"])
+    logger.info(f"Removing OSD {osd_num}")
+
+    juju_vm.ssh(
+        unit_name,
+        "sudo",
+        "microceph",
+        "disk",
+        "remove",
+        osd_num,
+        "--bypass-safety-checks",
+        "--prohibit-crush-scaledown",
+    )
+
+    helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=0)
+
+    # --- Step 3: Re-apply config WITHOUT wipe — dirty disk should be rejected ---
+    logger.info("Attempting enrollment without wipe on dirty disk")
+    _set_osd_config(juju_vm, osd_devices="eq(@type,'scsi')")
+
+    with helpers.fast_forward(juju_vm):
+        helpers.wait_for_status(juju_vm, APP_NAME, ("blocked", "error"), timeout=300)
+
+    # Reset config — the guard caught the error so the unit is blocked, not errored.
+    # Clearing the config triggers a new config-changed which will unblock.
+    _clear_osd_config_and_wait(juju_vm, timeout=300)
+
+    helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=0)
+
+    # --- Step 4: Re-apply WITH wipe — should succeed ---
+    logger.info("Re-enrolling dirty disk with wipe:osd flag")
+    _apply_osd_config_and_wait(
+        juju_vm,
+        osd_devices="eq(@type,'scsi')",
+        device_add_flags="wipe:osd",
+        timeout=600,
+    )
+
+    helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=1)
+
+    status = juju_vm.status()
+    assert (
+        status.apps[APP_NAME].app_status.current == "active"
+    ), f"Expected active after OSD enrollment, got {status.apps[APP_NAME].app_status.current}"
+
+    # Cleanup config (leave the OSD enrolled)
+    _clear_osd_config_and_wait(juju_vm, timeout=300)
+
+
+@pytest.mark.abort_on_fail
+def test_osd_devices_config_additive(
+    juju_vm: jubilant.Juju, deployed_microceph, attached_block_device: str
+):
+    """Verify that clearing osd-devices config does not remove enrolled OSDs.
+
+    The previous test enrolled 1 OSD and cleared the config. The OSD should
+    still be present because config removal only stops future enrollment — it
+    does not tear down existing OSDs.
+    """
+    logger.info("Verifying OSD persists after config is cleared")
+
+    # Config was already cleared by the previous test; just verify.
+    _wait_for_active(juju_vm, timeout=300)
+
+    helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=1)
+
+
+@pytest.mark.abort_on_fail
+def test_osd_devices_config_idempotent(
+    juju_vm: jubilant.Juju, deployed_microceph, attached_block_device: str
+):
+    """Verify that re-applying osd-devices config doesn't duplicate OSDs.
+
+    With 1 OSD already enrolled (from the enrolls_disk test), re-applying
+    the same DSL expression should not add a second OSD for the same disk.
+    """
+    logger.info("Testing idempotent re-application with enrolled disk")
+
+    _apply_osd_config_and_wait(
+        juju_vm,
+        osd_devices="eq(@type,'scsi')",
+        device_add_flags="wipe:osd",
+        timeout=600,
+    )
+
+    # Should still be exactly 1 OSD, not 2
+    helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=1)
+
+    # Cleanup
+    _clear_osd_config_and_wait(juju_vm, timeout=300)
+
+
+@pytest.fixture(scope="module")
+def second_block_device(juju_vm: jubilant.Juju, deployed_microceph) -> Iterator[str]:
+    """Create and attach a second LXD block volume for multi-OSD tests.
+
+    Uses a different size (4GB) so it can be distinguished from the first (3GB).
+    """
+    # Ensure config-based enrollment is disabled before attaching the disk.
+    _clear_osd_config_and_wait(juju_vm, timeout=300)
+
+    unit_name = helpers.first_unit_name(juju_vm.status(), APP_NAME)
+    inst_id = lxd.get_instance_id(juju_vm, APP_NAME, unit_name)
+    pool = lxd.get_lxd_storage_pool()
+    model_name = juju_vm.status().model.name
+    vol_name = f"osd-cfg-test2-{model_name}"
+
+    lxd.create_and_attach_volume(pool, vol_name, inst_id, size="4GB")
+    try:
+        disk_path = lxd.wait_for_disk(juju_vm, unit_name, size_pattern="4G|3.7G|3.8G|3.9G")
+        logger.info(f"Second block device available at {disk_path}")
+        yield disk_path
+    finally:
+        lxd.cleanup_volume(pool, vol_name, inst_id)
+
+
+@pytest.mark.abort_on_fail
+def test_osd_devices_config_coexists_with_action(
+    juju_vm: jubilant.Juju,
+    deployed_microceph,
+    attached_block_device: str,
+    second_block_device: str,
+):
+    """Verify config-based and action-based OSD enrollment coexist.
+
+    One OSD is already enrolled via config (attached_block_device).
+    This test adds a second OSD via the add-osd action on the second
+    block device, then verifies both are present.
+    """
+    logger.info(
+        f"Testing coexistence: config OSD at {attached_block_device}, "
+        f"action OSD at {second_block_device}"
+    )
+
+    # Ensure the config-based OSD is enrolled for the first disk only.
+    # @devnode in snap DSL now resolves to the kernel devnode path (/dev/sdX, /dev/nvmeXnY).
+    _apply_osd_config_and_wait(
+        juju_vm,
+        osd_devices=f"eq(@devnode,'{attached_block_device}')",
+        device_add_flags="wipe:osd",
+        timeout=600,
+    )
+
+    helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=1)
+
+    # Enroll second disk via action
+    unit_name = helpers.first_unit_name(juju_vm.status(), APP_NAME)
+    task = juju_vm.run(
+        unit_name,
+        "add-osd",
+        {"device-id": second_block_device, "wipe": True},
+        wait=600,
+    )
+    task.raise_on_failure()
+
+    with helpers.fast_forward(juju_vm):
+        helpers.wait_for_apps(juju_vm, APP_NAME, timeout=600)
+
+    # Both OSDs should be present
+    helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=2)

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -12,72 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import subprocess
+"""Compatibility wrappers for integration relation-data helpers."""
 
-import yaml
+from tests import helpers
 
 
-# These functions are picked from traefik-k8s-operator repo.
-# Raised a bug to move these functions to common repo so that
-# any charm can reuse them.
-# https://github.com/canonical/traefik-k8s-operator/issues/175
 def get_unit_info(unit: str, model: str) -> dict:
-    """Returns unit-info data structure.
-
-    Example:
-    cephclient/6:
-      machine: "26"
-      opened-ports: []
-      public-address: 10.121.193.146
-      charm: local:jammy/cephclient-requirer-mock-11
-      leader: true
-      life: alive
-      relation-info:
-      - relation-id: 9
-        endpoint: ceph
-        related-endpoint: ceph
-        application-data: {}
-        related-units:
-          microceph/20:
-            in-scope: true
-            data:
-              auth: cephx
-              broker-rsp-cephclient-6: '{"exit-code": 0, "request-id": "2ab0acf4"}'
-              ceph-public-address: 10.121.193.17
-              egress-subnets: 10.121.193.17/32
-              ingress-address: 10.121.193.17
-              key: AQDtJVtk30rAFhAAw+MRUxjSVe+BJmlX6HXMZg==
-              private-address: 10.121.193.17
-    """
-    cmd = ["juju", "show-unit", "-m", model, unit]
-
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-    raw_data = proc.stdout.read().decode("utf-8").strip()
-
-    data = yaml.safe_load(raw_data) if raw_data else None
-
-    if not data:
-        raise ValueError(f"No Unit info available for {unit}")
-
-    if unit not in data:
-        raise KeyError(unit, f"not in {data!r}")
-
-    unit_data = data[unit]
-    return unit_data
+    """Return unit info from ``juju show-unit`` output."""
+    return helpers.get_unit_info(unit, model)
 
 
 def get_relation_data(unit: str, endpoint: str, related_unit: str, model: str) -> dict:
-    """Returns relation data for a specific endpoint and related unit.
-
-    :param unit: Unit name for which unit-info to be extracted
-    :param endpoint: Endpoint name on local unit
-    :param related_unit: Remote unit name
-    :param model: Model name
-    """
-    unit_data = get_unit_info(unit, model)
-    for relation in unit_data.get("relation-info", []):
-        related_units = relation.get("related-units", {})
-        if endpoint == relation.get("endpoint") and related_unit in related_units:
-            return related_units.get(related_unit).get("data")
-
-    return {}
+    """Return relation data for a specific endpoint and related unit."""
+    return helpers.get_relation_data(unit, endpoint, related_unit, model)

--- a/tests/unit/test_device_flags.py
+++ b/tests/unit/test_device_flags.py
@@ -1,0 +1,118 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for device-add-flags parsing."""
+
+import unittest
+
+from device_flags import (
+    DeviceAddFlags,
+    parse_device_add_flags,
+)
+
+
+class TestDeviceAddFlagsParsing(unittest.TestCase):
+    """Tests for parse_device_add_flags function."""
+
+    def test_empty_flags(self):
+        """Empty string returns default flags."""
+        flags = parse_device_add_flags("")
+        self.assertFalse(flags.wipe_osd)
+        self.assertFalse(flags.encrypt_osd)
+
+    def test_none_flags(self):
+        """None returns default flags."""
+        flags = parse_device_add_flags(None)
+        self.assertFalse(flags.wipe_osd)
+        self.assertFalse(flags.encrypt_osd)
+
+    def test_whitespace_only(self):
+        """Whitespace-only string returns default flags."""
+        flags = parse_device_add_flags("   ")
+        self.assertFalse(flags.wipe_osd)
+        self.assertFalse(flags.encrypt_osd)
+
+    def test_wipe_osd_flag(self):
+        """wipe:osd flag is parsed correctly."""
+        flags = parse_device_add_flags("wipe:osd")
+        self.assertTrue(flags.wipe_osd)
+        self.assertFalse(flags.encrypt_osd)
+
+    def test_encrypt_osd_flag(self):
+        """encrypt:osd flag is parsed correctly."""
+        flags = parse_device_add_flags("encrypt:osd")
+        self.assertFalse(flags.wipe_osd)
+        self.assertTrue(flags.encrypt_osd)
+
+    def test_multiple_flags(self):
+        """Multiple flags are parsed correctly."""
+        flags = parse_device_add_flags("wipe:osd,encrypt:osd")
+        self.assertTrue(flags.wipe_osd)
+        self.assertTrue(flags.encrypt_osd)
+
+    def test_multiple_flags_reversed_order(self):
+        """Order of flags doesn't matter."""
+        flags = parse_device_add_flags("encrypt:osd,wipe:osd")
+        self.assertTrue(flags.wipe_osd)
+        self.assertTrue(flags.encrypt_osd)
+
+    def test_flags_with_spaces(self):
+        """Spaces around flags are handled."""
+        flags = parse_device_add_flags("  wipe:osd  ,  encrypt:osd  ")
+        self.assertTrue(flags.wipe_osd)
+        self.assertTrue(flags.encrypt_osd)
+
+    def test_case_insensitive(self):
+        """Flag parsing is case-insensitive."""
+        flags = parse_device_add_flags("WIPE:OSD")
+        self.assertTrue(flags.wipe_osd)
+
+    def test_mixed_case(self):
+        """Mixed case flags are handled."""
+        flags = parse_device_add_flags("Wipe:OSD,ENCRYPT:osd")
+        self.assertTrue(flags.wipe_osd)
+        self.assertTrue(flags.encrypt_osd)
+
+    def test_invalid_flag(self):
+        """Unknown flag raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            parse_device_add_flags("invalid:flag")
+        self.assertIn("Unknown flag", str(ctx.exception))
+        self.assertIn("invalid:flag", str(ctx.exception))
+
+    def test_invalid_flag_mixed_with_valid(self):
+        """Mix of valid and invalid flags raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            parse_device_add_flags("wipe:osd,invalid:flag")
+        self.assertIn("Unknown flag", str(ctx.exception))
+
+    def test_phase2_flags_not_supported(self):
+        """Phase 2 flags (wipe:wal, etc.) are not supported yet."""
+        for flag in ["wipe:wal", "wipe:db", "encrypt:wal", "encrypt:db"]:
+            with self.assertRaises(
+                ValueError, msg=f"Flag {flag} should not be supported in Phase 1"
+            ) as ctx:
+                parse_device_add_flags(flag)
+            self.assertIn("Unknown flag", str(ctx.exception))
+
+    def test_empty_flag_in_list(self):
+        """Empty flag in comma-separated list is ignored."""
+        flags = parse_device_add_flags("wipe:osd,,encrypt:osd")
+        self.assertTrue(flags.wipe_osd)
+        self.assertTrue(flags.encrypt_osd)
+
+    def test_returns_dataclass(self):
+        """Result is a DeviceAddFlags dataclass."""
+        flags = parse_device_add_flags("wipe:osd")
+        self.assertIsInstance(flags, DeviceAddFlags)

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -260,3 +260,69 @@ class TestMicroCeph(unittest.TestCase):
                 "--wipe",
             ]
         )
+
+    @patch("utils.run_cmd")
+    def test_add_osd_match_cmd_basic(self, run_cmd):
+        """Test add_osd_match_cmd with basic DSL expression."""
+        microceph.add_osd_match_cmd("eq(@type,'nvme')")
+        run_cmd.assert_called_with(["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')"])
+
+    @patch("utils.run_cmd")
+    def test_add_osd_match_cmd_with_wipe(self, run_cmd):
+        """Test add_osd_match_cmd with wipe flag."""
+        microceph.add_osd_match_cmd("eq(@type,'nvme')", wipe=True)
+        run_cmd.assert_called_with(
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--wipe"]
+        )
+
+    @patch("utils.run_cmd")
+    def test_add_osd_match_cmd_with_encrypt(self, run_cmd):
+        """Test add_osd_match_cmd with encrypt flag."""
+        microceph.add_osd_match_cmd("eq(@type,'nvme')", encrypt=True)
+        run_cmd.assert_called_with(
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--encrypt"]
+        )
+
+    @patch("utils.run_cmd")
+    def test_add_osd_match_cmd_with_dry_run(self, run_cmd):
+        """Test add_osd_match_cmd with dry_run flag."""
+        microceph.add_osd_match_cmd("eq(@type,'nvme')", dry_run=True)
+        run_cmd.assert_called_with(
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--dry-run"]
+        )
+
+    @patch("utils.run_cmd")
+    def test_add_osd_match_cmd_all_options(self, run_cmd):
+        """Test add_osd_match_cmd with all options enabled."""
+        microceph.add_osd_match_cmd(
+            "and(eq(@type,'nvme'),ge(@size,100GiB))",
+            wipe=True,
+            encrypt=True,
+            dry_run=True,
+        )
+        run_cmd.assert_called_with(
+            [
+                "microceph",
+                "disk",
+                "add",
+                "--osd-match",
+                "and(eq(@type,'nvme'),ge(@size,100GiB))",
+                "--wipe",
+                "--encrypt",
+                "--dry-run",
+            ]
+        )
+
+    @patch("utils.run_cmd")
+    def test_add_osd_match_cmd_complex_dsl(self, run_cmd):
+        """Test add_osd_match_cmd with complex DSL expression from spec."""
+        dsl = "or(and(re(@host,'^compute-'),re(@vendor,'Samsung')),and(re(@host,'^stor-'),re(@vendor,'Seagate')))"
+        microceph.add_osd_match_cmd(dsl)
+        run_cmd.assert_called_with(["microceph", "disk", "add", "--osd-match", dsl])
+
+    @patch("utils.run_cmd")
+    def test_add_osd_match_cmd_returns_output(self, run_cmd):
+        """Test add_osd_match_cmd returns command output."""
+        run_cmd.return_value = "Matched 3 devices: /dev/nvme0n1, /dev/nvme1n1, /dev/nvme2n1"
+        result = microceph.add_osd_match_cmd("eq(@type,'nvme')", dry_run=True)
+        self.assertEqual(result, "Matched 3 devices: /dev/nvme0n1, /dev/nvme1n1, /dev/nvme2n1")

--- a/tests/unit/test_storage_osd_config.py
+++ b/tests/unit/test_storage_osd_config.py
@@ -1,0 +1,275 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for StorageHandler._on_config_changed_osd_devices."""
+
+from subprocess import CalledProcessError, TimeoutExpired
+from unittest.mock import MagicMock, patch
+
+import ops_sunbeam.test_utils as test_utils
+from unit import testbase
+
+import charm
+
+
+class TestConfigChangedOsdDevices(testbase.TestBaseCharm):
+    """Tests for the osd-devices config-changed handler."""
+
+    PATCHES = ["subprocess"]
+
+    def setUp(self):
+        super().setUp(charm, self.PATCHES)
+        with open("config.yaml", "r") as f:
+            config_data = f.read()
+        with open("metadata.yaml", "r") as f:
+            metadata = f.read()
+        self.harness = test_utils.get_harness(
+            testbase._MicroCephCharm,
+            container_calls=self.container_calls,
+            charm_config=config_data,
+            charm_metadata=metadata,
+        )
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+    def _setup_ready_charm(self):
+        """Set up peer relation and mock ready_for_service to return True."""
+        test_utils.add_complete_peer_relation(self.harness)
+        self.harness._charm.peers.interface.state.joined = True
+        self.harness.charm.ready_for_service = MagicMock(return_value=True)
+
+    def _call_handler(self, event=None):
+        """Call the osd-devices config-changed handler with a mock event."""
+        if event is None:
+            event = MagicMock()
+        self.harness.charm.storage._on_config_changed_osd_devices(event)
+        return event
+
+    # --- Skip when not configured ---
+
+    def test_empty_osd_devices_skips(self):
+        """Handler returns early when osd-devices is empty."""
+        self.harness.update_config({"osd-devices": ""})
+        event = self._call_handler()
+        event.defer.assert_not_called()
+
+    def test_whitespace_osd_devices_skips(self):
+        """Handler returns early when osd-devices is whitespace."""
+        self.harness.update_config({"osd-devices": "   "})
+        event = self._call_handler()
+        event.defer.assert_not_called()
+
+    @patch("utils.subprocess")
+    def test_unchanged_config_skips_snap_call(self, subprocess):
+        """Handler skips snap call when osd-devices config is unchanged."""
+        self._setup_ready_charm()
+        self.harness.update_config(
+            {"osd-devices": "eq(@type,'nvme')", "device-add-flags": "wipe:osd"}
+        )
+        self.harness.charm.storage._stored.last_osd_devices = "eq(@type,'nvme')"
+        self.harness.charm.storage._stored.last_wipe_osd = True
+        self.harness.charm.storage._stored.last_encrypt_osd = False
+
+        subprocess.run.reset_mock()
+        self._call_handler()
+
+        subprocess.run.assert_not_called()
+
+    def test_empty_osd_devices_resets_config_cache(self):
+        """Handler clears cached config when osd-devices is empty."""
+        self.harness.charm.storage._stored.last_osd_devices = "eq(@type,'nvme')"
+        self.harness.charm.storage._stored.last_wipe_osd = True
+        self.harness.charm.storage._stored.last_encrypt_osd = True
+        self.harness.update_config({"osd-devices": "", "device-add-flags": "wipe:osd"})
+
+        self._call_handler()
+
+        self.assertEqual(self.harness.charm.storage._stored.last_osd_devices, "")
+        self.assertFalse(self.harness.charm.storage._stored.last_wipe_osd)
+        self.assertFalse(self.harness.charm.storage._stored.last_encrypt_osd)
+
+    # --- Defer when not ready ---
+
+    @patch("microceph.is_ready", return_value=False)
+    def test_not_ready_defers(self, _is_ready):
+        """Handler defers when cluster is not ready."""
+        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
+        event = self._call_handler()
+        event.defer.assert_called_once()
+
+    # --- Successful OSD enrollment ---
+
+    @patch("utils.subprocess")
+    def test_success_calls_add_osd_match(self, subprocess):
+        """Handler calls microceph disk add with the DSL expression."""
+        self._setup_ready_charm()
+        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
+
+        self._call_handler()
+
+        subprocess.run.assert_called_with(
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=180,
+        )
+
+    @patch("utils.subprocess")
+    def test_success_with_wipe_flag(self, subprocess):
+        """Handler passes --wipe when wipe:osd flag is set."""
+        self._setup_ready_charm()
+        self.harness.update_config(
+            {"osd-devices": "eq(@type,'nvme')", "device-add-flags": "wipe:osd"}
+        )
+
+        self._call_handler()
+
+        subprocess.run.assert_called_with(
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--wipe"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=180,
+        )
+
+    @patch("utils.subprocess")
+    def test_success_with_encrypt_flag(self, subprocess):
+        """Handler passes --encrypt when encrypt:osd flag is set."""
+        self._setup_ready_charm()
+        self.harness.update_config(
+            {"osd-devices": "eq(@type,'nvme')", "device-add-flags": "encrypt:osd"}
+        )
+
+        self._call_handler()
+
+        subprocess.run.assert_called_with(
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--encrypt"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=180,
+        )
+
+    @patch("utils.subprocess")
+    def test_success_with_all_flags(self, subprocess):
+        """Handler passes both --wipe and --encrypt when both flags are set."""
+        self._setup_ready_charm()
+        self.harness.update_config(
+            {"osd-devices": "eq(@type,'nvme')", "device-add-flags": "wipe:osd,encrypt:osd"}
+        )
+
+        self._call_handler()
+
+        subprocess.run.assert_called_with(
+            [
+                "microceph",
+                "disk",
+                "add",
+                "--osd-match",
+                "eq(@type,'nvme')",
+                "--wipe",
+                "--encrypt",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=180,
+        )
+
+    @patch("utils.subprocess")
+    def test_strips_whitespace_from_dsl(self, subprocess):
+        """Handler strips leading/trailing whitespace from the DSL expression."""
+        self._setup_ready_charm()
+        self.harness.update_config({"osd-devices": "  eq(@type,'nvme')  "})
+
+        self._call_handler()
+
+        subprocess.run.assert_called_with(
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=180,
+        )
+
+    # --- No devices matched (not an error) ---
+
+    @patch("utils.subprocess")
+    def test_no_devices_matched_stays_active(self, subprocess):
+        """Handler does not defer or crash when snap reports no devices matched."""
+        self._setup_ready_charm()
+        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
+
+        subprocess.CalledProcessError = CalledProcessError
+        subprocess.run.side_effect = CalledProcessError(
+            returncode=1, cmd=["microceph"], stderr="Error: no devices matched the expression"
+        )
+
+        event = self._call_handler()
+        event.defer.assert_not_called()
+
+    # --- CalledProcessError (real error) ---
+
+    @patch("utils.subprocess")
+    def test_snap_error_does_not_crash(self, subprocess):
+        """Handler handles snap failure without unhandled exception."""
+        self._setup_ready_charm()
+        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
+
+        subprocess.CalledProcessError = CalledProcessError
+        subprocess.run.side_effect = CalledProcessError(
+            returncode=1, cmd=["microceph"], stderr="Error: some snap failure"
+        )
+
+        event = self._call_handler()
+        event.defer.assert_not_called()
+
+    @patch("utils.subprocess")
+    def test_snap_error_with_empty_stderr(self, subprocess):
+        """Handler handles CalledProcessError with empty stderr without crash."""
+        self._setup_ready_charm()
+        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
+
+        subprocess.CalledProcessError = CalledProcessError
+        subprocess.run.side_effect = CalledProcessError(returncode=1, cmd=["microceph"], stderr="")
+
+        event = self._call_handler()
+        event.defer.assert_not_called()
+
+    @patch("utils.subprocess")
+    def test_snap_timeout_does_not_crash(self, subprocess):
+        """Handler handles snap timeout without unhandled exception."""
+        self._setup_ready_charm()
+        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
+
+        subprocess.CalledProcessError = CalledProcessError
+        subprocess.TimeoutExpired = TimeoutExpired
+        subprocess.run.side_effect = TimeoutExpired(cmd=["microceph"], timeout=180)
+
+        event = self._call_handler()
+        event.defer.assert_not_called()
+
+    # --- Invalid device-add-flags ---
+
+    @patch("utils.subprocess")
+    def test_invalid_flags_does_not_call_snap(self, subprocess):
+        """Handler does not call snap when device-add-flags are invalid."""
+        self._setup_ready_charm()
+        self.harness.update_config(
+            {"osd-devices": "eq(@type,'nvme')", "device-add-flags": "invalid:flag"}
+        )
+
+        self._call_handler()
+        subprocess.run.assert_not_called()


### PR DESCRIPTION
# Description

Added new configuration options in config.yaml (osd-devices, device-add-flags) to support DSL-based OSD device selection and flag-driven enrollment behavior.

Added test helpers, unit, integration tests.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Additional tests

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
