### PR TITLE
fix: ensure rgw restart on last changed config in update_cluster_configs

### DIFF
--- a/src/microceph.py
+++ b/src/microceph.py
@@ -166,11 +166,16 @@ def update_cluster_configs(configs: dict):
         except UnrecognizedClusterConfigOption:
             raise UnrecognizedClusterConfigOption(f"Option {key} not recognized by microceph")
 
-    # Set config, but restart only on the last item
-    items = sorted(configs.items())
-    for key, value in items[:-1]:
+    # Only trigger restart on the last *changed* item to avoid multiple restarts.
+    changed = [
+        (k, v)
+        for k, v in sorted(configs.items())
+        if not (k in configs_from_db and v == configs_from_db.get(k))
+    ]
+    for key, value in changed[:-1]:
         set_config(key, value, skip_restart=True)
-    set_config(items[-1][0], items[-1][1], skip_restart=False)
+    if changed:
+        set_config(changed[-1][0], changed[-1][1], skip_restart=False)
 
 
 def delete_cluster_configs(configs: list):

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -109,6 +109,34 @@ class TestMicroCeph(unittest.TestCase):
         cclient.from_socket().cluster.update_config.assert_not_called()
 
     @patch("microceph.Client")
+    def test_update_cluster_configs_triggers_restart_when_last_alphabetical_unchanged(
+        self, cclient
+    ):
+        """Regression test for GH#246: restart must fire exactly once when configs change.
+
+        When TLS is enabled, rgw_keystone_url and rgw_keystone_verify_ssl change.
+        """
+        cclient.from_socket().cluster.get_config.return_value = [
+            {"key": "rgw_keystone_url", "value": "http://dummy-ip", "wait": False},
+            {"key": "rgw_keystone_verify_ssl", "value": "false", "wait": False},
+            {"key": "rgw_swift_versioning_enabled", "value": "true", "wait": False},
+        ]
+        configs_to_update = {
+            "rgw_keystone_url": "https://dummy-ip",  # changed
+            "rgw_keystone_verify_ssl": "true",  # changed
+            "rgw_swift_versioning_enabled": "true",  # NOT changed
+        }
+        microceph.update_cluster_configs(configs_to_update)
+
+        update_calls = cclient.from_socket().cluster.update_config.mock_calls
+        skip_restart_values = [call.args[2] for call in update_calls]
+        # Exactly one restart must be triggered regardless of how many configs changed
+        assert skip_restart_values.count(False) == 1, (
+            f"Expected exactly one update_config call with skip_restart=False, "
+            f"got: {skip_restart_values}"
+        )
+
+    @patch("microceph.Client")
     def test_delete_cluster_configs(self, cclient):
         """Test delete_cluster_configs with configs to delete not in db."""
         cclient.from_socket().cluster.get_config.return_value = [

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -15,7 +15,7 @@
 """Tests for Microceph helper functions."""
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import microceph
 
@@ -128,13 +128,16 @@ class TestMicroCeph(unittest.TestCase):
         }
         microceph.update_cluster_configs(configs_to_update)
 
-        update_calls = cclient.from_socket().cluster.update_config.mock_calls
-        skip_restart_values = [call.args[2] for call in update_calls]
-        # Exactly one restart must be triggered regardless of how many configs changed
-        assert skip_restart_values.count(False) == 1, (
-            f"Expected exactly one update_config call with skip_restart=False, "
-            f"got: {skip_restart_values}"
+        cluster = cclient.from_socket().cluster
+        # Exactly one restart must be triggered regardless of how many configs changed,
+        # on the last changed key in sorted order, with all prior keys skipping restart.
+        cluster.update_config.assert_has_calls(
+            [
+                call("rgw_keystone_url", "https://dummy-ip", True),
+                call("rgw_keystone_verify_ssl", "true", False),
+            ]
         )
+        assert cluster.update_config.call_count == 2
 
     @patch("microceph.Client")
     def test_delete_cluster_configs(self, cclient):


### PR DESCRIPTION
restarts rgw clusterwide, whenever (>=1) rgw cluster configs are changed. 
closes: #246 