### PR TITLE
fix: ensure swift admin endpoint ends with /v1

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -273,7 +273,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
                 "description": "Object Store service",
                 "internal_url": swift_url,
                 "public_url": swift_url,
-                "admin_url": f"{ingress_url}/swift",
+                "admin_url": f"{ingress_url}/swift/v1",
             },
             {
                 "service_name": "s3",


### PR DESCRIPTION
OpenStack documentation [0] uses /v1 as the admin endpoint.

0: https://docs.openstack.org/swift/latest/install/controller-install-ubuntu.html

Other projects also configure it to /v1
OpenStack Ansible
https://opendev.org/openstack/openstack-ansible/commit/c700fdba0da5563f07935f0d7cba7d75ad586a23

The ceph documentation tutorial registers it to /v1

https://docs.ceph.com/en/reef/radosgw/keystone/

Triple directly states

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

## Contributor's Checklist

Please check that you have:

- [X] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
