### PR TITLE
fix: raise disk timeout for osd-match

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -19,6 +19,10 @@ platforms:
 
 parts:
   charm:
+    build-environment:
+      - CARGO: /usr/bin/cargo-1.85
+      - RUSTC: /usr/bin/rustc-1.85
+      - MATURIN_NO_INSTALL_RUST: "1"
     build-packages:
       - git
       - libffi-dev

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -37,6 +37,8 @@ MAJOR_VERSIONS = {
     "19": "squid",
 }
 
+OSD_MATCH_CMD_TIMEOUT = 1200
+
 
 def is_ready() -> bool:
     """Check if microceph snap is installed and bootstrapped/joined."""
@@ -403,7 +405,7 @@ def add_osd_match_cmd(
         cmd.append("--encrypt")
     if dry_run:
         cmd.append("--dry-run")
-    return utils.run_cmd(cmd)
+    return utils.run_cmd(cmd, timeout=OSD_MATCH_CMD_TIMEOUT)
 
 
 def get_snap_info(snap_name):

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -265,14 +265,18 @@ class TestMicroCeph(unittest.TestCase):
     def test_add_osd_match_cmd_basic(self, run_cmd):
         """Test add_osd_match_cmd with basic DSL expression."""
         microceph.add_osd_match_cmd("eq(@type,'nvme')")
-        run_cmd.assert_called_with(["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')"])
+        run_cmd.assert_called_with(
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')"],
+            timeout=1200,
+        )
 
     @patch("utils.run_cmd")
     def test_add_osd_match_cmd_with_wipe(self, run_cmd):
         """Test add_osd_match_cmd with wipe flag."""
         microceph.add_osd_match_cmd("eq(@type,'nvme')", wipe=True)
         run_cmd.assert_called_with(
-            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--wipe"]
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--wipe"],
+            timeout=1200,
         )
 
     @patch("utils.run_cmd")
@@ -280,7 +284,8 @@ class TestMicroCeph(unittest.TestCase):
         """Test add_osd_match_cmd with encrypt flag."""
         microceph.add_osd_match_cmd("eq(@type,'nvme')", encrypt=True)
         run_cmd.assert_called_with(
-            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--encrypt"]
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--encrypt"],
+            timeout=1200,
         )
 
     @patch("utils.run_cmd")
@@ -288,7 +293,8 @@ class TestMicroCeph(unittest.TestCase):
         """Test add_osd_match_cmd with dry_run flag."""
         microceph.add_osd_match_cmd("eq(@type,'nvme')", dry_run=True)
         run_cmd.assert_called_with(
-            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--dry-run"]
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--dry-run"],
+            timeout=1200,
         )
 
     @patch("utils.run_cmd")
@@ -310,7 +316,8 @@ class TestMicroCeph(unittest.TestCase):
                 "--wipe",
                 "--encrypt",
                 "--dry-run",
-            ]
+            ],
+            timeout=1200,
         )
 
     @patch("utils.run_cmd")
@@ -318,7 +325,7 @@ class TestMicroCeph(unittest.TestCase):
         """Test add_osd_match_cmd with complex DSL expression from spec."""
         dsl = "or(and(re(@host,'^compute-'),re(@vendor,'Samsung')),and(re(@host,'^stor-'),re(@vendor,'Seagate')))"
         microceph.add_osd_match_cmd(dsl)
-        run_cmd.assert_called_with(["microceph", "disk", "add", "--osd-match", dsl])
+        run_cmd.assert_called_with(["microceph", "disk", "add", "--osd-match", dsl], timeout=1200)
 
     @patch("utils.run_cmd")
     def test_add_osd_match_cmd_returns_output(self, run_cmd):

--- a/tests/unit/test_storage_osd_config.py
+++ b/tests/unit/test_storage_osd_config.py
@@ -123,7 +123,7 @@ class TestConfigChangedOsdDevices(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=1200,
         )
 
     @patch("utils.subprocess")
@@ -141,7 +141,7 @@ class TestConfigChangedOsdDevices(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=1200,
         )
 
     @patch("utils.subprocess")
@@ -159,7 +159,7 @@ class TestConfigChangedOsdDevices(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=1200,
         )
 
     @patch("utils.subprocess")
@@ -185,7 +185,7 @@ class TestConfigChangedOsdDevices(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=1200,
         )
 
     @patch("utils.subprocess")
@@ -201,7 +201,7 @@ class TestConfigChangedOsdDevices(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=1200,
         )
 
     # --- No devices matched (not an error) ---
@@ -256,7 +256,7 @@ class TestConfigChangedOsdDevices(testbase.TestBaseCharm):
 
         subprocess.CalledProcessError = CalledProcessError
         subprocess.TimeoutExpired = TimeoutExpired
-        subprocess.run.side_effect = TimeoutExpired(cmd=["microceph"], timeout=180)
+        subprocess.run.side_effect = TimeoutExpired(cmd=["microceph"], timeout=1200)
 
         event = self._call_handler()
         event.defer.assert_not_called()


### PR DESCRIPTION
# Description

Drastically raise disk timeout for osd-match. Especially with wiping and encryption, adding disks can become time consuming.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Existing tests

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
