### PR TITLE
fix: increase timeout for OSD disk add operations

### DIFF
--- a/src/microceph.py
+++ b/src/microceph.py
@@ -335,7 +335,7 @@ def add_osd_cmd(
         _setup_dm_crypt()
         cmd.append("--encrypt")
 
-    utils.run_cmd(cmd)
+    utils.run_cmd(cmd, timeout=900)
 
 
 def _setup_dm_crypt() -> None:
@@ -408,7 +408,7 @@ def add_osd_match_cmd(
         cmd.append("--encrypt")
     if dry_run:
         cmd.append("--dry-run")
-    return utils.run_cmd(cmd)
+    return utils.run_cmd(cmd, timeout=900)
 
 
 def get_snap_info(snap_name):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -338,7 +338,7 @@ class TestCharm(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=900,
         )
 
     @patch("utils.subprocess")
@@ -363,7 +363,7 @@ class TestCharm(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=900,
         )
         action_event.set_results.assert_called_with(result)
         action_event.fail.assert_called()
@@ -386,7 +386,7 @@ class TestCharm(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=900,
         )
 
     @patch("utils.subprocess")
@@ -407,7 +407,7 @@ class TestCharm(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=900,
         )
 
     @patch("microceph.utils.snap_has_connection", return_value=True)
@@ -436,7 +436,7 @@ class TestCharm(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=900,
         )
 
     @patch("microceph.utils.snap_has_connection", return_value=False)

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -248,14 +248,15 @@ class TestMicroCeph(unittest.TestCase):
     def test_add_osd_cmd(self, run_cmd):
         # Test default call
         microceph.add_osd_cmd("loop,4G,3")
-        run_cmd.assert_called_with(["microceph", "disk", "add", "loop,4G,3"])
+        run_cmd.assert_called_with(["microceph", "disk", "add", "loop,4G,3"], timeout=900)
 
     @patch("utils.run_cmd")
     def test_add_osd_cmd_with_wal(self, run_cmd):
         # Test with WAL device
         microceph.add_osd_cmd("loop,4G,3", wal_dev="/dev/sdb")
         run_cmd.assert_called_with(
-            ["microceph", "disk", "add", "loop,4G,3", "--wal-device", "/dev/sdb", "--wal-wipe"]
+            ["microceph", "disk", "add", "loop,4G,3", "--wal-device", "/dev/sdb", "--wal-wipe"],
+            timeout=900,
         )
 
     @patch("utils.run_cmd")
@@ -263,14 +264,15 @@ class TestMicroCeph(unittest.TestCase):
         # Test with DB device
         microceph.add_osd_cmd("loop,4G,3", db_dev="/dev/sdc")
         run_cmd.assert_called_with(
-            ["microceph", "disk", "add", "loop,4G,3", "--db-device", "/dev/sdc", "--db-wipe"]
+            ["microceph", "disk", "add", "loop,4G,3", "--db-device", "/dev/sdc", "--db-wipe"],
+            timeout=900,
         )
 
     @patch("utils.run_cmd")
     def test_add_osd_cmd_with_wipe(self, run_cmd):
         # Test with wipe flag
         microceph.add_osd_cmd("loop,4G,3", wipe=True)
-        run_cmd.assert_called_with(["microceph", "disk", "add", "loop,4G,3", "--wipe"])
+        run_cmd.assert_called_with(["microceph", "disk", "add", "loop,4G,3", "--wipe"], timeout=900)
 
     @patch("utils.run_cmd")
     def test_add_osd_cmd_all_options(self, run_cmd):
@@ -289,21 +291,24 @@ class TestMicroCeph(unittest.TestCase):
                 "/dev/sdc",
                 "--db-wipe",
                 "--wipe",
-            ]
+            ],
+            timeout=900,
         )
 
     @patch("utils.run_cmd")
     def test_add_osd_match_cmd_basic(self, run_cmd):
         """Test add_osd_match_cmd with basic DSL expression."""
         microceph.add_osd_match_cmd("eq(@type,'nvme')")
-        run_cmd.assert_called_with(["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')"])
+        run_cmd.assert_called_with(
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')"], timeout=900
+        )
 
     @patch("utils.run_cmd")
     def test_add_osd_match_cmd_with_wipe(self, run_cmd):
         """Test add_osd_match_cmd with wipe flag."""
         microceph.add_osd_match_cmd("eq(@type,'nvme')", wipe=True)
         run_cmd.assert_called_with(
-            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--wipe"]
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--wipe"], timeout=900
         )
 
     @patch("utils.run_cmd")
@@ -311,7 +316,8 @@ class TestMicroCeph(unittest.TestCase):
         """Test add_osd_match_cmd with encrypt flag."""
         microceph.add_osd_match_cmd("eq(@type,'nvme')", encrypt=True)
         run_cmd.assert_called_with(
-            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--encrypt"]
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--encrypt"],
+            timeout=900,
         )
 
     @patch("utils.run_cmd")
@@ -319,7 +325,8 @@ class TestMicroCeph(unittest.TestCase):
         """Test add_osd_match_cmd with dry_run flag."""
         microceph.add_osd_match_cmd("eq(@type,'nvme')", dry_run=True)
         run_cmd.assert_called_with(
-            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--dry-run"]
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--dry-run"],
+            timeout=900,
         )
 
     @patch("utils.run_cmd")
@@ -341,7 +348,8 @@ class TestMicroCeph(unittest.TestCase):
                 "--wipe",
                 "--encrypt",
                 "--dry-run",
-            ]
+            ],
+            timeout=900,
         )
 
     @patch("utils.run_cmd")
@@ -349,7 +357,7 @@ class TestMicroCeph(unittest.TestCase):
         """Test add_osd_match_cmd with complex DSL expression from spec."""
         dsl = "or(and(re(@host,'^compute-'),re(@vendor,'Samsung')),and(re(@host,'^stor-'),re(@vendor,'Seagate')))"
         microceph.add_osd_match_cmd(dsl)
-        run_cmd.assert_called_with(["microceph", "disk", "add", "--osd-match", dsl])
+        run_cmd.assert_called_with(["microceph", "disk", "add", "--osd-match", dsl], timeout=900)
 
     @patch("utils.run_cmd")
     def test_add_osd_match_cmd_returns_output(self, run_cmd):

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -272,7 +272,9 @@ class TestMicroCeph(unittest.TestCase):
     def test_add_osd_cmd_with_wipe(self, run_cmd):
         # Test with wipe flag
         microceph.add_osd_cmd("loop,4G,3", wipe=True)
-        run_cmd.assert_called_with(["microceph", "disk", "add", "loop,4G,3", "--wipe"], timeout=900)
+        run_cmd.assert_called_with(
+            ["microceph", "disk", "add", "loop,4G,3", "--wipe"], timeout=900
+        )
 
     @patch("utils.run_cmd")
     def test_add_osd_cmd_all_options(self, run_cmd):

--- a/tests/unit/test_storage_osd_config.py
+++ b/tests/unit/test_storage_osd_config.py
@@ -123,7 +123,7 @@ class TestConfigChangedOsdDevices(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=900,
         )
 
     @patch("utils.subprocess")
@@ -141,7 +141,7 @@ class TestConfigChangedOsdDevices(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=900,
         )
 
     @patch("utils.subprocess")
@@ -159,7 +159,7 @@ class TestConfigChangedOsdDevices(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=900,
         )
 
     @patch("utils.subprocess")
@@ -185,7 +185,7 @@ class TestConfigChangedOsdDevices(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=900,
         )
 
     @patch("utils.subprocess")
@@ -201,7 +201,7 @@ class TestConfigChangedOsdDevices(testbase.TestBaseCharm):
             capture_output=True,
             text=True,
             check=True,
-            timeout=180,
+            timeout=900,
         )
 
     # --- No devices matched (not an error) ---


### PR DESCRIPTION
## Summary

- Increase subprocess timeout for `add_osd_cmd` and `add_osd_match_cmd` from 180s to 900s
- Bulk OSD enrollment with `--wipe` and `--encrypt` flags can easily exceed the 3-minute default, causing "context deadline exceeded" failures

## Root Cause

Both `add_osd_cmd()` and `add_osd_match_cmd()` in `microceph.py` called `utils.run_cmd(cmd)` without a timeout override, inheriting the 180s default. When adding many OSDs simultaneously (e.g. 12 disks with `--wipe --encrypt`), the snap-level operation exceeds this limit.

## Test plan

- [x] All 84 unit tests pass (`test_microceph.py`, `test_storage_osd_config.py`, `test_charm.py`)
- [ ] Verify with a multi-disk deployment that OSD enrollment completes without timeout

Closes #257