### PR TITLE
feat: auto-create CephFS when client requests MDS permissions

### DIFF
--- a/src/ceph_broker.py
+++ b/src/ceph_broker.py
@@ -49,6 +49,8 @@ from ceph import (
     snapshot_pool,
 )
 
+DEFAULT_CEPHFS_NAME = "cephfs"
+
 
 def decode_req_encode_rsp(f):
     """Decorator to decode incoming requests and encode responses."""
@@ -839,22 +841,18 @@ def handle_put_osd_in_bucket(request, service):
         return {"exit-code": 1, "stderr": msg}
 
 
-def _ensure_cephfs_for_client(permissions, service):
+def _ensure_cephfs_for_client(permissions):
     """Auto-create a default CephFS if the client requests MDS caps and none exists."""
-    # Check if permissions include MDS capabilities
-    has_mds = False
-    for perm in permissions:
-        if perm == "mds":
-            has_mds = True
-            break
-    if not has_mds:
+    if "mds" not in permissions:
+        log("No MDS capabilities requested, skipping CephFS check", level=DEBUG)
         return
 
-    # Check if the default 'cephfs' volume already exists
+    # Check if the default CephFS volume already exists
     try:
         fs_volumes = list_fs_volumes()
         for vol in fs_volumes:
-            if vol.get("name") == "cephfs":
+            if vol.get("name") == DEFAULT_CEPHFS_NAME:
+                log("CephFS volume '{}' already exists".format(DEFAULT_CEPHFS_NAME), level=DEBUG)
                 return
     except Exception:
         log("Failed to list CephFS volumes", level=WARNING)
@@ -862,11 +860,14 @@ def _ensure_cephfs_for_client(permissions, service):
 
     # Create default CephFS volume (auto-creates pools and assigns MDS)
     log(
-        "Client requested MDS caps but no 'cephfs' volume exists. Creating it now.",
+        "Client requested MDS caps but no '{}' volume exists. Creating it now.".format(
+            DEFAULT_CEPHFS_NAME
+        ),
         level=INFO,
     )
     try:
-        create_fs_volume("cephfs")
+        create_fs_volume(DEFAULT_CEPHFS_NAME)
+        log("Successfully created CephFS volume '{}'".format(DEFAULT_CEPHFS_NAME), level=DEBUG)
     except Exception as e:
         log("Failed to auto-create CephFS volume: {}".format(e), level=ERROR)
 
@@ -887,9 +888,10 @@ def handle_set_key_permissions(request, service):
         check_call(call)
     except CalledProcessError as e:
         log("Error updating key capabilities: {}".format(e), level=ERROR)
+        return
 
     # Auto-create CephFS if client requests MDS capabilities
-    _ensure_cephfs_for_client(permissions, service)
+    _ensure_cephfs_for_client(permissions)
 
 
 def handle_add_permissions_to_key(request, service):

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -274,6 +274,74 @@ class TestBroker(test_utils.CharmTestCase):
         list_fs_volumes.assert_not_called()
         create_fs_volume.assert_not_called()
 
+    @patch.object(broker, "create_fs_volume")
+    @patch.object(broker, "list_fs_volumes")
+    @patch.object(broker, "check_call")
+    def test_set_key_permissions_list_fs_volumes_fails(
+        self, check_call, list_fs_volumes, create_fs_volume
+    ):
+        """When list_fs_volumes raises, log warning and skip creation."""
+        list_fs_volumes.side_effect = Exception("ceph command failed")
+        req = {
+            "client": "ceph-csi",
+            "permissions": [
+                "mon",
+                "allow r",
+                "mds",
+                "allow rw",
+            ],
+        }
+        broker.handle_set_key_permissions(req, "admin")
+        check_call.assert_called_once()
+        list_fs_volumes.assert_called_once()
+        create_fs_volume.assert_not_called()
+
+    @patch.object(broker, "create_fs_volume")
+    @patch.object(broker, "list_fs_volumes")
+    @patch.object(broker, "check_call")
+    def test_set_key_permissions_create_fs_volume_fails(
+        self, check_call, list_fs_volumes, create_fs_volume
+    ):
+        """When create_fs_volume raises, log error and continue."""
+        list_fs_volumes.return_value = []
+        create_fs_volume.side_effect = Exception("ceph fs volume create failed")
+        req = {
+            "client": "ceph-csi",
+            "permissions": [
+                "mon",
+                "allow r",
+                "mds",
+                "allow rw",
+            ],
+        }
+        # Should not raise
+        broker.handle_set_key_permissions(req, "admin")
+        check_call.assert_called_once()
+        list_fs_volumes.assert_called_once()
+        create_fs_volume.assert_called_once_with(broker.DEFAULT_CEPHFS_NAME)
+
+    @patch.object(broker, "create_fs_volume")
+    @patch.object(broker, "list_fs_volumes")
+    @patch.object(broker, "check_call")
+    def test_set_key_permissions_check_call_fails(
+        self, check_call, list_fs_volumes, create_fs_volume
+    ):
+        """When check_call fails, do not attempt CephFS creation."""
+        check_call.side_effect = broker.CalledProcessError(1, "ceph auth caps")
+        req = {
+            "client": "ceph-csi",
+            "permissions": [
+                "mon",
+                "allow r",
+                "mds",
+                "allow rw",
+            ],
+        }
+        broker.handle_set_key_permissions(req, "admin")
+        check_call.assert_called_once()
+        list_fs_volumes.assert_not_called()
+        create_fs_volume.assert_not_called()
+
     @patch("ceph.check_call")
     @patch("ceph.check_output")
     def test_broker_misc(self, check_output, check_call):


### PR DESCRIPTION
When a ceph-client (e.g. ceph-csi with cephfs-enable=true) sends a set-key-permissions broker request that includes MDS capabilities, auto-create a default 'cephfs' volume if none exists. This prevents ceph-csi from entering blocked state due to missing filesystem listing.