### PR TITLE
fix: handle UNIQUE constraint table rename, fix quorum check command, and guard departed unit data access

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -32,4 +32,3 @@ parts:
       - astral-uv
     build-packages:
       - git
-

--- a/src/ceph.py
+++ b/src/ceph.py
@@ -1201,7 +1201,7 @@ def cluster_has_quorum() -> bool:
     In adopted ceph environments, microceph may not have a local mon up.
     Thus, this method checks if the accessible ceph cluster has some quorum.
     """
-    cmd = ["ceph", "status", "--format=json"]
+    cmd = ["microceph.ceph", "status", "--format=json"]
     try:
         result = json.loads(str(check_output(cmd).decode("UTF-8")))
     except CalledProcessError:

--- a/src/cluster.py
+++ b/src/cluster.py
@@ -66,11 +66,9 @@ class ClusterNodes(ops.framework.Object):
             self.charm.peers.set_app_data({f"{event.unit.name}.join_token": token})
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.warning(e.stderr)
-            error_node_already_exists = (
-                'Failed to create "internal_token_records" entry: UNIQUE '
-                "constraint failed: internal_token_records.name"
-            )
-            if error_node_already_exists not in e.stderr:
+            # MicroCeph renamed the table from internal_token_records to
+            # core_token_records in the squid release. Handle both.
+            if "UNIQUE constraint failed" not in e.stderr or "token_records.name" not in e.stderr:
                 raise e
 
     def join_node_to_cluster(self, event: ops.framework.EventBase) -> None:

--- a/src/relation_handlers.py
+++ b/src/relation_handlers.py
@@ -557,8 +557,8 @@ class CephClientProvides(Object):
             "- providing client with keys, processing broker requests"
         )
 
-        settings = relation.data[unit]
-        if "broker_req" not in settings:
+        settings = relation.data.get(unit)
+        if not settings or "broker_req" not in settings:
             logger.warning(f"broker_req not in settings: {settings}")
             return
 

--- a/tests/unit/test_ceph.py
+++ b/tests/unit/test_ceph.py
@@ -46,6 +46,25 @@ class TestCeph(unittest.TestCase):
         check_output.return_value = b'{"quorum": [ 0 ]}'
         self.assertTrue(ceph.cluster_has_quorum())
 
+    @patch("ceph.check_output")
+    def test_cluster_has_quorum_uses_microceph_ceph(self, check_output):
+        """Verify cluster_has_quorum calls microceph.ceph, not bare ceph."""
+        check_output.return_value = b'{"quorum": [ 0, 1, 2 ]}'
+        ceph.cluster_has_quorum()
+        check_output.assert_called_once_with(["microceph.ceph", "status", "--format=json"])
+
+    @patch("ceph.check_output")
+    def test_cluster_has_quorum_no_quorum(self, check_output):
+        check_output.return_value = b'{"quorum": []}'
+        self.assertFalse(ceph.cluster_has_quorum())
+
+    @patch("ceph.check_output")
+    def test_cluster_has_quorum_command_failure(self, check_output):
+        from subprocess import CalledProcessError
+
+        check_output.side_effect = CalledProcessError(1, "cmd")
+        self.assertFalse(ceph.cluster_has_quorum())
+
     @patch("utils.run_cmd")
     def test_create_fs_volume(self, run_cmd):
         ceph.create_fs_volume("volly")

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1,0 +1,162 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the cluster module — add_node_to_cluster UNIQUE constraint handling."""
+
+import subprocess
+import unittest
+from unittest.mock import MagicMock, patch
+
+import cluster
+
+
+class TestAddNodeToCluster(unittest.TestCase):
+    """Tests for ClusterNodes.add_node_to_cluster."""
+
+    def _make_cluster_nodes(self):
+        """Create a ClusterNodes instance with mocked charm."""
+        charm_mock = MagicMock()
+        charm_mock.peers.get_all_unit_values.return_value = ["test-hostname"]
+        charm_mock.peers.set_app_data = MagicMock()
+        # ClusterNodes.__init__ calls super().__init__ which needs a framework
+        with patch.object(cluster.ops.framework.Object, "__init__"):
+            cn = cluster.ClusterNodes.__new__(cluster.ClusterNodes)
+            cn.charm = charm_mock
+        return cn
+
+    def _make_event(self):
+        event = MagicMock()
+        event.unit = MagicMock()
+        event.unit.name = "microceph/1"
+        return event
+
+    def _make_called_process_error(self, stderr):
+        """Create a CalledProcessError with the given stderr."""
+        err = subprocess.CalledProcessError(1, "microceph cluster add")
+        err.stderr = stderr
+        return err
+
+    @patch("utils.run_cmd")
+    def test_add_node_success(self, run_cmd):
+        """Normal add succeeds and sets join token."""
+        run_cmd.return_value = "test-token\n"
+        cn = self._make_cluster_nodes()
+        event = self._make_event()
+
+        cn.add_node_to_cluster(event)
+
+        run_cmd.assert_called_once_with(["microceph", "cluster", "add", "test-hostname"])
+        cn.charm.peers.set_app_data.assert_called_once_with(
+            {"microceph/1.join_token": "test-token"}
+        )
+
+    @patch("utils.run_cmd")
+    def test_add_node_unique_constraint_core_token_records(self, run_cmd):
+        """UNIQUE constraint on core_token_records (squid+) is handled gracefully."""
+        run_cmd.side_effect = self._make_called_process_error(
+            'Error: Failed to create "core_token_records" entry: '
+            "UNIQUE constraint failed: core_token_records.name"
+        )
+        cn = self._make_cluster_nodes()
+        event = self._make_event()
+
+        # Should NOT raise
+        cn.add_node_to_cluster(event)
+        cn.charm.peers.set_app_data.assert_not_called()
+
+    @patch("utils.run_cmd")
+    def test_add_node_unique_constraint_internal_token_records(self, run_cmd):
+        """UNIQUE constraint on internal_token_records (pre-squid) is handled gracefully."""
+        run_cmd.side_effect = self._make_called_process_error(
+            'Error: Failed to create "internal_token_records" entry: '
+            "UNIQUE constraint failed: internal_token_records.name"
+        )
+        cn = self._make_cluster_nodes()
+        event = self._make_event()
+
+        # Should NOT raise
+        cn.add_node_to_cluster(event)
+        cn.charm.peers.set_app_data.assert_not_called()
+
+    @patch("utils.run_cmd")
+    def test_add_node_unique_constraint_future_table_name(self, run_cmd):
+        """UNIQUE constraint on a hypothetical future table name is also handled."""
+        run_cmd.side_effect = self._make_called_process_error(
+            'Error: Failed to create "whatever_token_records" entry: '
+            "UNIQUE constraint failed: whatever_token_records.name"
+        )
+        cn = self._make_cluster_nodes()
+        event = self._make_event()
+
+        # Should NOT raise — substring match covers any *_token_records table
+        cn.add_node_to_cluster(event)
+        cn.charm.peers.set_app_data.assert_not_called()
+
+    @patch("utils.run_cmd")
+    def test_add_node_other_unique_constraint_raises(self, run_cmd):
+        """A UNIQUE constraint on a non-token_records table should still raise."""
+        run_cmd.side_effect = self._make_called_process_error(
+            "UNIQUE constraint failed: some_other_table.column"
+        )
+        cn = self._make_cluster_nodes()
+        event = self._make_event()
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            cn.add_node_to_cluster(event)
+
+    @patch("utils.run_cmd")
+    def test_add_node_other_error_raises(self, run_cmd):
+        """Non-UNIQUE errors should propagate."""
+        run_cmd.side_effect = self._make_called_process_error(
+            "Error: something completely different went wrong"
+        )
+        cn = self._make_cluster_nodes()
+        event = self._make_event()
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            cn.add_node_to_cluster(event)
+
+    @patch("utils.run_cmd")
+    def test_add_node_timeout_error_raises(self, run_cmd):
+        """Timeout errors should propagate."""
+        err = subprocess.TimeoutExpired("microceph cluster add", 30)
+        err.stderr = ""
+        run_cmd.side_effect = err
+        cn = self._make_cluster_nodes()
+        event = self._make_event()
+
+        with self.assertRaises(subprocess.TimeoutExpired):
+            cn.add_node_to_cluster(event)
+
+    def test_add_node_no_unit(self):
+        """Event without unit should return early."""
+        cn = self._make_cluster_nodes()
+        event = MagicMock()
+        event.unit = None
+
+        cn.add_node_to_cluster(event)
+        cn.charm.peers.get_all_unit_values.assert_not_called()
+
+    def test_add_node_no_hostname(self):
+        """No hostname found should return early."""
+        cn = self._make_cluster_nodes()
+        cn.charm.peers.get_all_unit_values.return_value = []
+        event = self._make_event()
+
+        cn.add_node_to_cluster(event)
+        cn.charm.peers.set_app_data.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description

When investigating a fix for a customer issue, fixed the following:

- cluster.py: Change substring matching when handling errors after running "microceph cluster add"
  Table internal_token_records was changed to core_token_records.
  Change to table names was introduced in: https://github.com/canonical/microcluster/pull/137  
  Fixes #187


- ceph.py: change cluster_has_quorum() to call "microceph.ceph".
  It seems like it was forgotten from when all other calls when changed from "ceph" to "microcloud.ceph"
  Fixes #252


- relation_handlers.py: Add safety guard in _process_broker_request() to avoid KeyError
  when getting relation data for a unit that may no longer be available during departure
  Fixes #253




## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Reproduced the issue with a deployment on LXD VMs
- Tested the fix in the same environment with `juju refresh`
- Added the following testing:
    - `tests/unit/test_cluster.py` (9 new tests): Covers UNIQUE constraint handling for both old and new table names, plus edge cases (other errors propagate, no unit, no hostname).
    - `tests/unit/test_ceph.py` (3 new tests): Verifies `cluster_has_quorum()` calls `microceph.ceph`, handles empty quorum, and handles command failure.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] added tests to verify effectiveness of this change.
