### PR TITLE
feat: waldb dsl storage config

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -594,7 +594,7 @@ jobs:
           # constraints to deploy on virtual machine.
           juju deploy ~/artifacts/microceph.charm --storage osd-standalone='2G,6' --constraints="virt-type=virtual-machine root-disk=24G mem=8G"
           # wait for charm to bootstrap and OSD devices to enroll.
-          juju wait-for unit microceph/0 --timeout '30m' --query='workload-message=="(workload) charm is ready"'
+          juju wait-for unit microceph/0 --timeout '30m' --query='workload-status=="active" && juju-status=="idle"'
           bash ./tests/scripts/ci_helpers.sh check_osd_count microceph/0 6
           date
 
@@ -602,7 +602,7 @@ jobs:
         run: |
           set -eux
           juju detach-storage osd-standalone/0
-          juju wait-for unit microceph/0 --timeout '20m' --query='workload-message=="(workload) charm is ready"'
+          juju wait-for unit microceph/0 --timeout '20m' --query='workload-status=="active" && juju-status=="idle"'
           # wait before completely removing the storage.
           sleep 1m
           juju remove-storage osd-standalone/0
@@ -613,7 +613,7 @@ jobs:
         run: |
           set -eux
           juju add-storage microceph/0 osd-standalone='2G,1'
-          juju wait-for unit microceph/0 --timeout '20m' --query='workload-message=="(workload) charm is ready"'
+          juju wait-for unit microceph/0 --timeout '20m' --query='workload-status=="active" && juju-status=="idle"'
           bash tests/scripts/ci_helpers.sh check_osd_count microceph/0 6
           date
 
@@ -891,7 +891,7 @@ jobs:
           # constraints to deploy on virtual machine.
           juju deploy ~/artifacts/microceph.charm --storage osd-standalone='2G,6' --constraints="virt-type=virtual-machine root-disk=24G mem=8G"
           # wait for charm to bootstrap and OSD devices to enroll.
-          juju wait-for unit microceph/0 --timeout '30m' --query='workload-message=="(workload) charm is ready"'
+          juju wait-for unit microceph/0 --timeout '30m' --query='workload-status=="active" && juju-status=="idle"'
           bash ./tests/scripts/ci_helpers.sh check_osd_count microceph/0 6
           date
 
@@ -965,8 +965,8 @@ jobs:
           juju deploy ~/artifacts/microceph.charm primary --storage osd-standalone='2G,3' --constraints="virt-type=virtual-machine root-disk=25G mem=8G"
           juju deploy ~/artifacts/microceph.charm secondary --storage osd-standalone='2G,3' --constraints="virt-type=virtual-machine root-disk=25G mem=8G"
           # wait for charm to bootstrap and OSD devices to enroll.
-          juju wait-for unit primary/0 --timeout '30m' --query='workload-message=="(workload) charm is ready"'
-          juju wait-for unit secondary/0 --timeout '15m' --query='workload-message=="(workload) charm is ready"'
+          juju wait-for unit primary/0 --timeout '30m' --query='workload-status=="active" && juju-status=="idle"'
+          juju wait-for unit secondary/0 --timeout '15m' --query='workload-status=="active" && juju-status=="idle"'
           bash ./tests/scripts/ci_helpers.sh check_osd_count primary/0 3
           bash ./tests/scripts/ci_helpers.sh check_osd_count secondary/0 3
           date
@@ -1184,7 +1184,7 @@ jobs:
           set -x
           juju add-unit microceph -n 1
           sleep 60s
-          juju wait-for unit microceph/3 --query='workload-message=="(workload) charm is ready"' --timeout=20m
+          juju wait-for unit microceph/3 --query='workload-status=="active" && juju-status=="idle"' --timeout=20m
 
            # "juju" substring is a part of all hosts, so it will fetch total OSD count
           ./tests/scripts/ci_helpers.sh ensure_osd_count_on_host "juju" 9
@@ -1273,7 +1273,7 @@ jobs:
             --storage osd-standalone='2G,6' --constraints="virt-type=virtual-machine root-disk=24G mem=16G cores=4"
           # Wait for the LXD VM to be fully provisioned before waiting for the unit
           juju wait-for machine 0 --timeout '10m' --query='status=="started"'
-          juju wait-for unit microceph/0 --timeout '30m' --query='workload-message=="(workload) charm is ready"'
+          juju wait-for unit microceph/0 --timeout '30m' --query='workload-status=="active" && juju-status=="idle"'
           juju status
 
       - name: Integrate MicroCeph with COS via ${{ matrix.agent }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -593,8 +593,9 @@ jobs:
           date
           # constraints to deploy on virtual machine.
           juju deploy ~/artifacts/microceph.charm --storage osd-standalone='2G,6' --constraints="virt-type=virtual-machine root-disk=24G mem=8G"
-          # wait for charm to bootstrap and OSD devices to enroll.
+          # wait for charm to bootstrap, then give deferred storage events time to start enrolling OSDs.
           juju wait-for unit microceph/0 --timeout '30m' --query='workload-status=="active" && juju-status=="idle"'
+          sleep 30
           bash ./tests/scripts/ci_helpers.sh check_osd_count microceph/0 6
           date
 
@@ -614,6 +615,7 @@ jobs:
           set -eux
           juju add-storage microceph/0 osd-standalone='2G,1'
           juju wait-for unit microceph/0 --timeout '20m' --query='workload-status=="active" && juju-status=="idle"'
+          sleep 30
           bash tests/scripts/ci_helpers.sh check_osd_count microceph/0 6
           date
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -594,7 +594,7 @@ jobs:
           # constraints to deploy on virtual machine.
           juju deploy ~/artifacts/microceph.charm --storage osd-standalone='2G,6' --constraints="virt-type=virtual-machine root-disk=24G mem=8G"
           # wait for charm to bootstrap, then give deferred storage events time to start enrolling OSDs.
-          juju wait-for unit microceph/0 --timeout '30m' --query='workload-status=="active" && juju-status=="idle"'
+          juju wait-for unit microceph/0 --timeout '30m' --query='workload-status=="active" && agent-status=="idle"'
           sleep 30
           bash ./tests/scripts/ci_helpers.sh check_osd_count microceph/0 6
           date
@@ -603,7 +603,7 @@ jobs:
         run: |
           set -eux
           juju detach-storage osd-standalone/0
-          juju wait-for unit microceph/0 --timeout '20m' --query='workload-status=="active" && juju-status=="idle"'
+          juju wait-for unit microceph/0 --timeout '20m' --query='workload-status=="active" && agent-status=="idle"'
           # wait before completely removing the storage.
           sleep 1m
           juju remove-storage osd-standalone/0
@@ -614,7 +614,7 @@ jobs:
         run: |
           set -eux
           juju add-storage microceph/0 osd-standalone='2G,1'
-          juju wait-for unit microceph/0 --timeout '20m' --query='workload-status=="active" && juju-status=="idle"'
+          juju wait-for unit microceph/0 --timeout '20m' --query='workload-status=="active" && agent-status=="idle"'
           sleep 30
           bash tests/scripts/ci_helpers.sh check_osd_count microceph/0 6
           date
@@ -893,7 +893,7 @@ jobs:
           # constraints to deploy on virtual machine.
           juju deploy ~/artifacts/microceph.charm --storage osd-standalone='2G,6' --constraints="virt-type=virtual-machine root-disk=24G mem=8G"
           # wait for charm to bootstrap and OSD devices to enroll.
-          juju wait-for unit microceph/0 --timeout '30m' --query='workload-status=="active" && juju-status=="idle"'
+          juju wait-for unit microceph/0 --timeout '30m' --query='workload-status=="active" && agent-status=="idle"'
           bash ./tests/scripts/ci_helpers.sh check_osd_count microceph/0 6
           date
 
@@ -967,8 +967,8 @@ jobs:
           juju deploy ~/artifacts/microceph.charm primary --storage osd-standalone='2G,3' --constraints="virt-type=virtual-machine root-disk=25G mem=8G"
           juju deploy ~/artifacts/microceph.charm secondary --storage osd-standalone='2G,3' --constraints="virt-type=virtual-machine root-disk=25G mem=8G"
           # wait for charm to bootstrap and OSD devices to enroll.
-          juju wait-for unit primary/0 --timeout '30m' --query='workload-status=="active" && juju-status=="idle"'
-          juju wait-for unit secondary/0 --timeout '15m' --query='workload-status=="active" && juju-status=="idle"'
+          juju wait-for unit primary/0 --timeout '30m' --query='workload-status=="active" && agent-status=="idle"'
+          juju wait-for unit secondary/0 --timeout '15m' --query='workload-status=="active" && agent-status=="idle"'
           bash ./tests/scripts/ci_helpers.sh check_osd_count primary/0 3
           bash ./tests/scripts/ci_helpers.sh check_osd_count secondary/0 3
           date
@@ -1186,7 +1186,7 @@ jobs:
           set -x
           juju add-unit microceph -n 1
           sleep 60s
-          juju wait-for unit microceph/3 --query='workload-status=="active" && juju-status=="idle"' --timeout=20m
+          juju wait-for unit microceph/3 --query='workload-status=="active" && agent-status=="idle"' --timeout=20m
 
            # "juju" substring is a part of all hosts, so it will fetch total OSD count
           ./tests/scripts/ci_helpers.sh ensure_osd_count_on_host "juju" 9
@@ -1275,7 +1275,7 @@ jobs:
             --storage osd-standalone='2G,6' --constraints="virt-type=virtual-machine root-disk=24G mem=16G cores=4"
           # Wait for the LXD VM to be fully provisioned before waiting for the unit
           juju wait-for machine 0 --timeout '10m' --query='status=="started"'
-          juju wait-for unit microceph/0 --timeout '30m' --query='workload-status=="active" && juju-status=="idle"'
+          juju wait-for unit microceph/0 --timeout '30m' --query='workload-status=="active" && agent-status=="idle"'
           juju status
 
       - name: Integrate MicroCeph with COS via ${{ matrix.agent }}

--- a/config.yaml
+++ b/config.yaml
@@ -65,7 +65,7 @@ options:
     type: string
     default: ""
     description: |
-      DSL expression to match block devices for OSD enrollment.
+      DSL expression to match block devices for config-driven OSD enrollment.
       The DSL uses functional syntax with predicates and variables.
 
       Supported predicates: and(), or(), not(), eq(), ne(), gt(), ge(), lt(), le(), in(), re()
@@ -79,18 +79,53 @@ options:
       When set, the charm evaluates this expression against available
       block devices on each unit and enrolls matching devices as OSDs.
       This is additive to action-based and Juju storage-based OSDs.
+  wal-devices:
+    type: string
+    default: ""
+    description: |
+      DSL expression to match block devices used as WAL carrier devices for
+      config-driven enrollment triggered by osd-devices.
+
+      This option is ignored unless osd-devices is also set.
+  db-devices:
+    type: string
+    default: ""
+    description: |
+      DSL expression to match block devices used as RocksDB carrier devices for
+      config-driven enrollment triggered by osd-devices.
+
+      This option is ignored unless osd-devices is also set.
+  wal-size:
+    type: string
+    default: ""
+    description: |
+      Requested WAL partition size for devices selected by wal-devices.
+
+      This option is ignored unless osd-devices is also set.
+  db-size:
+    type: string
+    default: ""
+    description: |
+      Requested RocksDB partition size for devices selected by db-devices.
+
+      This option is ignored unless osd-devices is also set.
   device-add-flags:
     type: string
     default: ""
     description: |
-      Comma-separated list of flags controlling device addition with the
-      osd-devices config option.
+      Comma-separated list of flags controlling config-driven device addition
+      with the osd-devices flow.
 
       Supported flags:
-        wipe:osd    - Wipe non-pristine OSD devices before enrollment
-        encrypt:osd - Encrypt OSD devices
+        wipe:osd     - Wipe non-pristine OSD devices before enrollment
+        encrypt:osd  - Encrypt OSD devices
+        wipe:wal     - Wipe WAL carrier devices before use
+        encrypt:wal  - Encrypt WAL partitions/devices
+        wipe:db      - Wipe DB carrier devices before use
+        encrypt:db   - Encrypt DB partitions/devices
 
-      Example: wipe:osd,encrypt:osd
+      Example: wipe:osd,encrypt:osd,wipe:wal,encrypt:db
 
-      Note: these flags are not in effect when adding disks via the add-disk
-      action. Use action parameters for this purpose.
+      Note: WAL/DB config and these flags only apply to config-driven
+      provisioning initiated by osd-devices. They are not in effect when using
+      the add-osd action; use action parameters for that path.

--- a/config.yaml
+++ b/config.yaml
@@ -128,4 +128,5 @@ options:
 
       Note: WAL/DB config and these flags only apply to config-driven
       provisioning initiated by osd-devices. They are not in effect when using
-      the add-osd action; use action parameters for that path.
+      the add-osd action, which currently supports only device-level wipe and
+      encryption parameters.

--- a/src/device_flags.py
+++ b/src/device_flags.py
@@ -14,12 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Validators for OSD device configuration options."""
+"""Validators for config-driven device addition flags."""
 
 from dataclasses import dataclass
 
-# Valid device-add-flags for Phase 1
-VALID_FLAGS = frozenset(["wipe:osd", "encrypt:osd"])
+_FLAG_ATTRS = {
+    "wipe:osd": "wipe_osd",
+    "encrypt:osd": "encrypt_osd",
+    "wipe:wal": "wipe_wal",
+    "encrypt:wal": "encrypt_wal",
+    "wipe:db": "wipe_db",
+    "encrypt:db": "encrypt_db",
+}
+
+VALID_FLAGS = frozenset(_FLAG_ATTRS)
 
 
 @dataclass
@@ -28,6 +36,10 @@ class DeviceAddFlags:
 
     wipe_osd: bool = False
     encrypt_osd: bool = False
+    wipe_wal: bool = False
+    encrypt_wal: bool = False
+    wipe_db: bool = False
+    encrypt_db: bool = False
 
 
 def parse_device_add_flags(flags_str: str) -> DeviceAddFlags:
@@ -55,9 +67,6 @@ def parse_device_add_flags(flags_str: str) -> DeviceAddFlags:
             raise ValueError(
                 f"Unknown flag: '{flag}'. Valid flags: {', '.join(sorted(VALID_FLAGS))}"
             )
-        if flag == "wipe:osd":
-            result.wipe_osd = True
-        elif flag == "encrypt:osd":
-            result.encrypt_osd = True
+        setattr(result, _FLAG_ATTRS[flag], True)
 
     return result

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -384,31 +384,72 @@ def add_batch_osds(disks: list) -> None:
     utils.run_cmd(cmd)
 
 
+def _append_optional_match_args(cmd: list, *flag_value_pairs: tuple[str, str | None]) -> None:
+    """Append optional `--flag value` pairs for non-empty values."""
+    for flag, value in flag_value_pairs:
+        if value:
+            cmd.extend([flag, value])
+
+
+def _append_enabled_flags(cmd: list, *flag_pairs: tuple[bool, str]) -> None:
+    """Append enabled boolean flags in order."""
+    for enabled, flag in flag_pairs:
+        if enabled:
+            cmd.append(flag)
+
+
+def add_disk_match_cmd(
+    osd_match: str,
+    *,
+    wal_match: str = None,
+    wal_size: str = None,
+    db_match: str = None,
+    db_size: str = None,
+    wipe: bool = False,
+    encrypt: bool = False,
+    wal_wipe: bool = False,
+    wal_encrypt: bool = False,
+    db_wipe: bool = False,
+    db_encrypt: bool = False,
+    dry_run: bool = False,
+) -> str:
+    """Execute MicroCeph disk add with DSL-based OSD/WAL/DB matching."""
+    cmd = ["microceph", "disk", "add", "--osd-match", osd_match]
+
+    _append_optional_match_args(
+        cmd,
+        ("--wal-match", wal_match),
+        ("--wal-size", wal_size),
+    )
+    _append_enabled_flags(cmd, (wal_wipe, "--wal-wipe"), (wal_encrypt, "--wal-encrypt"))
+
+    _append_optional_match_args(
+        cmd,
+        ("--db-match", db_match),
+        ("--db-size", db_size),
+    )
+    _append_enabled_flags(cmd, (db_wipe, "--db-wipe"), (db_encrypt, "--db-encrypt"))
+    _append_enabled_flags(cmd, (wipe, "--wipe"), (encrypt, "--encrypt"), (dry_run, "--dry-run"))
+
+    if any((encrypt, wal_encrypt, db_encrypt)):
+        _setup_dm_crypt()
+
+    return utils.run_cmd(cmd, timeout=900)
+
+
 def add_osd_match_cmd(
     osd_match: str,
     wipe: bool = False,
     encrypt: bool = False,
     dry_run: bool = False,
 ) -> str:
-    """Execute MicroCeph disk add with DSL-based OSD matching.
-
-    Args:
-        osd_match: DSL expression for matching OSD devices
-        wipe: If True, wipe non-pristine devices before enrollment
-        encrypt: If True, encrypt matched devices
-        dry_run: If True, report matches without adding devices
-
-    Returns:
-        Command output (useful for dry-run results)
-    """
-    cmd = ["microceph", "disk", "add", "--osd-match", osd_match]
-    if wipe:
-        cmd.append("--wipe")
-    if encrypt:
-        cmd.append("--encrypt")
-    if dry_run:
-        cmd.append("--dry-run")
-    return utils.run_cmd(cmd, timeout=900)
+    """Compatibility wrapper for DSL-based OSD matching."""
+    return add_disk_match_cmd(
+        osd_match=osd_match,
+        wipe=wipe,
+        encrypt=encrypt,
+        dry_run=dry_run,
+    )
 
 
 def get_snap_info(snap_name):

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -414,6 +414,23 @@ def add_disk_match_cmd(
     dry_run: bool = False,
 ) -> str:
     """Execute MicroCeph disk add with DSL-based OSD/WAL/DB matching."""
+    logger.debug(
+        "Preparing microceph disk add command osd_match=%s wal_match=%s wal_size=%s "
+        "db_match=%s db_size=%s wipe=%s encrypt=%s wal_wipe=%s wal_encrypt=%s "
+        "db_wipe=%s db_encrypt=%s dry_run=%s",
+        osd_match,
+        wal_match,
+        wal_size,
+        db_match,
+        db_size,
+        wipe,
+        encrypt,
+        wal_wipe,
+        wal_encrypt,
+        db_wipe,
+        db_encrypt,
+        dry_run,
+    )
     cmd = ["microceph", "disk", "add", "--osd-match", osd_match]
     wal_enabled = bool(wal_match)
     db_enabled = bool(db_match)
@@ -435,7 +452,21 @@ def add_disk_match_cmd(
         _append_enabled_flags(cmd, (db_wipe, "--db-wipe"), (db_encrypt, "--db-encrypt"))
     _append_enabled_flags(cmd, (wipe, "--wipe"), (encrypt, "--encrypt"), (dry_run, "--dry-run"))
 
+    logger.debug(
+        "Built microceph disk add command wal_enabled=%s db_enabled=%s cmd=%s",
+        wal_enabled,
+        db_enabled,
+        cmd,
+    )
+
     if encrypt or (wal_enabled and wal_encrypt) or (db_enabled and db_encrypt):
+        logger.debug(
+            "Encryption requested for disk add command; ensuring dm-crypt is available "
+            "osd_encrypt=%s wal_encrypt=%s db_encrypt=%s",
+            encrypt,
+            wal_encrypt,
+            db_encrypt,
+        )
         _setup_dm_crypt()
 
     return utils.run_cmd(cmd, timeout=900)

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -472,21 +472,6 @@ def add_disk_match_cmd(
     return utils.run_cmd(cmd, timeout=900)
 
 
-def add_osd_match_cmd(
-    osd_match: str,
-    wipe: bool = False,
-    encrypt: bool = False,
-    dry_run: bool = False,
-) -> str:
-    """Compatibility wrapper for DSL-based OSD matching."""
-    return add_disk_match_cmd(
-        osd_match=osd_match,
-        wipe=wipe,
-        encrypt=encrypt,
-        dry_run=dry_run,
-    )
-
-
 def get_snap_info(snap_name):
     """Get snap info from the charm store."""
     url = f"https://api.snapcraft.io/v2/snaps/info/{snap_name}"

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -415,23 +415,27 @@ def add_disk_match_cmd(
 ) -> str:
     """Execute MicroCeph disk add with DSL-based OSD/WAL/DB matching."""
     cmd = ["microceph", "disk", "add", "--osd-match", osd_match]
+    wal_enabled = bool(wal_match)
+    db_enabled = bool(db_match)
 
-    _append_optional_match_args(
-        cmd,
-        ("--wal-match", wal_match),
-        ("--wal-size", wal_size),
-    )
-    _append_enabled_flags(cmd, (wal_wipe, "--wal-wipe"), (wal_encrypt, "--wal-encrypt"))
+    if wal_enabled:
+        _append_optional_match_args(
+            cmd,
+            ("--wal-match", wal_match),
+            ("--wal-size", wal_size),
+        )
+        _append_enabled_flags(cmd, (wal_wipe, "--wal-wipe"), (wal_encrypt, "--wal-encrypt"))
 
-    _append_optional_match_args(
-        cmd,
-        ("--db-match", db_match),
-        ("--db-size", db_size),
-    )
-    _append_enabled_flags(cmd, (db_wipe, "--db-wipe"), (db_encrypt, "--db-encrypt"))
+    if db_enabled:
+        _append_optional_match_args(
+            cmd,
+            ("--db-match", db_match),
+            ("--db-size", db_size),
+        )
+        _append_enabled_flags(cmd, (db_wipe, "--db-wipe"), (db_encrypt, "--db-encrypt"))
     _append_enabled_flags(cmd, (wipe, "--wipe"), (encrypt, "--encrypt"), (dry_run, "--dry-run"))
 
-    if any((encrypt, wal_encrypt, db_encrypt)):
+    if encrypt or (wal_enabled and wal_encrypt) or (db_enabled and db_encrypt):
         _setup_dm_crypt()
 
     return utils.run_cmd(cmd, timeout=900)

--- a/src/storage.py
+++ b/src/storage.py
@@ -208,6 +208,10 @@ class StorageHandler(Object):
         """Process config-driven storage requests for OSD/WAL/DB matching."""
         with sunbeam_guard.guard(self.charm, self.name):
             storage_request = self._normalize_storage_config()
+            logger.debug(
+                "Normalized storage config request: %s",
+                json.dumps(storage_request, sort_keys=True),
+            )
 
             if not storage_request["osd_match"]:
                 if self._has_ignored_waldb_config():
@@ -228,9 +232,21 @@ class StorageHandler(Object):
 
             if self._is_cached_osd_config(storage_request):
                 logger.debug(
-                    "Skipping storage config processing: unchanged signature=%s",
+                    "Skipping storage config processing because OSD-affecting inputs are "
+                    "unchanged; exact repeats and WAL/DB-only changes both hit this path. "
+                    "cacheable_request=%s signature=%s",
+                    json.dumps(self._cacheable_osd_request(storage_request), sort_keys=True),
                     self._storage_config_signature(storage_request),
                 )
+                if self._storage_request_has_auxiliary_config(storage_request):
+                    logger.info(
+                        "Skipping config-driven WAL/DB apply because no new OSD selection was "
+                        "detected; WAL/DB settings are only applied when new OSDs are added "
+                        "osd_match=%s wal_enabled=%s db_enabled=%s",
+                        storage_request["osd_match"],
+                        bool(storage_request["wal_match"]),
+                        bool(storage_request["db_match"]),
+                    )
                 self._set_storage_config_idle_status()
                 return
 
@@ -238,9 +254,22 @@ class StorageHandler(Object):
 
     def _normalize_storage_config(self) -> dict:
         """Normalize config-driven storage settings into a stable request dict."""
+        raw_config = {
+            "osd-devices": self.charm.model.config.get("osd-devices", ""),
+            "wal-devices": self.charm.model.config.get("wal-devices", ""),
+            "db-devices": self.charm.model.config.get("db-devices", ""),
+            "wal-size": self.charm.model.config.get("wal-size", ""),
+            "db-size": self.charm.model.config.get("db-size", ""),
+            "device-add-flags": self.charm.model.config.get("device-add-flags", ""),
+        }
+        logger.debug(
+            "Raw storage config values before normalization: %s",
+            json.dumps(raw_config, sort_keys=True),
+        )
+
         osd_match = self._normalized_config_value("osd-devices")
         if not osd_match:
-            return {
+            normalized = {
                 "osd_match": None,
                 "wal_match": None,
                 "db_match": None,
@@ -248,23 +277,44 @@ class StorageHandler(Object):
                 "db_size": None,
                 "flags": asdict(DeviceAddFlags()),
             }
+            logger.debug(
+                "Normalized storage config without osd-devices: %s",
+                json.dumps(normalized, sort_keys=True),
+            )
+            return normalized
 
         flags = self._parse_osd_device_flags(self.charm.model.config.get("device-add-flags", ""))
         wal_match = self._normalized_config_value("wal-devices")
         db_match = self._normalized_config_value("db-devices")
+        raw_wal_size = self._normalized_config_value("wal-size")
+        raw_db_size = self._normalized_config_value("db-size")
 
-        wal_size = self._normalized_config_value("wal-size") if wal_match else None
-        db_size = self._normalized_config_value("db-size") if db_match else None
+        wal_size = raw_wal_size if wal_match else None
+        db_size = raw_db_size if db_match else None
 
-        if not wal_match:
+        if not wal_match and (raw_wal_size or flags.wipe_wal or flags.encrypt_wal):
+            logger.debug(
+                "Dropping WAL size/flags because wal-devices is unset: raw_wal_size=%s "
+                "wipe_wal=%s encrypt_wal=%s",
+                raw_wal_size,
+                flags.wipe_wal,
+                flags.encrypt_wal,
+            )
             flags.wipe_wal = False
             flags.encrypt_wal = False
 
-        if not db_match:
+        if not db_match and (raw_db_size or flags.wipe_db or flags.encrypt_db):
+            logger.debug(
+                "Dropping DB size/flags because db-devices is unset: raw_db_size=%s "
+                "wipe_db=%s encrypt_db=%s",
+                raw_db_size,
+                flags.wipe_db,
+                flags.encrypt_db,
+            )
             flags.wipe_db = False
             flags.encrypt_db = False
 
-        return {
+        normalized = {
             "osd_match": osd_match,
             "wal_match": wal_match,
             "db_match": db_match,
@@ -272,6 +322,11 @@ class StorageHandler(Object):
             "db_size": db_size,
             "flags": asdict(flags),
         }
+        logger.debug(
+            "Normalized storage config with osd-devices: %s",
+            json.dumps(normalized, sort_keys=True),
+        )
+        return normalized
 
     def _normalized_config_value(self, key: str):
         """Trim a string config value and convert empty strings to None."""
@@ -280,15 +335,45 @@ class StorageHandler(Object):
 
     def _has_ignored_waldb_config(self) -> bool:
         """Whether WAL/DB config was provided without an OSD activation request."""
-        if any(
-            self._normalized_config_value(key)
+        configured_keys = [
+            key
             for key in ("wal-devices", "db-devices", "wal-size", "db-size")
-        ):
+            if self._normalized_config_value(key)
+        ]
+        if configured_keys:
+            logger.debug(
+                "Detected WAL/DB config values without osd-devices: keys=%s",
+                configured_keys,
+            )
             return True
 
         waldb_flags = {"wipe:wal", "encrypt:wal", "wipe:db", "encrypt:db"}
         raw_flags = (self.charm.model.config.get("device-add-flags", "") or "").split(",")
-        return any(flag.strip().lower() in waldb_flags for flag in raw_flags if flag.strip())
+        configured_flags = [
+            flag.strip().lower()
+            for flag in raw_flags
+            if flag.strip() and flag.strip().lower() in waldb_flags
+        ]
+        if configured_flags:
+            logger.debug(
+                "Detected WAL/DB device-add-flags without osd-devices: flags=%s",
+                configured_flags,
+            )
+            return True
+
+        return False
+
+    def _storage_request_has_auxiliary_config(self, storage_request: dict) -> bool:
+        """Whether a normalized request contains any WAL/DB-specific settings."""
+        flags = storage_request["flags"]
+        return bool(
+            storage_request["wal_match"]
+            or storage_request["db_match"]
+            or flags["wipe_wal"]
+            or flags["encrypt_wal"]
+            or flags["wipe_db"]
+            or flags["encrypt_db"]
+        )
 
     def _cacheable_osd_request(self, storage_request: dict) -> dict:
         """Return the subset of storage config that can trigger a new snap command."""
@@ -310,6 +395,14 @@ class StorageHandler(Object):
 
     def _reset_osd_config_cache(self):
         """Reset cache for last successfully applied config-driven storage request."""
+        logger.debug(
+            "Resetting config-driven storage cache previous_osd_match=%s previous_wipe=%s "
+            "previous_encrypt=%s previous_signature=%s",
+            self._stored.last_osd_devices,
+            self._stored.last_wipe_osd,
+            self._stored.last_encrypt_osd,
+            self._stored.last_storage_config_signature,
+        )
         self._stored.last_osd_devices = ""
         self._stored.last_wipe_osd = False
         self._stored.last_encrypt_osd = False
@@ -326,25 +419,49 @@ class StorageHandler(Object):
             storage_request
         )
         logger.debug(
-            "Updated storage config cache signature=%s",
+            "Persisted storage config cache cacheable_request=%s signature=%s",
+            json.dumps(cacheable_request, sort_keys=True),
             self._stored.last_storage_config_signature,
         )
 
     def _is_cached_osd_config(self, storage_request: dict) -> bool:
         """Check whether current config-driven storage request was already applied."""
         requested = self._cacheable_osd_request(storage_request)
+        requested_signature = self._storage_config_signature(storage_request)
         last_signature = self._stored.last_storage_config_signature
+        legacy_state = {
+            "osd_match": self._stored.last_osd_devices,
+            "wipe_osd": self._stored.last_wipe_osd,
+            "encrypt_osd": self._stored.last_encrypt_osd,
+        }
+        logger.debug(
+            "Checking storage config cache requested=%s requested_signature=%s "
+            "stored_signature=%s legacy_state=%s",
+            json.dumps(requested, sort_keys=True),
+            requested_signature,
+            last_signature,
+            json.dumps(legacy_state, sort_keys=True),
+        )
 
         if last_signature:
-            if last_signature == self._storage_config_signature(storage_request):
+            if last_signature == requested_signature:
+                logger.debug("Storage config cache hit via current signature")
                 return True
 
             try:
                 cached_request = json.loads(last_signature)
             except (TypeError, ValueError):
                 cached_request = None
+                logger.debug(
+                    "Stored storage config signature is not parseable as JSON request: %r",
+                    last_signature,
+                )
 
             if isinstance(cached_request, dict):
+                logger.debug(
+                    "Parsed stored storage config signature into request=%s",
+                    json.dumps(cached_request, sort_keys=True),
+                )
                 cached_flags = cached_request.get("flags") or {}
                 if (
                     cached_request.get("osd_match") == requested["osd_match"]
@@ -352,19 +469,28 @@ class StorageHandler(Object):
                     and cached_flags.get("encrypt_osd", False)
                     == requested["flags"]["encrypt_osd"]
                 ):
+                    logger.debug("Storage config cache hit via parsed legacy signature")
                     return True
 
-        return (
+        legacy_hit = (
             self._stored.last_osd_devices == requested["osd_match"]
             and self._stored.last_wipe_osd == requested["flags"]["wipe_osd"]
             and self._stored.last_encrypt_osd == requested["flags"]["encrypt_osd"]
         )
+        if legacy_hit:
+            logger.debug("Storage config cache hit via legacy stored fields")
+            return True
+
+        logger.debug("Storage config cache miss")
+        return False
 
     def _set_storage_config_idle_status(self):
         """Restore ready status for storage-config no-op/recovery paths."""
         if not self.charm.ready_for_service():
+            logger.debug("Skipping idle status restore because charm is not ready for service")
             return
 
+        logger.debug("Restoring active status for storage-config idle path")
         self.charm.status.set(ActiveStatus("charm is ready"))
 
     def _parse_osd_device_flags(self, device_add_flags: str) -> DeviceAddFlags:
@@ -377,10 +503,32 @@ class StorageHandler(Object):
     def _validate_storage_config(self, storage_request: dict):
         """Validate the minimal charm-owned storage config combinations."""
         if storage_request["wal_match"] and not storage_request["wal_size"]:
+            logger.info(
+                "Blocking config-driven storage because wal-devices was set without wal-size "
+                "osd_match=%s wal_match=%s",
+                storage_request["osd_match"],
+                storage_request["wal_match"],
+            )
+            logger.debug(
+                "Invalid storage config detected: wal-devices is set without wal-size "
+                "request=%s",
+                json.dumps(storage_request, sort_keys=True),
+            )
             raise sunbeam_guard.BlockedExceptionError(
                 "Invalid storage config: wal-devices requires wal-size"
             )
         if storage_request["db_match"] and not storage_request["db_size"]:
+            logger.info(
+                "Blocking config-driven storage because db-devices was set without db-size "
+                "osd_match=%s db_match=%s",
+                storage_request["osd_match"],
+                storage_request["db_match"],
+            )
+            logger.debug(
+                "Invalid storage config detected: db-devices is set without db-size "
+                "request=%s",
+                json.dumps(storage_request, sort_keys=True),
+            )
             raise sunbeam_guard.BlockedExceptionError(
                 "Invalid storage config: db-devices requires db-size"
             )
@@ -391,8 +539,21 @@ class StorageHandler(Object):
             "Processing storage config request: %s",
             json.dumps(storage_request, sort_keys=True),
         )
+        logger.info(
+            "Applying config-driven storage osd_match=%s wal_enabled=%s db_enabled=%s "
+            "wipe=%s encrypt=%s",
+            storage_request["osd_match"],
+            bool(storage_request["wal_match"]),
+            bool(storage_request["db_match"]),
+            storage_request["flags"]["wipe_osd"],
+            storage_request["flags"]["encrypt_osd"],
+        )
         try:
             self.charm.status.set(MaintenanceStatus("Processing storage config"))
+            logger.debug(
+                "Calling microceph.add_disk_match_cmd for request=%s",
+                json.dumps(storage_request, sort_keys=True),
+            )
             output = microceph.add_disk_match_cmd(
                 osd_match=storage_request["osd_match"],
                 wal_match=storage_request["wal_match"],
@@ -410,16 +571,29 @@ class StorageHandler(Object):
                 logger.info("Storage config command output:\n%s", output.strip())
             self.charm.status.set(ActiveStatus("charm is ready"))
             self._set_osd_config_cache(storage_request)
-            logger.info("Successfully processed storage config request")
+            logger.info(
+                "Successfully processed storage config osd_match=%s wal_enabled=%s "
+                "db_enabled=%s",
+                storage_request["osd_match"],
+                bool(storage_request["wal_match"]),
+                bool(storage_request["db_match"]),
+            )
         except (CalledProcessError, TimeoutExpired) as e:
             err_msg = self._error_message(e)
             if "no devices matched" in err_msg.lower():
-                logger.info("No devices matched config-driven OSD request")
+                logger.info(
+                    "No devices matched config-driven OSD request request=%s",
+                    json.dumps(storage_request, sort_keys=True),
+                )
                 self.charm.status.set(ActiveStatus("charm is ready"))
                 self._set_osd_config_cache(storage_request)
                 return
 
-            logger.error("Failed to process storage config %s", err_msg)
+            logger.error(
+                "Failed to process storage config request=%s error=%s",
+                json.dumps(storage_request, sort_keys=True),
+                err_msg,
+            )
             raise sunbeam_guard.BlockedExceptionError(f"Failed to add OSDs via config: {err_msg}")
 
     # helper functions

--- a/src/storage.py
+++ b/src/storage.py
@@ -250,12 +250,26 @@ class StorageHandler(Object):
             }
 
         flags = self._parse_osd_device_flags(self.charm.model.config.get("device-add-flags", ""))
+        wal_match = self._normalized_config_value("wal-devices")
+        db_match = self._normalized_config_value("db-devices")
+
+        wal_size = self._normalized_config_value("wal-size") if wal_match else None
+        db_size = self._normalized_config_value("db-size") if db_match else None
+
+        if not wal_match:
+            flags.wipe_wal = False
+            flags.encrypt_wal = False
+
+        if not db_match:
+            flags.wipe_db = False
+            flags.encrypt_db = False
+
         return {
             "osd_match": osd_match,
-            "wal_match": self._normalized_config_value("wal-devices"),
-            "db_match": self._normalized_config_value("db-devices"),
-            "wal_size": self._normalized_config_value("wal-size"),
-            "db_size": self._normalized_config_value("db-size"),
+            "wal_match": wal_match,
+            "db_match": db_match,
+            "wal_size": wal_size,
+            "db_size": db_size,
             "flags": asdict(flags),
         }
 

--- a/src/storage.py
+++ b/src/storage.py
@@ -118,6 +118,7 @@ class StorageHandler(Object):
             self.storage_status.set(MaintenanceStatus("Enrolling OSDs"))
             self._enroll_disks_in_batch(enroll)
             self.storage_status.set(ActiveStatus(""))
+            self._restore_ready_workload_status()
 
     def _on_storage_detaching(self, event: StorageDetachingEvent):
         """Unified storage detaching handler."""
@@ -133,15 +134,46 @@ class StorageHandler(Object):
         with sunbeam_guard.guard(self._storage_guard, self.name):
             try:
                 self.remove_osd(osd_num)
+                self._restore_ready_workload_status()
             except CalledProcessError as e:
                 err_msg = self._error_message(e)
                 if self._is_safety_failure(err_msg):
-                    warning = f"Storage {event.storage.full_id} detached, provide replacement for osd.{osd_num}."
+                    warning = (
+                        f"Storage {event.storage.full_id} detached, provide replacement "
+                        f"for osd.{osd_num}."
+                    )
                     logger.warning(warning)
                     # forcefully remove OSD and entry from stored state
                     # because Juju WILL deprovision storage.
                     self.remove_osd(osd_num, force=True)
                     raise sunbeam_guard.BlockedExceptionError(warning)
+
+    def _restore_ready_workload_status(self) -> None:
+        """Restore the ready message without clearing non-idle workload states."""
+        workload_status = self.charm.status.status
+        current_message = getattr(workload_status, "message", "")
+
+        if workload_status.name == "unknown":
+            self.charm.status.set(ActiveStatus("charm is ready"))
+            return
+
+        if workload_status.name != "active":
+            logger.debug(
+                "Skipping ready workload status restore because workload slot is %s: %s",
+                workload_status.name,
+                current_message,
+            )
+            return
+
+        if current_message and current_message != "charm is ready":
+            logger.debug(
+                "Skipping ready workload status restore because workload slot already has "
+                "an active message: %s",
+                current_message,
+            )
+            return
+
+        self.charm.status.set(ActiveStatus("charm is ready"))
 
     def _add_osd_action(self, event: ActionEvent):
         """Add OSD disks to microceph."""

--- a/src/storage.py
+++ b/src/storage.py
@@ -216,6 +216,7 @@ class StorageHandler(Object):
                     "osd-devices config not set, skipping config-based storage enrollment"
                 )
                 self._reset_osd_config_cache()
+                self._set_storage_config_idle_status()
                 return
 
             self._validate_storage_config(storage_request)
@@ -230,6 +231,7 @@ class StorageHandler(Object):
                     "Skipping storage config processing: unchanged signature=%s",
                     self._storage_config_signature(storage_request),
                 )
+                self._set_storage_config_idle_status()
                 return
 
             self._apply_osd_config(storage_request)
@@ -298,6 +300,13 @@ class StorageHandler(Object):
         return self._stored.last_storage_config_signature == self._storage_config_signature(
             storage_request
         )
+
+    def _set_storage_config_idle_status(self):
+        """Restore ready status for storage-config no-op/recovery paths."""
+        if not self.charm.ready_for_service():
+            return
+
+        self.charm.status.set(ActiveStatus("charm is ready"))
 
     def _parse_osd_device_flags(self, device_add_flags: str) -> DeviceAddFlags:
         """Parse device-add-flags for config-driven storage handling."""

--- a/src/storage.py
+++ b/src/storage.py
@@ -290,17 +290,38 @@ class StorageHandler(Object):
         raw_flags = (self.charm.model.config.get("device-add-flags", "") or "").split(",")
         return any(flag.strip().lower() in waldb_flags for flag in raw_flags if flag.strip())
 
+    def _cacheable_osd_request(self, storage_request: dict) -> dict:
+        """Return the subset of storage config that can trigger a new snap command."""
+        return {
+            "osd_match": storage_request["osd_match"],
+            "flags": {
+                "wipe_osd": storage_request["flags"]["wipe_osd"],
+                "encrypt_osd": storage_request["flags"]["encrypt_osd"],
+            },
+        }
+
     def _storage_config_signature(self, storage_request: dict) -> str:
-        """Build a stable signature for the normalized storage request."""
-        return json.dumps(storage_request, sort_keys=True, separators=(",", ":"))
+        """Build a stable signature for OSD-affecting storage inputs."""
+        return json.dumps(
+            self._cacheable_osd_request(storage_request),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
 
     def _reset_osd_config_cache(self):
         """Reset cache for last successfully applied config-driven storage request."""
+        self._stored.last_osd_devices = ""
+        self._stored.last_wipe_osd = False
+        self._stored.last_encrypt_osd = False
         self._stored.last_storage_config_signature = ""
         logger.debug("Reset config-driven storage cache")
 
     def _set_osd_config_cache(self, storage_request: dict):
         """Persist cache for last successfully applied config-driven storage request."""
+        cacheable_request = self._cacheable_osd_request(storage_request)
+        self._stored.last_osd_devices = cacheable_request["osd_match"]
+        self._stored.last_wipe_osd = cacheable_request["flags"]["wipe_osd"]
+        self._stored.last_encrypt_osd = cacheable_request["flags"]["encrypt_osd"]
         self._stored.last_storage_config_signature = self._storage_config_signature(
             storage_request
         )
@@ -311,8 +332,32 @@ class StorageHandler(Object):
 
     def _is_cached_osd_config(self, storage_request: dict) -> bool:
         """Check whether current config-driven storage request was already applied."""
-        return self._stored.last_storage_config_signature == self._storage_config_signature(
-            storage_request
+        requested = self._cacheable_osd_request(storage_request)
+        last_signature = self._stored.last_storage_config_signature
+
+        if last_signature:
+            if last_signature == self._storage_config_signature(storage_request):
+                return True
+
+            try:
+                cached_request = json.loads(last_signature)
+            except (TypeError, ValueError):
+                cached_request = None
+
+            if isinstance(cached_request, dict):
+                cached_flags = cached_request.get("flags") or {}
+                if (
+                    cached_request.get("osd_match") == requested["osd_match"]
+                    and cached_flags.get("wipe_osd", False) == requested["flags"]["wipe_osd"]
+                    and cached_flags.get("encrypt_osd", False)
+                    == requested["flags"]["encrypt_osd"]
+                ):
+                    return True
+
+        return (
+            self._stored.last_osd_devices == requested["osd_match"]
+            and self._stored.last_wipe_osd == requested["flags"]["wipe_osd"]
+            and self._stored.last_encrypt_osd == requested["flags"]["encrypt_osd"]
         )
 
     def _set_storage_config_idle_status(self):

--- a/src/storage.py
+++ b/src/storage.py
@@ -18,6 +18,7 @@
 
 import json
 import logging
+from dataclasses import asdict
 from subprocess import CalledProcessError, TimeoutExpired, run
 
 import ops_sunbeam.guard as sunbeam_guard
@@ -61,6 +62,7 @@ class StorageHandler(Object):
             last_osd_devices="",
             last_wipe_osd=False,
             last_encrypt_osd=False,
+            last_storage_config_signature="",
         )
         self.charm = charm
         self.name = name
@@ -203,104 +205,153 @@ class StorageHandler(Object):
         event.set_results({"osds": osds, "unpartitioned-disks": available_disks})
 
     def _on_config_changed_osd_devices(self, event):
-        """Process osd-devices config option.
-
-        This method is called on config-changed events to enroll matching
-        devices as OSDs. The DSL expression is passed to the MicroCeph snap
-        which performs device matching and enrollment.
-        """
-        osd_devices = self.charm.model.config.get("osd-devices", "")
-        device_add_flags = self.charm.model.config.get("device-add-flags", "")
-        osd_match = osd_devices.strip()
-
-        # Skip if osd-devices is not configured
-        if not osd_match:
-            logger.debug("osd-devices config not set, skipping config-based OSD enrollment")
-            self._reset_osd_config_cache()
-            return
-
-        # Wait for cluster to be ready
-        if not self.charm.ready_for_service():
-            logger.warning("MicroCeph not ready yet, deferring osd-devices processing")
-            event.defer()
-            return
-
-        # Execute the OSD match command
+        """Process config-driven storage requests for OSD/WAL/DB matching."""
         with sunbeam_guard.guard(self.charm, self.name):
-            flags = self._parse_osd_device_flags(device_add_flags)
-            if self._is_cached_osd_config(osd_match, flags):
+            storage_request = self._normalize_storage_config()
+
+            if not storage_request["osd_match"]:
+                if self._has_ignored_waldb_config():
+                    logger.info("WAL/DB settings ignored because no new OSDs are being added")
                 logger.debug(
-                    "Skipping osd-devices processing: unchanged config osd_match=%s wipe=%s encrypt=%s",
-                    osd_match,
-                    flags.wipe_osd,
-                    flags.encrypt_osd,
+                    "osd-devices config not set, skipping config-based storage enrollment"
+                )
+                self._reset_osd_config_cache()
+                return
+
+            self._validate_storage_config(storage_request)
+
+            if not self.charm.ready_for_service():
+                logger.warning("MicroCeph not ready yet, deferring storage config processing")
+                event.defer()
+                return
+
+            if self._is_cached_osd_config(storage_request):
+                logger.debug(
+                    "Skipping storage config processing: unchanged signature=%s",
+                    self._storage_config_signature(storage_request),
                 )
                 return
 
-            self._apply_osd_config(osd_match, flags)
+            self._apply_osd_config(storage_request)
+
+    def _normalize_storage_config(self) -> dict:
+        """Normalize config-driven storage settings into a stable request dict."""
+        osd_match = self._normalized_config_value("osd-devices")
+        if not osd_match:
+            return {
+                "osd_match": None,
+                "wal_match": None,
+                "db_match": None,
+                "wal_size": None,
+                "db_size": None,
+                "flags": asdict(DeviceAddFlags()),
+            }
+
+        flags = self._parse_osd_device_flags(self.charm.model.config.get("device-add-flags", ""))
+        return {
+            "osd_match": osd_match,
+            "wal_match": self._normalized_config_value("wal-devices"),
+            "db_match": self._normalized_config_value("db-devices"),
+            "wal_size": self._normalized_config_value("wal-size"),
+            "db_size": self._normalized_config_value("db-size"),
+            "flags": asdict(flags),
+        }
+
+    def _normalized_config_value(self, key: str):
+        """Trim a string config value and convert empty strings to None."""
+        value = (self.charm.model.config.get(key, "") or "").strip()
+        return value or None
+
+    def _has_ignored_waldb_config(self) -> bool:
+        """Whether WAL/DB config was provided without an OSD activation request."""
+        if any(
+            self._normalized_config_value(key)
+            for key in ("wal-devices", "db-devices", "wal-size", "db-size")
+        ):
+            return True
+
+        waldb_flags = {"wipe:wal", "encrypt:wal", "wipe:db", "encrypt:db"}
+        raw_flags = (self.charm.model.config.get("device-add-flags", "") or "").split(",")
+        return any(flag.strip().lower() in waldb_flags for flag in raw_flags if flag.strip())
+
+    def _storage_config_signature(self, storage_request: dict) -> str:
+        """Build a stable signature for the normalized storage request."""
+        return json.dumps(storage_request, sort_keys=True, separators=(",", ":"))
 
     def _reset_osd_config_cache(self):
-        """Reset cache for last successfully applied osd-devices configuration."""
-        self._stored.last_osd_devices = ""
-        self._stored.last_wipe_osd = False
-        self._stored.last_encrypt_osd = False
-        logger.debug("Reset osd-devices config cache")
+        """Reset cache for last successfully applied config-driven storage request."""
+        self._stored.last_storage_config_signature = ""
+        logger.debug("Reset config-driven storage cache")
 
-    def _set_osd_config_cache(self, osd_match: str, flags: DeviceAddFlags):
-        """Persist cache for last successfully applied osd-devices configuration."""
-        self._stored.last_osd_devices = osd_match
-        self._stored.last_wipe_osd = flags.wipe_osd
-        self._stored.last_encrypt_osd = flags.encrypt_osd
+    def _set_osd_config_cache(self, storage_request: dict):
+        """Persist cache for last successfully applied config-driven storage request."""
+        self._stored.last_storage_config_signature = self._storage_config_signature(
+            storage_request
+        )
         logger.debug(
-            "Updated osd-devices config cache osd_match=%s wipe=%s encrypt=%s",
-            osd_match,
-            flags.wipe_osd,
-            flags.encrypt_osd,
+            "Updated storage config cache signature=%s",
+            self._stored.last_storage_config_signature,
         )
 
-    def _is_cached_osd_config(self, osd_match: str, flags: DeviceAddFlags) -> bool:
-        """Check whether current osd-devices configuration was already applied."""
-        return (
-            self._stored.last_osd_devices == osd_match
-            and self._stored.last_wipe_osd == flags.wipe_osd
-            and self._stored.last_encrypt_osd == flags.encrypt_osd
+    def _is_cached_osd_config(self, storage_request: dict) -> bool:
+        """Check whether current config-driven storage request was already applied."""
+        return self._stored.last_storage_config_signature == self._storage_config_signature(
+            storage_request
         )
 
     def _parse_osd_device_flags(self, device_add_flags: str) -> DeviceAddFlags:
-        """Parse device-add-flags for osd-devices handling."""
+        """Parse device-add-flags for config-driven storage handling."""
         try:
             return parse_device_add_flags(device_add_flags)
         except ValueError as e:
             raise sunbeam_guard.BlockedExceptionError(f"Invalid device-add-flags: {e}")
 
-    def _apply_osd_config(self, osd_match: str, flags: DeviceAddFlags):
-        """Execute OSD enrollment via osd-match and cache successful configs."""
+    def _validate_storage_config(self, storage_request: dict):
+        """Validate the minimal charm-owned storage config combinations."""
+        if storage_request["wal_match"] and not storage_request["wal_size"]:
+            raise sunbeam_guard.BlockedExceptionError(
+                "Invalid storage config: wal-devices requires wal-size"
+            )
+        if storage_request["db_match"] and not storage_request["db_size"]:
+            raise sunbeam_guard.BlockedExceptionError(
+                "Invalid storage config: db-devices requires db-size"
+            )
+
+    def _apply_osd_config(self, storage_request: dict):
+        """Execute config-driven storage enrollment and cache successful requests."""
         logger.info(
-            "Processing osd-devices config osd_match=%s wipe=%s encrypt=%s",
-            osd_match,
-            flags.wipe_osd,
-            flags.encrypt_osd,
+            "Processing storage config request: %s",
+            json.dumps(storage_request, sort_keys=True),
         )
         try:
-            self.charm.status.set(MaintenanceStatus("Processing osd-devices config"))
-            microceph.add_osd_match_cmd(
-                osd_match=osd_match,
-                wipe=flags.wipe_osd,
-                encrypt=flags.encrypt_osd,
+            self.charm.status.set(MaintenanceStatus("Processing storage config"))
+            output = microceph.add_disk_match_cmd(
+                osd_match=storage_request["osd_match"],
+                wal_match=storage_request["wal_match"],
+                wal_size=storage_request["wal_size"],
+                db_match=storage_request["db_match"],
+                db_size=storage_request["db_size"],
+                wipe=storage_request["flags"]["wipe_osd"],
+                encrypt=storage_request["flags"]["encrypt_osd"],
+                wal_wipe=storage_request["flags"]["wipe_wal"],
+                wal_encrypt=storage_request["flags"]["encrypt_wal"],
+                db_wipe=storage_request["flags"]["wipe_db"],
+                db_encrypt=storage_request["flags"]["encrypt_db"],
             )
+            if output and output.strip():
+                logger.info("Storage config command output:\n%s", output.strip())
             self.charm.status.set(ActiveStatus("charm is ready"))
-            self._set_osd_config_cache(osd_match, flags)
-            logger.info("Successfully processed osd-devices config: %s", osd_match)
+            self._set_osd_config_cache(storage_request)
+            logger.info("Successfully processed storage config request")
         except (CalledProcessError, TimeoutExpired) as e:
             err_msg = self._error_message(e)
-            # "no devices matched" is not an error - it's a valid scenario
             if "no devices matched" in err_msg.lower():
-                logger.info("No devices matched osd-devices DSL expression")
+                logger.info("No devices matched config-driven OSD request")
                 self.charm.status.set(ActiveStatus("charm is ready"))
-                self._set_osd_config_cache(osd_match, flags)
+                self._set_osd_config_cache(storage_request)
                 return
 
-            logger.error("Failed to process osd-devices config %s: %s", osd_match, err_msg)
+            logger.error("Failed to process storage config %s", err_msg)
             raise sunbeam_guard.BlockedExceptionError(f"Failed to add OSDs via config: {err_msg}")
 
     # helper functions
@@ -324,7 +375,7 @@ class StorageHandler(Object):
 
     def _error_message(self, exc: Exception) -> str:
         """Build an actionable error message from subprocess exceptions."""
-        return getattr(exc, "stderr", None) or str(exc)
+        return getattr(exc, "stderr", None) or getattr(exc, "stdout", None) or str(exc)
 
     def _run(self, cmd: list) -> str:
         """Wrapper around subprocess run for storage commands."""

--- a/src/storage.py
+++ b/src/storage.py
@@ -24,13 +24,20 @@ from subprocess import CalledProcessError, TimeoutExpired, run
 import ops_sunbeam.guard as sunbeam_guard
 from ops.charm import ActionEvent, CharmBase, StorageAttachedEvent, StorageDetachingEvent
 from ops.framework import Object, StoredState
-from ops.model import ActiveStatus, MaintenanceStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 import microceph
 from device_flags import DeviceAddFlags, parse_device_add_flags
 
 logger = logging.getLogger(__name__)
+
+STORAGE_CONFIG_STATUS_PREFIXES = (
+    "Invalid storage config:",
+    "Invalid device-add-flags:",
+    "Failed to add OSDs via config:",
+)
+STORAGE_CONFIG_MAINTENANCE_MESSAGES = frozenset({"Processing storage config"})
 
 
 class StorageHandler(Object):
@@ -221,6 +228,16 @@ class StorageHandler(Object):
                 )
                 self._reset_osd_config_cache()
                 self._set_storage_config_idle_status()
+                return
+
+            if self._has_unrelated_workload_status():
+                status = self.charm.status.status
+                logger.debug(
+                    "Skipping config-driven storage processing because workload status is "
+                    "owned by another handler status=%s message=%s",
+                    status.name,
+                    getattr(status, "message", ""),
+                )
                 return
 
             self._validate_storage_config(storage_request)
@@ -466,8 +483,7 @@ class StorageHandler(Object):
                 if (
                     cached_request.get("osd_match") == requested["osd_match"]
                     and cached_flags.get("wipe_osd", False) == requested["flags"]["wipe_osd"]
-                    and cached_flags.get("encrypt_osd", False)
-                    == requested["flags"]["encrypt_osd"]
+                    and cached_flags.get("encrypt_osd", False) == requested["flags"]["encrypt_osd"]
                 ):
                     logger.debug("Storage config cache hit via parsed legacy signature")
                     return True
@@ -484,10 +500,39 @@ class StorageHandler(Object):
         logger.debug("Storage config cache miss")
         return False
 
+    def _is_storage_config_status(self, status) -> bool:
+        """Whether the current workload status is owned by config-driven storage."""
+        if isinstance(status, MaintenanceStatus):
+            return status.message in STORAGE_CONFIG_MAINTENANCE_MESSAGES
+
+        if isinstance(status, (BlockedStatus, WaitingStatus)):
+            return status.message.startswith(STORAGE_CONFIG_STATUS_PREFIXES)
+
+        return False
+
+    def _has_unrelated_workload_status(self) -> bool:
+        """Whether another handler already owns a blocking workload status."""
+        status = self.charm.status.status
+        return isinstance(status, BlockedStatus) and not self._is_storage_config_status(status)
+
     def _set_storage_config_idle_status(self):
         """Restore ready status for storage-config no-op/recovery paths."""
         if not self.charm.ready_for_service():
             logger.debug("Skipping idle status restore because charm is not ready for service")
+            return
+
+        status = self.charm.status.status
+        if isinstance(status, ActiveStatus):
+            logger.debug("Skipping idle status restore because workload status is already active")
+            return
+
+        if isinstance(status, BlockedStatus) and not self._is_storage_config_status(status):
+            logger.debug(
+                "Preserving existing blocked workload status during storage-config idle "
+                "path status=%s message=%s",
+                status.name,
+                getattr(status, "message", ""),
+            )
             return
 
         logger.debug("Restoring active status for storage-config idle path")
@@ -525,8 +570,7 @@ class StorageHandler(Object):
                 storage_request["db_match"],
             )
             logger.debug(
-                "Invalid storage config detected: db-devices is set without db-size "
-                "request=%s",
+                "Invalid storage config detected: db-devices is set without db-size request=%s",
                 json.dumps(storage_request, sort_keys=True),
             )
             raise sunbeam_guard.BlockedExceptionError(

--- a/src/storage.py
+++ b/src/storage.py
@@ -20,24 +20,19 @@ import json
 import logging
 from dataclasses import asdict
 from subprocess import CalledProcessError, TimeoutExpired, run
+from types import SimpleNamespace
 
+import ops_sunbeam.compound_status as compound_status
 import ops_sunbeam.guard as sunbeam_guard
 from ops.charm import ActionEvent, CharmBase, StorageAttachedEvent, StorageDetachingEvent
 from ops.framework import Object, StoredState
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
+from ops.model import ActiveStatus, MaintenanceStatus
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 import microceph
 from device_flags import DeviceAddFlags, parse_device_add_flags
 
 logger = logging.getLogger(__name__)
-
-STORAGE_CONFIG_STATUS_PREFIXES = (
-    "Invalid storage config:",
-    "Invalid device-add-flags:",
-    "Failed to add OSDs via config:",
-)
-STORAGE_CONFIG_MAINTENANCE_MESSAGES = frozenset({"Processing storage config"})
 
 
 class StorageHandler(Object):
@@ -73,6 +68,12 @@ class StorageHandler(Object):
         )
         self.charm = charm
         self.name = name
+        self.storage_status = compound_status.Status(self.name)
+        self.storage_config_status = compound_status.Status(f"{self.name}-config")
+        self.charm.status_pool.add(self.storage_status)
+        self.charm.status_pool.add(self.storage_config_status)
+        self._storage_guard = SimpleNamespace(status=self.storage_status)
+        self._storage_config_guard = SimpleNamespace(status=self.storage_config_status)
 
         # Attach handlers
         self.framework.observe(
@@ -113,10 +114,10 @@ class StorageHandler(Object):
                 enroll.append(storage)
 
         logger.debug(f"Enroll list {enroll}")
-        with sunbeam_guard.guard(self.charm, self.name):
-            self.charm.status.set(MaintenanceStatus("Enrolling OSDs"))
+        with sunbeam_guard.guard(self._storage_guard, self.name):
+            self.storage_status.set(MaintenanceStatus("Enrolling OSDs"))
             self._enroll_disks_in_batch(enroll)
-            self.charm.status.set(ActiveStatus("charm is ready"))
+            self.storage_status.set(ActiveStatus(""))
 
     def _on_storage_detaching(self, event: StorageDetachingEvent):
         """Unified storage detaching handler."""
@@ -129,7 +130,7 @@ class StorageHandler(Object):
         if osd_num is None:
             return
 
-        with sunbeam_guard.guard(self.charm, self.name):
+        with sunbeam_guard.guard(self._storage_guard, self.name):
             try:
                 self.remove_osd(osd_num)
             except CalledProcessError as e:
@@ -213,7 +214,7 @@ class StorageHandler(Object):
 
     def _on_config_changed_osd_devices(self, event):
         """Process config-driven storage requests for OSD/WAL/DB matching."""
-        with sunbeam_guard.guard(self.charm, self.name):
+        with sunbeam_guard.guard(self._storage_config_guard, f"{self.name}-config"):
             storage_request = self._normalize_storage_config()
             logger.debug(
                 "Normalized storage config request: %s",
@@ -490,45 +491,15 @@ class StorageHandler(Object):
         logger.debug("Storage config cache miss")
         return False
 
-    def _is_storage_config_status(self, status) -> bool:
-        """Whether the current workload status is owned by config-driven storage."""
-        if isinstance(status, MaintenanceStatus):
-            return status.message in STORAGE_CONFIG_MAINTENANCE_MESSAGES
-
-        if isinstance(status, (BlockedStatus, WaitingStatus)):
-            return status.message.startswith(STORAGE_CONFIG_STATUS_PREFIXES)
-
-        return False
-
-    def _unrelated_blocked_workload_status(self):
-        """Return a pre-existing non-storage blocked workload status, if any."""
-        status = self.charm.status.status
-        if isinstance(status, BlockedStatus) and not self._is_storage_config_status(status):
-            return status
-        return None
-
     def _set_storage_config_idle_status(self):
-        """Restore ready status for storage-config no-op/recovery paths."""
-        if not self.charm.ready_for_service():
-            logger.debug("Skipping idle status restore because charm is not ready for service")
-            return
-
-        status = self.charm.status.status
-        if isinstance(status, ActiveStatus):
-            logger.debug("Skipping idle status restore because workload status is already active")
-            return
-
-        if isinstance(status, BlockedStatus) and not self._is_storage_config_status(status):
-            logger.debug(
-                "Preserving existing blocked workload status during storage-config idle "
-                "path status=%s message=%s",
-                status.name,
-                getattr(status, "message", ""),
-            )
+        """Clear config-driven storage status for no-op/recovery paths."""
+        status = self.storage_config_status.status
+        if isinstance(status, ActiveStatus) and not status.message:
+            logger.debug("Storage-config status already active")
             return
 
         logger.debug("Restoring active status for storage-config idle path")
-        self.charm.status.set(ActiveStatus("charm is ready"))
+        self.storage_config_status.set(ActiveStatus(""))
 
     def _parse_osd_device_flags(self, device_add_flags: str) -> DeviceAddFlags:
         """Parse device-add-flags for config-driven storage handling."""
@@ -584,16 +555,8 @@ class StorageHandler(Object):
             storage_request["flags"]["wipe_osd"],
             storage_request["flags"]["encrypt_osd"],
         )
-        preserved_status = self._unrelated_blocked_workload_status()
         try:
-            if preserved_status is None:
-                self.charm.status.set(MaintenanceStatus("Processing storage config"))
-            else:
-                logger.debug(
-                    "Processing storage config while preserving unrelated blocked status "
-                    "message=%s",
-                    preserved_status.message,
-                )
+            self.storage_config_status.set(MaintenanceStatus("Processing storage config"))
             logger.debug(
                 "Calling microceph.add_disk_match_cmd for request=%s",
                 json.dumps(storage_request, sort_keys=True),
@@ -613,15 +576,7 @@ class StorageHandler(Object):
             )
             if output and output.strip():
                 logger.info("Storage config command output:\n%s", output.strip())
-            if preserved_status is not None:
-                logger.debug(
-                    "Restoring unrelated blocked status after successful storage config apply "
-                    "message=%s",
-                    preserved_status.message,
-                )
-                self.charm.status.set(preserved_status)
-            else:
-                self.charm.status.set(ActiveStatus("charm is ready"))
+            self.storage_config_status.set(ActiveStatus(""))
             self._set_osd_config_cache(storage_request)
             logger.info(
                 "Successfully processed storage config osd_match=%s wal_enabled=%s "
@@ -637,15 +592,7 @@ class StorageHandler(Object):
                     "No devices matched config-driven OSD request request=%s",
                     json.dumps(storage_request, sort_keys=True),
                 )
-                if preserved_status is not None:
-                    logger.debug(
-                        "Restoring unrelated blocked status after no-op storage config "
-                        "message=%s",
-                        preserved_status.message,
-                    )
-                    self.charm.status.set(preserved_status)
-                else:
-                    self.charm.status.set(ActiveStatus("charm is ready"))
+                self.storage_config_status.set(ActiveStatus(""))
                 self._set_osd_config_cache(storage_request)
                 return
 

--- a/src/storage.py
+++ b/src/storage.py
@@ -230,16 +230,6 @@ class StorageHandler(Object):
                 self._set_storage_config_idle_status()
                 return
 
-            if self._has_unrelated_workload_status():
-                status = self.charm.status.status
-                logger.debug(
-                    "Skipping config-driven storage processing because workload status is "
-                    "owned by another handler status=%s message=%s",
-                    status.name,
-                    getattr(status, "message", ""),
-                )
-                return
-
             self._validate_storage_config(storage_request)
 
             if not self.charm.ready_for_service():
@@ -510,10 +500,12 @@ class StorageHandler(Object):
 
         return False
 
-    def _has_unrelated_workload_status(self) -> bool:
-        """Whether another handler already owns a blocking workload status."""
+    def _unrelated_blocked_workload_status(self):
+        """Return a pre-existing non-storage blocked workload status, if any."""
         status = self.charm.status.status
-        return isinstance(status, BlockedStatus) and not self._is_storage_config_status(status)
+        if isinstance(status, BlockedStatus) and not self._is_storage_config_status(status):
+            return status
+        return None
 
     def _set_storage_config_idle_status(self):
         """Restore ready status for storage-config no-op/recovery paths."""
@@ -592,8 +584,16 @@ class StorageHandler(Object):
             storage_request["flags"]["wipe_osd"],
             storage_request["flags"]["encrypt_osd"],
         )
+        preserved_status = self._unrelated_blocked_workload_status()
         try:
-            self.charm.status.set(MaintenanceStatus("Processing storage config"))
+            if preserved_status is None:
+                self.charm.status.set(MaintenanceStatus("Processing storage config"))
+            else:
+                logger.debug(
+                    "Processing storage config while preserving unrelated blocked status "
+                    "message=%s",
+                    preserved_status.message,
+                )
             logger.debug(
                 "Calling microceph.add_disk_match_cmd for request=%s",
                 json.dumps(storage_request, sort_keys=True),
@@ -613,7 +613,15 @@ class StorageHandler(Object):
             )
             if output and output.strip():
                 logger.info("Storage config command output:\n%s", output.strip())
-            self.charm.status.set(ActiveStatus("charm is ready"))
+            if preserved_status is not None:
+                logger.debug(
+                    "Restoring unrelated blocked status after successful storage config apply "
+                    "message=%s",
+                    preserved_status.message,
+                )
+                self.charm.status.set(preserved_status)
+            else:
+                self.charm.status.set(ActiveStatus("charm is ready"))
             self._set_osd_config_cache(storage_request)
             logger.info(
                 "Successfully processed storage config osd_match=%s wal_enabled=%s "
@@ -629,7 +637,15 @@ class StorageHandler(Object):
                     "No devices matched config-driven OSD request request=%s",
                     json.dumps(storage_request, sort_keys=True),
                 )
-                self.charm.status.set(ActiveStatus("charm is ready"))
+                if preserved_status is not None:
+                    logger.debug(
+                        "Restoring unrelated blocked status after no-op storage config "
+                        "message=%s",
+                        preserved_status.message,
+                    )
+                    self.charm.status.set(preserved_status)
+                else:
+                    self.charm.status.set(ActiveStatus("charm is ready"))
                 self._set_osd_config_cache(storage_request)
                 return
 

--- a/tests/functests/conftest.py
+++ b/tests/functests/conftest.py
@@ -69,9 +69,10 @@ def attached_lxd_volume(juju: jubilant.Juju, deployed_microceph: str) -> Iterato
     model_name = juju.status().model.name
     vol_name = f"functest-{model_name}"
 
+    existing_disks = set(lxd.list_disks(juju, unit_name))
     lxd.create_and_attach_volume(pool, vol_name, inst_id)
     try:
-        disk_path = lxd.wait_for_disk(juju, unit_name)
+        disk_path = lxd.wait_for_disk(juju, unit_name, existing_disks=existing_disks)
         logger.info(f"Block device available at {disk_path}")
         yield disk_path
     finally:

--- a/tests/helpers/lxd.py
+++ b/tests/helpers/lxd.py
@@ -16,8 +16,10 @@
 
 import json
 import logging
+import re
 import subprocess
 import time
+from collections.abc import Collection
 
 import jubilant
 
@@ -69,18 +71,47 @@ def cleanup_volume(pool: str, vol_name: str, instance_id: str) -> None:
     subprocess.run(["lxc", "storage", "volume", "delete", pool, vol_name], check=False)
 
 
-def wait_for_disk(juju: jubilant.Juju, unit_name: str, size_pattern: str = "1G|953.7M") -> str:
-    """Wait for a disk matching the size pattern to appear in the unit."""
+def list_disks(juju: jubilant.Juju, unit_name: str) -> dict[str, str]:
+    """Return visible block disks keyed by in-guest path."""
+    output = juju.ssh(unit_name, "lsblk", "-d", "-J", "-o", "PATH,SIZE,TYPE")
+    blockdevices = json.loads(output).get("blockdevices", [])
+    return {
+        device["path"]: device["size"]
+        for device in blockdevices
+        if device.get("type") == "disk" and device.get("path") and device.get("size")
+    }
+
+
+def wait_for_disk(
+    juju: jubilant.Juju,
+    unit_name: str,
+    size_pattern: str = "1G|953.7M",
+    existing_disks: Collection[str] | None = None,
+) -> str:
+    """Wait for a newly attached disk matching the size pattern to appear in the unit."""
     logger.info("Waiting for disk to appear")
+    size_matcher = re.compile(rf"^(?:{size_pattern})$")
+    known_disks = set(existing_disks or ())
+    last_seen: dict[str, str] = {}
+
     for _ in range(30):
-        # Look for disk with specific size
-        cmd = f"lsblk -d -o NAME,SIZE,TYPE | grep -E '{size_pattern}' | grep 'disk' | awk '{{print \"/dev/\" $1}}' | head -n1"
         try:
-            disk_path = juju.ssh(unit_name, cmd).strip()
-            if disk_path:
-                return disk_path
+            disks = list_disks(juju, unit_name)
+            last_seen = disks
+            candidates = {
+                path: size
+                for path, size in disks.items()
+                if path not in known_disks and size_matcher.fullmatch(size)
+            }
+            if len(candidates) == 1:
+                return sorted(candidates)[0]
+            if candidates:
+                logger.info("Found multiple matching new disks: %s", sorted(candidates))
         except Exception as e:
-            logger.warning(f"SSH failed: {e}")
+            logger.warning("SSH failed: %s", e)
         time.sleep(5)
 
-    raise TimeoutError("Attached disk not found in VM")
+    raise TimeoutError(
+        f"Attached disk not found in VM; size_pattern={size_pattern!r}, "
+        f"existing_disks={sorted(known_disks)}, visible_disks={last_seen}"
+    )

--- a/tests/integration/test_osd_devices_config.py
+++ b/tests/integration/test_osd_devices_config.py
@@ -109,9 +109,15 @@ def attached_block_device(juju_vm: jubilant.Juju, deployed_microceph) -> Iterato
     model_name = juju_vm.status().model.name
     vol_name = f"osd-cfg-test-{model_name}"
 
+    existing_disks = set(lxd.list_disks(juju_vm, unit_name))
     lxd.create_and_attach_volume(pool, vol_name, inst_id, size="3GB")
     try:
-        disk_path = lxd.wait_for_disk(juju_vm, unit_name, size_pattern="3G|2.8G|2.9G")
+        disk_path = lxd.wait_for_disk(
+            juju_vm,
+            unit_name,
+            size_pattern="3G|2.8G|2.9G",
+            existing_disks=existing_disks,
+        )
         logger.info(f"Block device available at {disk_path}")
         yield disk_path
     finally:
@@ -365,9 +371,15 @@ def second_block_device(juju_vm: jubilant.Juju, deployed_microceph) -> Iterator[
     model_name = juju_vm.status().model.name
     vol_name = f"osd-cfg-test2-{model_name}"
 
+    existing_disks = set(lxd.list_disks(juju_vm, unit_name))
     lxd.create_and_attach_volume(pool, vol_name, inst_id, size="4GB")
     try:
-        disk_path = lxd.wait_for_disk(juju_vm, unit_name, size_pattern="4G|3.7G|3.8G|3.9G")
+        disk_path = lxd.wait_for_disk(
+            juju_vm,
+            unit_name,
+            size_pattern="4G|3.7G|3.8G|3.9G",
+            existing_disks=existing_disks,
+        )
         logger.info(f"Second block device available at {disk_path}")
         yield disk_path
     finally:

--- a/tests/integration/test_storage_waldb_config.py
+++ b/tests/integration/test_storage_waldb_config.py
@@ -112,8 +112,14 @@ def _create_attached_disk(
     model_name = juju_vm.status().model.name
     vol_name = f"{prefix}-{model_name}"
 
+    existing_disks = set(lxd.list_disks(juju_vm, unit_name))
     lxd.create_and_attach_volume(pool, vol_name, inst_id, size=size)
-    disk_path = lxd.wait_for_disk(juju_vm, unit_name, size_pattern=size_pattern)
+    disk_path = lxd.wait_for_disk(
+        juju_vm,
+        unit_name,
+        size_pattern=size_pattern,
+        existing_disks=existing_disks,
+    )
     logger.info("Attached %s volume %s at %s", prefix, vol_name, disk_path)
     return pool, vol_name, inst_id, disk_path
 

--- a/tests/integration/test_storage_waldb_config.py
+++ b/tests/integration/test_storage_waldb_config.py
@@ -132,7 +132,7 @@ def _resolve_osd_link(juju_vm: jubilant.Juju, osd_num: int, link_name: str) -> s
     """Resolve an OSD data-dir symlink such as ``block.db`` or ``block.wal``."""
     unit_name = helpers.first_unit_name(juju_vm.status(), APP_NAME)
     script = (
-        f'path=/var/snap/microceph/common/data/osd/ceph-{osd_num}/{link_name}; '
+        f"path=/var/snap/microceph/common/data/osd/ceph-{osd_num}/{link_name}; "
         'if [ -e "$path" ]; then readlink -f "$path"; fi'
     )
     return juju_vm.ssh(unit_name, "sudo", "bash", "-ec", script).strip()

--- a/tests/integration/test_storage_waldb_config.py
+++ b/tests/integration/test_storage_waldb_config.py
@@ -1,0 +1,361 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for declarative OSD/WAL/DB storage provisioning."""
+
+import json
+import logging
+from pathlib import Path
+from typing import Iterator
+
+import jubilant
+import pytest
+
+from tests import helpers
+from tests.helpers import lxd
+
+logger = logging.getLogger(__name__)
+
+APP_NAME = "microceph"
+
+
+def _wait_for_active(juju_vm: jubilant.Juju, timeout: int = 300) -> None:
+    """Wait for the application to become active/idle."""
+    with helpers.fast_forward(juju_vm):
+        helpers.wait_for_apps(juju_vm, APP_NAME, timeout=timeout)
+
+
+def _set_storage_config(
+    juju_vm: jubilant.Juju,
+    *,
+    osd_devices: str = "",
+    wal_devices: str = "",
+    db_devices: str = "",
+    wal_size: str = "",
+    db_size: str = "",
+    device_add_flags: str = "",
+) -> None:
+    """Apply config-driven storage options."""
+    juju_vm.config(
+        APP_NAME,
+        {
+            "osd-devices": osd_devices,
+            "wal-devices": wal_devices,
+            "db-devices": db_devices,
+            "wal-size": wal_size,
+            "db-size": db_size,
+            "device-add-flags": device_add_flags,
+        },
+    )
+
+
+def _apply_storage_config_and_wait(
+    juju_vm: jubilant.Juju,
+    *,
+    osd_devices: str,
+    wal_devices: str = "",
+    db_devices: str = "",
+    wal_size: str = "",
+    db_size: str = "",
+    device_add_flags: str = "",
+    timeout: int = 600,
+) -> None:
+    """Apply config-driven storage settings and wait for active state."""
+    _set_storage_config(
+        juju_vm,
+        osd_devices=osd_devices,
+        wal_devices=wal_devices,
+        db_devices=db_devices,
+        wal_size=wal_size,
+        db_size=db_size,
+        device_add_flags=device_add_flags,
+    )
+    _wait_for_active(juju_vm, timeout=timeout)
+
+
+def _clear_storage_config_and_wait(juju_vm: jubilant.Juju, timeout: int = 300) -> None:
+    """Clear config-driven storage settings and wait for active state."""
+    _set_storage_config(juju_vm)
+    status = juju_vm.status()
+    unit_name = helpers.first_unit_name(status, APP_NAME)
+    unit_status = status.apps[APP_NAME].units[unit_name]
+    if (
+        unit_status.juju_status.current == "error"
+        or unit_status.workload_status.current == "error"
+    ):
+        juju_vm.cli("resolved", unit_name)
+    _wait_for_active(juju_vm, timeout=timeout)
+
+
+def _create_attached_disk(
+    juju_vm: jubilant.Juju,
+    *,
+    prefix: str,
+    size: str,
+    size_pattern: str,
+) -> tuple[str, str, str, str]:
+    """Create and attach an LXD block volume, returning cleanup metadata and path."""
+    unit_name = helpers.first_unit_name(juju_vm.status(), APP_NAME)
+    inst_id = lxd.get_instance_id(juju_vm, APP_NAME, unit_name)
+    pool = lxd.get_lxd_storage_pool()
+    model_name = juju_vm.status().model.name
+    vol_name = f"{prefix}-{model_name}"
+
+    lxd.create_and_attach_volume(pool, vol_name, inst_id, size=size)
+    disk_path = lxd.wait_for_disk(juju_vm, unit_name, size_pattern=size_pattern)
+    logger.info("Attached %s volume %s at %s", prefix, vol_name, disk_path)
+    return pool, vol_name, inst_id, disk_path
+
+
+@pytest.fixture(scope="module")
+def deployed_microceph(juju_vm: jubilant.Juju, microceph_charm: Path):
+    """Deploy MicroCeph in a VM suitable for block-device integration tests."""
+    helpers.deploy_microceph(
+        juju_vm,
+        microceph_charm,
+        APP_NAME,
+        config={"snap-channel": "latest/edge"},
+        timeout=3600,
+    )
+    return APP_NAME
+
+
+@pytest.fixture(scope="module")
+def happy_path_devices(juju_vm: jubilant.Juju, deployed_microceph) -> Iterator[dict[str, str]]:
+    """Attach distinct OSD, WAL, and DB devices for the happy-path test."""
+    attached = [
+        _create_attached_disk(
+            juju_vm, prefix="waldb-happy-osd", size="3GB", size_pattern="3G|2.8G|2.9G"
+        ),
+        _create_attached_disk(
+            juju_vm, prefix="waldb-happy-wal", size="4GB", size_pattern="4G|3.7G|3.8G|3.9G"
+        ),
+        _create_attached_disk(
+            juju_vm, prefix="waldb-happy-db", size="5GB", size_pattern="5G|4.6G|4.7G|4.8G"
+        ),
+    ]
+    try:
+        yield {"osd": attached[0][3], "wal": attached[1][3], "db": attached[2][3]}
+    finally:
+        for pool, vol_name, inst_id, _ in reversed(attached):
+            lxd.cleanup_volume(pool, vol_name, inst_id)
+
+
+@pytest.fixture(scope="module")
+def warning_path_devices(juju_vm: jubilant.Juju, deployed_microceph) -> Iterator[dict[str, str]]:
+    """Attach fresh OSD and DB devices for warning-only WAL coverage."""
+    attached = [
+        _create_attached_disk(
+            juju_vm, prefix="waldb-warn-osd", size="6GB", size_pattern="6G|5.5G|5.6G|5.7G"
+        ),
+        _create_attached_disk(
+            juju_vm, prefix="waldb-warn-db", size="7GB", size_pattern="7G|6.5G|6.6G|6.7G"
+        ),
+    ]
+    try:
+        yield {"osd": attached[0][3], "db": attached[1][3]}
+    finally:
+        for pool, vol_name, inst_id, _ in reversed(attached):
+            lxd.cleanup_volume(pool, vol_name, inst_id)
+
+
+@pytest.fixture(scope="module")
+def overlap_osd_device(juju_vm: jubilant.Juju, deployed_microceph) -> Iterator[str]:
+    """Attach a fresh OSD device used for overlap validation testing."""
+    pool, vol_name, inst_id, disk_path = _create_attached_disk(
+        juju_vm,
+        prefix="waldb-overlap-osd",
+        size="8GB",
+        size_pattern="8G|7.4G|7.5G|7.6G",
+    )
+    try:
+        yield disk_path
+    finally:
+        lxd.cleanup_volume(pool, vol_name, inst_id)
+
+
+@pytest.fixture(scope="module")
+def action_osd_device(juju_vm: jubilant.Juju, deployed_microceph) -> Iterator[str]:
+    """Attach a separate disk used to verify coexistence with add-osd."""
+    pool, vol_name, inst_id, disk_path = _create_attached_disk(
+        juju_vm,
+        prefix="waldb-action-osd",
+        size="9GB",
+        size_pattern="9G|8.3G|8.4G|8.5G",
+    )
+    try:
+        yield disk_path
+    finally:
+        lxd.cleanup_volume(pool, vol_name, inst_id)
+
+
+@pytest.mark.abort_on_fail
+def test_storage_config_snap_has_waldb_flags(juju_vm: jubilant.Juju, deployed_microceph):
+    """Verify the installed snap exposes the Phase 2 disk-add DSL flags."""
+    unit_name = helpers.first_unit_name(juju_vm.status(), APP_NAME)
+    help_output = juju_vm.ssh(unit_name, "sudo", "microceph", "disk", "add", "--help")
+
+    for expected_flag in (
+        "--osd-match",
+        "--wal-match",
+        "--wal-size",
+        "--wal-wipe",
+        "--wal-encrypt",
+        "--db-match",
+        "--db-size",
+        "--db-wipe",
+        "--db-encrypt",
+        "--dry-run",
+    ):
+        assert (
+            expected_flag in help_output
+        ), f"Snap does not support {expected_flag}. Help output:\n{help_output}"
+
+
+@pytest.mark.abort_on_fail
+def test_storage_config_missing_wal_size_blocks(
+    juju_vm: jubilant.Juju, deployed_microceph, warning_path_devices: dict[str, str]
+):
+    """Minimal charm-side validation should block wal-devices without wal-size."""
+    _set_storage_config(
+        juju_vm,
+        osd_devices=f"eq(@devnode,'{warning_path_devices['osd']}')",
+        wal_devices="eq(@devnode,'/dev/does-not-exist')",
+        db_devices=f"eq(@devnode,'{warning_path_devices['db']}')",
+        db_size="1GiB",
+        device_add_flags="wipe:osd,wipe:db",
+    )
+
+    with helpers.fast_forward(juju_vm):
+        helpers.wait_for_status(juju_vm, APP_NAME, ("blocked", "error"), timeout=180)
+
+    _clear_storage_config_and_wait(juju_vm, timeout=300)
+
+
+@pytest.mark.abort_on_fail
+def test_storage_config_happy_path_provisions_osd_wal_db(
+    juju_vm: jubilant.Juju, deployed_microceph, happy_path_devices: dict[str, str]
+):
+    """Provision an OSD with distinct WAL and DB carrier devices."""
+    _apply_storage_config_and_wait(
+        juju_vm,
+        osd_devices=f"eq(@devnode,'{happy_path_devices['osd']}')",
+        wal_devices=f"eq(@devnode,'{happy_path_devices['wal']}')",
+        db_devices=f"eq(@devnode,'{happy_path_devices['db']}')",
+        wal_size="1GiB",
+        db_size="2GiB",
+        device_add_flags="wipe:osd,wipe:wal,wipe:db",
+        timeout=900,
+    )
+
+    helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=1, timeout=900)
+
+
+@pytest.mark.abort_on_fail
+def test_storage_config_reapply_is_idempotent(
+    juju_vm: jubilant.Juju, deployed_microceph, happy_path_devices: dict[str, str]
+):
+    """Re-applying the same config should not duplicate OSDs."""
+    _apply_storage_config_and_wait(
+        juju_vm,
+        osd_devices=f"eq(@devnode,'{happy_path_devices['osd']}')",
+        wal_devices=f"eq(@devnode,'{happy_path_devices['wal']}')",
+        db_devices=f"eq(@devnode,'{happy_path_devices['db']}')",
+        wal_size="1GiB",
+        db_size="2GiB",
+        device_add_flags="wipe:osd,wipe:wal,wipe:db",
+        timeout=900,
+    )
+
+    helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=1, timeout=900)
+
+
+@pytest.mark.abort_on_fail
+def test_storage_config_warning_only_no_wal_match_stays_active(
+    juju_vm: jubilant.Juju, deployed_microceph, warning_path_devices: dict[str, str]
+):
+    """A no-WAL-match warning should stay active and still add the OSD."""
+    _apply_storage_config_and_wait(
+        juju_vm,
+        osd_devices=f"eq(@devnode,'{warning_path_devices['osd']}')",
+        wal_devices="eq(@devnode,'/dev/does-not-exist')",
+        db_devices=f"eq(@devnode,'{warning_path_devices['db']}')",
+        wal_size="1GiB",
+        db_size="2GiB",
+        device_add_flags="wipe:osd,wipe:db",
+        timeout=900,
+    )
+
+    status = juju_vm.status()
+    assert status.apps[APP_NAME].app_status.current == "active"
+    helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=2, timeout=900)
+
+
+@pytest.mark.abort_on_fail
+def test_storage_config_overlap_failure_blocks(
+    juju_vm: jubilant.Juju, deployed_microceph, overlap_osd_device: str
+):
+    """Using the same fresh device for OSD and WAL matching should fail."""
+    _set_storage_config(
+        juju_vm,
+        osd_devices=f"eq(@devnode,'{overlap_osd_device}')",
+        wal_devices=f"eq(@devnode,'{overlap_osd_device}')",
+        wal_size="1GiB",
+        device_add_flags="wipe:osd,wipe:wal",
+    )
+
+    with helpers.fast_forward(juju_vm):
+        helpers.wait_for_status(juju_vm, APP_NAME, ("blocked", "error"), timeout=300)
+
+    _clear_storage_config_and_wait(juju_vm, timeout=300)
+    helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=2, timeout=900)
+
+
+@pytest.mark.abort_on_fail
+def test_storage_config_clear_does_not_remove_existing_osds(
+    juju_vm: jubilant.Juju, deployed_microceph
+):
+    """Clearing config should stop future reconciliation but keep existing OSDs."""
+    _clear_storage_config_and_wait(juju_vm, timeout=300)
+    helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=2, timeout=900)
+
+
+@pytest.mark.abort_on_fail
+def test_storage_config_coexists_with_add_osd_action(
+    juju_vm: jubilant.Juju, deployed_microceph, action_osd_device: str
+):
+    """Config-driven OSDs should coexist with OSDs enrolled through add-osd."""
+    unit_name = helpers.first_unit_name(juju_vm.status(), APP_NAME)
+    task = juju_vm.run(
+        unit_name,
+        "add-osd",
+        {"device-id": action_osd_device, "wipe": True},
+        wait=900,
+    )
+    task.raise_on_failure()
+
+    with helpers.fast_forward(juju_vm):
+        helpers.wait_for_apps(juju_vm, APP_NAME, timeout=900)
+
+    helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=3, timeout=900)
+
+
+@pytest.mark.abort_on_fail
+def test_storage_config_disk_list_still_returns_json(juju_vm: jubilant.Juju, deployed_microceph):
+    """Sanity-check the deployed unit still reports disks after WAL/DB flows."""
+    unit_name = helpers.first_unit_name(juju_vm.status(), APP_NAME)
+    disk_list = juju_vm.ssh(unit_name, "sudo", "microceph", "disk", "list", "--json")
+    parsed = json.loads(disk_list)
+    assert "ConfiguredDisks" in parsed
+    assert len(parsed["ConfiguredDisks"]) >= 3

--- a/tests/integration/test_storage_waldb_config.py
+++ b/tests/integration/test_storage_waldb_config.py
@@ -98,6 +98,89 @@ def _clear_storage_config_and_wait(juju_vm: jubilant.Juju, timeout: int = 300) -
     _wait_for_active(juju_vm, timeout=timeout)
 
 
+def _disk_list_json(juju_vm: jubilant.Juju) -> dict:
+    """Return ``microceph disk list --json`` from the lead unit."""
+    unit_name = helpers.first_unit_name(juju_vm.status(), APP_NAME)
+    disk_list = juju_vm.ssh(unit_name, "sudo", "microceph", "disk", "list", "--json")
+    return json.loads(disk_list)
+
+
+def _configured_disks(juju_vm: jubilant.Juju) -> list[dict]:
+    """Return configured disks from ``microceph disk list --json``."""
+    return _disk_list_json(juju_vm).get("ConfiguredDisks", [])
+
+
+def _configured_osd_ids(juju_vm: jubilant.Juju) -> set[int]:
+    """Return configured OSD ids currently visible to MicroCeph."""
+    return {int(disk["osd"]) for disk in _configured_disks(juju_vm)}
+
+
+def _new_configured_osd(juju_vm: jubilant.Juju, before: set[int]) -> dict:
+    """Return the single newly configured OSD after a test action."""
+    new_disks = [disk for disk in _configured_disks(juju_vm) if int(disk["osd"]) not in before]
+    assert len(new_disks) == 1, f"Expected exactly one new configured OSD, got: {new_disks}"
+    return new_disks[0]
+
+
+def _resolve_guest_path(juju_vm: jubilant.Juju, path: str) -> str:
+    """Resolve a guest path to its canonical device node path."""
+    unit_name = helpers.first_unit_name(juju_vm.status(), APP_NAME)
+    return juju_vm.ssh(unit_name, "sudo", "readlink", "-f", path).strip()
+
+
+def _resolve_osd_link(juju_vm: jubilant.Juju, osd_num: int, link_name: str) -> str:
+    """Resolve an OSD data-dir symlink such as ``block.db`` or ``block.wal``."""
+    unit_name = helpers.first_unit_name(juju_vm.status(), APP_NAME)
+    script = (
+        f'path=/var/snap/microceph/common/data/osd/ceph-{osd_num}/{link_name}; '
+        'if [ -e "$path" ]; then readlink -f "$path"; fi'
+    )
+    return juju_vm.ssh(unit_name, "sudo", "bash", "-ec", script).strip()
+
+
+def _assert_osd_device_layout(
+    juju_vm: jubilant.Juju,
+    *,
+    osd_num: int,
+    data_device: str,
+    wal_device: str | None = None,
+    db_device: str | None = None,
+) -> None:
+    """Assert that the OSD data dir links point at the expected devices."""
+    block_path = _resolve_osd_link(juju_vm, osd_num, "block")
+    assert block_path.startswith(
+        data_device
+    ), f"OSD {osd_num} data path {block_path!r} does not resolve to {data_device!r}"
+
+    if wal_device is not None:
+        wal_path = _resolve_osd_link(juju_vm, osd_num, "block.wal")
+        assert wal_path, f"OSD {osd_num} is missing block.wal"
+        assert wal_path.startswith(
+            wal_device
+        ), f"OSD {osd_num} WAL path {wal_path!r} does not resolve to {wal_device!r}"
+
+    if db_device is not None:
+        db_path = _resolve_osd_link(juju_vm, osd_num, "block.db")
+        assert db_path, f"OSD {osd_num} is missing block.db"
+        assert db_path.startswith(
+            db_device
+        ), f"OSD {osd_num} DB path {db_path!r} does not resolve to {db_device!r}"
+
+
+def _assert_disk_list_excludes_devices(juju_vm: jubilant.Juju, *devices: str) -> None:
+    """Assert that disk-list does not expose WAL/DB carrier devices as disks."""
+    disk_list = _disk_list_json(juju_vm)
+    offenders: list[tuple[str, str, str]] = []
+
+    for section in ("ConfiguredDisks", "AvailableDisks"):
+        for disk in disk_list.get(section, []):
+            resolved_path = _resolve_guest_path(juju_vm, disk["path"])
+            if any(resolved_path.startswith(device) for device in devices):
+                offenders.append((section, disk["path"], resolved_path))
+
+    assert not offenders, f"Disk list still exposes WAL/DB carrier devices: {offenders}"
+
+
 def _create_attached_disk(
     juju_vm: jubilant.Juju,
     *,
@@ -254,6 +337,8 @@ def test_storage_config_happy_path_provisions_osd_wal_db(
     juju_vm: jubilant.Juju, deployed_microceph, happy_path_devices: dict[str, str]
 ):
     """Provision an OSD with distinct WAL and DB carrier devices."""
+    before_osds = _configured_osd_ids(juju_vm)
+
     _apply_storage_config_and_wait(
         juju_vm,
         osd_devices=f"eq(@devnode,'{happy_path_devices['osd']}')",
@@ -266,6 +351,19 @@ def test_storage_config_happy_path_provisions_osd_wal_db(
     )
 
     helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=1, timeout=900)
+    new_osd = _new_configured_osd(juju_vm, before_osds)
+    _assert_osd_device_layout(
+        juju_vm,
+        osd_num=int(new_osd["osd"]),
+        data_device=happy_path_devices["osd"],
+        wal_device=happy_path_devices["wal"],
+        db_device=happy_path_devices["db"],
+    )
+    _assert_disk_list_excludes_devices(
+        juju_vm,
+        happy_path_devices["wal"],
+        happy_path_devices["db"],
+    )
 
 
 @pytest.mark.abort_on_fail
@@ -273,6 +371,8 @@ def test_storage_config_reapply_is_idempotent(
     juju_vm: jubilant.Juju, deployed_microceph, happy_path_devices: dict[str, str]
 ):
     """Re-applying the same config should not duplicate OSDs."""
+    before_osds = _configured_osd_ids(juju_vm)
+
     _apply_storage_config_and_wait(
         juju_vm,
         osd_devices=f"eq(@devnode,'{happy_path_devices['osd']}')",
@@ -285,6 +385,16 @@ def test_storage_config_reapply_is_idempotent(
     )
 
     helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=1, timeout=900)
+    after_osds = _configured_osd_ids(juju_vm)
+    assert after_osds == before_osds, f"Reapply unexpectedly changed configured OSDs: {after_osds}"
+    only_osd = next(iter(after_osds))
+    _assert_osd_device_layout(
+        juju_vm,
+        osd_num=only_osd,
+        data_device=happy_path_devices["osd"],
+        wal_device=happy_path_devices["wal"],
+        db_device=happy_path_devices["db"],
+    )
 
 
 @pytest.mark.abort_on_fail
@@ -292,6 +402,8 @@ def test_storage_config_warning_only_no_wal_match_stays_active(
     juju_vm: jubilant.Juju, deployed_microceph, warning_path_devices: dict[str, str]
 ):
     """A no-WAL-match warning should stay active and still add the OSD."""
+    before_osds = _configured_osd_ids(juju_vm)
+
     _apply_storage_config_and_wait(
         juju_vm,
         osd_devices=f"eq(@devnode,'{warning_path_devices['osd']}')",
@@ -306,6 +418,14 @@ def test_storage_config_warning_only_no_wal_match_stays_active(
     status = juju_vm.status()
     assert status.apps[APP_NAME].app_status.current == "active"
     helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=2, timeout=900)
+    new_osd = _new_configured_osd(juju_vm, before_osds)
+    _assert_osd_device_layout(
+        juju_vm,
+        osd_num=int(new_osd["osd"]),
+        data_device=warning_path_devices["osd"],
+        db_device=warning_path_devices["db"],
+    )
+    _assert_disk_list_excludes_devices(juju_vm, warning_path_devices["db"])
 
 
 @pytest.mark.abort_on_fail
@@ -323,6 +443,12 @@ def test_storage_config_overlap_failure_blocks(
 
     with helpers.fast_forward(juju_vm):
         helpers.wait_for_status(juju_vm, APP_NAME, ("blocked", "error"), timeout=300)
+
+    status = juju_vm.status()
+    unit_name = helpers.first_unit_name(status, APP_NAME)
+    unit_status = status.apps[APP_NAME].units[unit_name]
+    assert unit_status.workload_status.current in {"blocked", "error"}
+    assert "overlap" in unit_status.workload_status.message.lower()
 
     _clear_storage_config_and_wait(juju_vm, timeout=300)
     helpers.assert_osd_count(juju_vm, APP_NAME, expected_osds=2, timeout=900)
@@ -360,8 +486,6 @@ def test_storage_config_coexists_with_add_osd_action(
 @pytest.mark.abort_on_fail
 def test_storage_config_disk_list_still_returns_json(juju_vm: jubilant.Juju, deployed_microceph):
     """Sanity-check the deployed unit still reports disks after WAL/DB flows."""
-    unit_name = helpers.first_unit_name(juju_vm.status(), APP_NAME)
-    disk_list = juju_vm.ssh(unit_name, "sudo", "microceph", "disk", "list", "--json")
-    parsed = json.loads(disk_list)
+    parsed = _disk_list_json(juju_vm)
     assert "ConfiguredDisks" in parsed
     assert len(parsed["ConfiguredDisks"]) >= 3

--- a/tests/unit/test_ceph_rgw.py
+++ b/tests/unit/test_ceph_rgw.py
@@ -82,8 +82,9 @@ class TestCephRgwClientProviderHandler(testbase.TestBaseCharm):
         )
 
     def test_ceph_rgw_connected_ready(self):
-        self.harness.update_config({"enable-rgw": "*"})
         self.ready_for_service.return_value = True
+        self.harness.update_config({"enable-rgw": "*"})
+        self.ready_for_service.reset_mock()
         self.get_osd_count.return_value = 3
         self._service_status = {
             "rgw": {
@@ -103,8 +104,9 @@ class TestCephRgwClientProviderHandler(testbase.TestBaseCharm):
         self.run_cmd.assert_called_with(["sudo", "microceph.ceph", "service", "status"])
 
     def test_set_readiness_on_related_units(self):
-        self.harness.update_config({"enable-rgw": ""})
         self.ready_for_service.return_value = False
+        self.harness.update_config({"enable-rgw": ""})
+        self.ready_for_service.reset_mock()
         self.get_osd_count.return_value = 0
 
         self.harness.set_leader()
@@ -122,7 +124,7 @@ class TestCephRgwClientProviderHandler(testbase.TestBaseCharm):
         # rgw enabled, but charm is not yet ready for service.
         self.harness.update_config({"enable-rgw": "*"})
 
-        self.ready_for_service.assert_called_once()
+        self.ready_for_service.assert_called()
         self.get_osd_count.assert_not_called()
 
         # ready for service, but no OSDs yet.

--- a/tests/unit/test_device_flags.py
+++ b/tests/unit/test_device_flags.py
@@ -16,80 +16,61 @@
 
 import unittest
 
-from device_flags import (
-    DeviceAddFlags,
-    parse_device_add_flags,
-)
+from device_flags import DeviceAddFlags, parse_device_add_flags
 
 
 class TestDeviceAddFlagsParsing(unittest.TestCase):
     """Tests for parse_device_add_flags function."""
 
-    def test_empty_flags(self):
-        """Empty string returns default flags."""
-        flags = parse_device_add_flags("")
+    def assert_all_flags_disabled(self, flags: DeviceAddFlags):
+        """Assert that all parsed flags are False."""
         self.assertFalse(flags.wipe_osd)
         self.assertFalse(flags.encrypt_osd)
+        self.assertFalse(flags.wipe_wal)
+        self.assertFalse(flags.encrypt_wal)
+        self.assertFalse(flags.wipe_db)
+        self.assertFalse(flags.encrypt_db)
+
+    def test_empty_flags(self):
+        """Empty string returns default flags."""
+        self.assert_all_flags_disabled(parse_device_add_flags(""))
 
     def test_none_flags(self):
         """None returns default flags."""
-        flags = parse_device_add_flags(None)
-        self.assertFalse(flags.wipe_osd)
-        self.assertFalse(flags.encrypt_osd)
+        self.assert_all_flags_disabled(parse_device_add_flags(None))
 
     def test_whitespace_only(self):
         """Whitespace-only string returns default flags."""
-        flags = parse_device_add_flags("   ")
-        self.assertFalse(flags.wipe_osd)
+        self.assert_all_flags_disabled(parse_device_add_flags("   "))
+
+    def test_phase2_flags_parse_correctly(self):
+        """OSD, WAL, and DB flags are parsed correctly together."""
+        flags = parse_device_add_flags(
+            "wipe:osd,encrypt:osd,wipe:wal,encrypt:wal,wipe:db,encrypt:db"
+        )
+        self.assertTrue(flags.wipe_osd)
+        self.assertTrue(flags.encrypt_osd)
+        self.assertTrue(flags.wipe_wal)
+        self.assertTrue(flags.encrypt_wal)
+        self.assertTrue(flags.wipe_db)
+        self.assertTrue(flags.encrypt_db)
+
+    def test_case_insensitive_and_empty_entries(self):
+        """Parsing is case-insensitive and ignores empty comma-separated entries."""
+        flags = parse_device_add_flags(" Wipe:OSD ,, encrypt:wal, ENCRYPT:db , wipe:DB ")
+        self.assertTrue(flags.wipe_osd)
         self.assertFalse(flags.encrypt_osd)
+        self.assertFalse(flags.wipe_wal)
+        self.assertTrue(flags.encrypt_wal)
+        self.assertTrue(flags.wipe_db)
+        self.assertTrue(flags.encrypt_db)
 
-    def test_wipe_osd_flag(self):
-        """wipe:osd flag is parsed correctly."""
-        flags = parse_device_add_flags("wipe:osd")
-        self.assertTrue(flags.wipe_osd)
-        self.assertFalse(flags.encrypt_osd)
-
-    def test_encrypt_osd_flag(self):
-        """encrypt:osd flag is parsed correctly."""
-        flags = parse_device_add_flags("encrypt:osd")
-        self.assertFalse(flags.wipe_osd)
-        self.assertTrue(flags.encrypt_osd)
-
-    def test_multiple_flags(self):
-        """Multiple flags are parsed correctly."""
-        flags = parse_device_add_flags("wipe:osd,encrypt:osd")
-        self.assertTrue(flags.wipe_osd)
-        self.assertTrue(flags.encrypt_osd)
-
-    def test_multiple_flags_reversed_order(self):
-        """Order of flags doesn't matter."""
-        flags = parse_device_add_flags("encrypt:osd,wipe:osd")
-        self.assertTrue(flags.wipe_osd)
-        self.assertTrue(flags.encrypt_osd)
-
-    def test_flags_with_spaces(self):
-        """Spaces around flags are handled."""
-        flags = parse_device_add_flags("  wipe:osd  ,  encrypt:osd  ")
-        self.assertTrue(flags.wipe_osd)
-        self.assertTrue(flags.encrypt_osd)
-
-    def test_case_insensitive(self):
-        """Flag parsing is case-insensitive."""
-        flags = parse_device_add_flags("WIPE:OSD")
-        self.assertTrue(flags.wipe_osd)
-
-    def test_mixed_case(self):
-        """Mixed case flags are handled."""
-        flags = parse_device_add_flags("Wipe:OSD,ENCRYPT:osd")
-        self.assertTrue(flags.wipe_osd)
-        self.assertTrue(flags.encrypt_osd)
-
-    def test_invalid_flag(self):
-        """Unknown flag raises ValueError."""
+    def test_unknown_phase2_typo_raises(self):
+        """Unknown phase-2 flags fail fast."""
         with self.assertRaises(ValueError) as ctx:
-            parse_device_add_flags("invalid:flag")
+            parse_device_add_flags("wipe:osd,encrypt:wla")
         self.assertIn("Unknown flag", str(ctx.exception))
-        self.assertIn("invalid:flag", str(ctx.exception))
+        self.assertIn("encrypt:wla", str(ctx.exception))
 
     def test_invalid_flag_mixed_with_valid(self):
         """Mix of valid and invalid flags raises ValueError."""
@@ -97,22 +78,7 @@ class TestDeviceAddFlagsParsing(unittest.TestCase):
             parse_device_add_flags("wipe:osd,invalid:flag")
         self.assertIn("Unknown flag", str(ctx.exception))
 
-    def test_phase2_flags_not_supported(self):
-        """Phase 2 flags (wipe:wal, etc.) are not supported yet."""
-        for flag in ["wipe:wal", "wipe:db", "encrypt:wal", "encrypt:db"]:
-            with self.assertRaises(
-                ValueError, msg=f"Flag {flag} should not be supported in Phase 1"
-            ) as ctx:
-                parse_device_add_flags(flag)
-            self.assertIn("Unknown flag", str(ctx.exception))
-
-    def test_empty_flag_in_list(self):
-        """Empty flag in comma-separated list is ignored."""
-        flags = parse_device_add_flags("wipe:osd,,encrypt:osd")
-        self.assertTrue(flags.wipe_osd)
-        self.assertTrue(flags.encrypt_osd)
-
     def test_returns_dataclass(self):
         """Result is a DeviceAddFlags dataclass."""
-        flags = parse_device_add_flags("wipe:osd")
+        flags = parse_device_add_flags("wipe:wal")
         self.assertIsInstance(flags, DeviceAddFlags)

--- a/tests/unit/test_lxd_helpers.py
+++ b/tests/unit/test_lxd_helpers.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for LXD integration helpers."""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tests.helpers import lxd
+
+
+class TestLxdHelpers(unittest.TestCase):
+    """Validate LXD test helpers."""
+
+    def test_list_disks_filters_non_disk_entries(self):
+        """Only whole block disks with paths should be returned."""
+        juju = MagicMock()
+        juju.ssh.return_value = json.dumps(
+            {
+                "blockdevices": [
+                    {"path": "/dev/sda", "size": "16G", "type": "disk"},
+                    {"path": "/dev/sda1", "size": "15G", "type": "part"},
+                    {"path": "/dev/loop0", "size": "100M", "type": "loop"},
+                    {"size": "6G", "type": "disk"},
+                ]
+            }
+        )
+
+        self.assertEqual(lxd.list_disks(juju, "microceph/0"), {"/dev/sda": "16G"})
+        juju.ssh.assert_called_once_with(
+            "microceph/0", "lsblk", "-d", "-J", "-o", "PATH,SIZE,TYPE"
+        )
+
+    @patch("tests.helpers.lxd.time.sleep")
+    @patch("tests.helpers.lxd.list_disks")
+    def test_wait_for_disk_returns_new_matching_disk(self, mock_list_disks, _mock_sleep):
+        """A newly attached matching disk should be selected over existing disks."""
+        mock_list_disks.side_effect = [
+            {"/dev/sda": "16G", "/dev/sdb": "3G"},
+            {"/dev/sda": "16G", "/dev/sdb": "3G", "/dev/sdc": "6G"},
+        ]
+
+        disk_path = lxd.wait_for_disk(
+            MagicMock(),
+            "microceph/0",
+            size_pattern="6G|5.6G",
+            existing_disks={"/dev/sda", "/dev/sdb"},
+        )
+
+        self.assertEqual(disk_path, "/dev/sdc")
+
+    @patch("tests.helpers.lxd.time.sleep")
+    @patch("tests.helpers.lxd.list_disks", return_value={"/dev/sda": "16G", "/dev/sdb": "6G"})
+    def test_wait_for_disk_size_match_is_anchored(self, _mock_list_disks, _mock_sleep):
+        """A 6G selector must not spuriously match the existing 16G root disk."""
+        disk_path = lxd.wait_for_disk(MagicMock(), "microceph/0", size_pattern="6G")
+
+        self.assertEqual(disk_path, "/dev/sdb")

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -297,73 +297,138 @@ class TestMicroCeph(unittest.TestCase):
             timeout=900,
         )
 
+    @patch("microceph._setup_dm_crypt")
     @patch("utils.run_cmd")
-    def test_add_osd_match_cmd_basic(self, run_cmd):
-        """Test add_osd_match_cmd with basic DSL expression."""
-        microceph.add_osd_match_cmd("eq(@type,'nvme')")
-        run_cmd.assert_called_with(
+    def test_add_disk_match_cmd_osd_only(self, run_cmd, setup_dm_crypt):
+        """Test DSL-based disk add for OSD-only requests."""
+        microceph.add_disk_match_cmd("eq(@type,'nvme')")
+        run_cmd.assert_called_once_with(
             ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')"], timeout=900
         )
+        setup_dm_crypt.assert_not_called()
 
+    @patch("microceph._setup_dm_crypt")
     @patch("utils.run_cmd")
-    def test_add_osd_match_cmd_with_wipe(self, run_cmd):
-        """Test add_osd_match_cmd with wipe flag."""
-        microceph.add_osd_match_cmd("eq(@type,'nvme')", wipe=True)
-        run_cmd.assert_called_with(
-            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--wipe"], timeout=900
+    def test_add_disk_match_cmd_with_wal(self, run_cmd, setup_dm_crypt):
+        """Test DSL-based disk add with WAL flags."""
+        microceph.add_disk_match_cmd(
+            "eq(@type,'nvme')",
+            wal_match="eq(@type,'ssd')",
+            wal_size="20GiB",
+            wal_wipe=True,
         )
-
-    @patch("utils.run_cmd")
-    def test_add_osd_match_cmd_with_encrypt(self, run_cmd):
-        """Test add_osd_match_cmd with encrypt flag."""
-        microceph.add_osd_match_cmd("eq(@type,'nvme')", encrypt=True)
-        run_cmd.assert_called_with(
-            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--encrypt"],
+        run_cmd.assert_called_once_with(
+            [
+                "microceph",
+                "disk",
+                "add",
+                "--osd-match",
+                "eq(@type,'nvme')",
+                "--wal-match",
+                "eq(@type,'ssd')",
+                "--wal-size",
+                "20GiB",
+                "--wal-wipe",
+            ],
             timeout=900,
         )
+        setup_dm_crypt.assert_not_called()
 
+    @patch("microceph._setup_dm_crypt")
     @patch("utils.run_cmd")
-    def test_add_osd_match_cmd_with_dry_run(self, run_cmd):
-        """Test add_osd_match_cmd with dry_run flag."""
-        microceph.add_osd_match_cmd("eq(@type,'nvme')", dry_run=True)
-        run_cmd.assert_called_with(
-            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--dry-run"],
+    def test_add_disk_match_cmd_with_db(self, run_cmd, setup_dm_crypt):
+        """Test DSL-based disk add with DB flags."""
+        microceph.add_disk_match_cmd(
+            "eq(@type,'nvme')",
+            db_match="eq(@type,'hdd')",
+            db_size="40GiB",
+            db_wipe=True,
+        )
+        run_cmd.assert_called_once_with(
+            [
+                "microceph",
+                "disk",
+                "add",
+                "--osd-match",
+                "eq(@type,'nvme')",
+                "--db-match",
+                "eq(@type,'hdd')",
+                "--db-size",
+                "40GiB",
+                "--db-wipe",
+            ],
             timeout=900,
         )
+        setup_dm_crypt.assert_not_called()
 
+    @patch("microceph._setup_dm_crypt")
     @patch("utils.run_cmd")
-    def test_add_osd_match_cmd_all_options(self, run_cmd):
-        """Test add_osd_match_cmd with all options enabled."""
-        microceph.add_osd_match_cmd(
+    def test_add_disk_match_cmd_with_wal_and_db(self, run_cmd, setup_dm_crypt):
+        """Test DSL-based disk add with OSD, WAL, and DB flags."""
+        microceph.add_disk_match_cmd(
             "and(eq(@type,'nvme'),ge(@size,100GiB))",
+            wal_match="eq(@type,'ssd')",
+            wal_size="20GiB",
+            db_match="eq(@type,'hdd')",
+            db_size="40GiB",
             wipe=True,
-            encrypt=True,
             dry_run=True,
+            wal_wipe=True,
+            db_encrypt=True,
         )
-        run_cmd.assert_called_with(
+        run_cmd.assert_called_once_with(
             [
                 "microceph",
                 "disk",
                 "add",
                 "--osd-match",
                 "and(eq(@type,'nvme'),ge(@size,100GiB))",
+                "--wal-match",
+                "eq(@type,'ssd')",
+                "--wal-size",
+                "20GiB",
+                "--wal-wipe",
+                "--db-match",
+                "eq(@type,'hdd')",
+                "--db-size",
+                "40GiB",
+                "--db-encrypt",
                 "--wipe",
-                "--encrypt",
                 "--dry-run",
             ],
             timeout=900,
         )
+        setup_dm_crypt.assert_called_once_with()
 
+    @patch("microceph._setup_dm_crypt")
     @patch("utils.run_cmd")
-    def test_add_osd_match_cmd_complex_dsl(self, run_cmd):
-        """Test add_osd_match_cmd with complex DSL expression from spec."""
-        dsl = "or(and(re(@host,'^compute-'),re(@vendor,'Samsung')),and(re(@host,'^stor-'),re(@vendor,'Seagate')))"
-        microceph.add_osd_match_cmd(dsl)
-        run_cmd.assert_called_with(["microceph", "disk", "add", "--osd-match", dsl], timeout=900)
+    def test_add_disk_match_cmd_calls_dm_crypt_for_any_encryption(self, run_cmd, setup_dm_crypt):
+        """Any encryption flag triggers dm-crypt setup exactly once."""
+        for kwargs in (
+            {"encrypt": True},
+            {"wal_match": "eq(@type,'ssd')", "wal_size": "20GiB", "wal_encrypt": True},
+            {"db_match": "eq(@type,'hdd')", "db_size": "40GiB", "db_encrypt": True},
+        ):
+            with self.subTest(kwargs=kwargs):
+                run_cmd.reset_mock()
+                setup_dm_crypt.reset_mock()
+                microceph.add_disk_match_cmd("eq(@type,'nvme')", **kwargs)
+                setup_dm_crypt.assert_called_once_with()
+                run_cmd.assert_called_once()
 
-    @patch("utils.run_cmd")
-    def test_add_osd_match_cmd_returns_output(self, run_cmd):
-        """Test add_osd_match_cmd returns command output."""
-        run_cmd.return_value = "Matched 3 devices: /dev/nvme0n1, /dev/nvme1n1, /dev/nvme2n1"
-        result = microceph.add_osd_match_cmd("eq(@type,'nvme')", dry_run=True)
-        self.assertEqual(result, "Matched 3 devices: /dev/nvme0n1, /dev/nvme1n1, /dev/nvme2n1")
+    @patch("microceph.add_disk_match_cmd")
+    def test_add_osd_match_cmd_wrapper(self, add_disk_match_cmd):
+        """add_osd_match_cmd remains a compatibility wrapper."""
+        add_disk_match_cmd.return_value = "matched devices"
+
+        result = microceph.add_osd_match_cmd(
+            "eq(@type,'nvme')", wipe=True, encrypt=True, dry_run=True
+        )
+
+        self.assertEqual(result, "matched devices")
+        add_disk_match_cmd.assert_called_once_with(
+            osd_match="eq(@type,'nvme')",
+            wipe=True,
+            encrypt=True,
+            dry_run=True,
+        )

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -402,8 +402,29 @@ class TestMicroCeph(unittest.TestCase):
 
     @patch("microceph._setup_dm_crypt")
     @patch("utils.run_cmd")
-    def test_add_disk_match_cmd_calls_dm_crypt_for_any_encryption(self, run_cmd, setup_dm_crypt):
-        """Any encryption flag triggers dm-crypt setup exactly once."""
+    def test_add_disk_match_cmd_ignores_orphaned_auxiliary_args(self, run_cmd, setup_dm_crypt):
+        """WAL/DB size and flags are ignored when their match selectors are unset."""
+        microceph.add_disk_match_cmd(
+            "eq(@type,'nvme')",
+            wal_size="20GiB",
+            wal_wipe=True,
+            wal_encrypt=True,
+            db_size="40GiB",
+            db_wipe=True,
+            db_encrypt=True,
+        )
+
+        run_cmd.assert_called_once_with(
+            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')"], timeout=900
+        )
+        setup_dm_crypt.assert_not_called()
+
+    @patch("microceph._setup_dm_crypt")
+    @patch("utils.run_cmd")
+    def test_add_disk_match_cmd_calls_dm_crypt_for_any_active_encryption(
+        self, run_cmd, setup_dm_crypt
+    ):
+        """Any active encryption flag triggers dm-crypt setup exactly once."""
         for kwargs in (
             {"encrypt": True},
             {"wal_match": "eq(@type,'ssd')", "wal_size": "20GiB", "wal_encrypt": True},

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -436,20 +436,3 @@ class TestMicroCeph(unittest.TestCase):
                 microceph.add_disk_match_cmd("eq(@type,'nvme')", **kwargs)
                 setup_dm_crypt.assert_called_once_with()
                 run_cmd.assert_called_once()
-
-    @patch("microceph.add_disk_match_cmd")
-    def test_add_osd_match_cmd_wrapper(self, add_disk_match_cmd):
-        """add_osd_match_cmd remains a compatibility wrapper."""
-        add_disk_match_cmd.return_value = "matched devices"
-
-        result = microceph.add_osd_match_cmd(
-            "eq(@type,'nvme')", wipe=True, encrypt=True, dry_run=True
-        )
-
-        self.assertEqual(result, "matched devices")
-        add_disk_match_cmd.assert_called_once_with(
-            osd_match="eq(@type,'nvme')",
-            wipe=True,
-            encrypt=True,
-            dry_run=True,
-        )

--- a/tests/unit/test_storage_osd_config.py
+++ b/tests/unit/test_storage_osd_config.py
@@ -62,6 +62,14 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         self.storage._on_config_changed_osd_devices(event)
         return event
 
+    def _storage_config_status(self):
+        """Return the storage-config status slot."""
+        return self.storage.storage_config_status.status
+
+    def _workload_status(self):
+        """Return the shared workload status slot."""
+        return self.harness.charm.status.status
+
     def test_normalize_storage_config_trims_and_includes_waldb(self):
         """Normalization trims whitespace and includes WAL/DB settings."""
         self.harness.update_config(
@@ -228,7 +236,8 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         self._call_handler()
 
         add_disk_match_cmd.assert_not_called()
-        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
+        self.assertIsInstance(self._storage_config_status(), ActiveStatus)
+        self.assertEqual(self._storage_config_status().message, "")
 
     @patch("storage.microceph.add_disk_match_cmd")
     def test_waldb_change_without_osd_delta_skips_snap_call(self, add_disk_match_cmd):
@@ -248,8 +257,8 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         self.harness.update_config({"wal-size": "30GiB"})
 
         add_disk_match_cmd.assert_not_called()
-        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
-        self.assertEqual(self.harness.charm.status.status.message, "charm is ready")
+        self.assertIsInstance(self._storage_config_status(), ActiveStatus)
+        self.assertEqual(self._storage_config_status().message, "")
 
     @patch("storage.microceph.add_disk_match_cmd")
     def test_clearing_auxiliary_match_without_osd_delta_skips_snap_call(self, add_disk_match_cmd):
@@ -270,8 +279,8 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         self.harness.update_config({"wal-devices": "", "wal-size": "20GiB"})
 
         add_disk_match_cmd.assert_not_called()
-        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
-        self.assertEqual(self.harness.charm.status.status.message, "charm is ready")
+        self.assertIsInstance(self._storage_config_status(), ActiveStatus)
+        self.assertEqual(self._storage_config_status().message, "")
 
     @patch("storage.microceph.add_disk_match_cmd")
     def test_osd_change_applies_latest_waldb_settings(self, add_disk_match_cmd):
@@ -316,7 +325,9 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         )
 
         with patch.object(
-            self.harness.charm.status, "set", wraps=self.harness.charm.status.set
+            self.storage.storage_config_status,
+            "set",
+            wraps=self.storage.storage_config_status.set,
         ) as set_status:
             self.harness.update_config(
                 {
@@ -343,8 +354,8 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
             db_encrypt=False,
         )
         self.assertTrue(self.storage._stored.last_storage_config_signature)
-        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
-        self.assertEqual(self.harness.charm.status.status.message, "charm is ready")
+        self.assertIsInstance(self._storage_config_status(), ActiveStatus)
+        self.assertEqual(self._storage_config_status().message, "")
         self.assertTrue(
             any(
                 isinstance(call.args[0], MaintenanceStatus)
@@ -354,7 +365,7 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         )
         self.assertTrue(
             any(
-                isinstance(call.args[0], ActiveStatus) and call.args[0].message == "charm is ready"
+                isinstance(call.args[0], ActiveStatus) and call.args[0].message == ""
                 for call in set_status.call_args_list
             )
         )
@@ -371,24 +382,26 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
 
         self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
 
-        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
+        self.assertIsInstance(self._storage_config_status(), ActiveStatus)
+        self.assertEqual(self._storage_config_status().message, "")
         self.assertTrue(self.storage._stored.last_storage_config_signature)
 
     def test_unrelated_blocked_status_survives_empty_osd_idle_path(self):
-        """Storage idle handling must not clear non-storage config blocks."""
+        """Storage-config idle handling must not clear workload status."""
         self._setup_ready_charm()
 
         self.harness.update_config({"enable-rgw": "invalid"})
 
-        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+        self.assertIsInstance(self._workload_status(), BlockedStatus)
         self.assertEqual(
-            self.harness.charm.status.status.message,
+            self._workload_status().message,
             "Improper value for config enable-rgw",
         )
+        self.assertIsInstance(self._storage_config_status(), ActiveStatus)
 
     @patch("storage.microceph.add_disk_match_cmd")
     def test_unrelated_blocked_status_survives_cached_osd_idle_path(self, add_disk_match_cmd):
-        """Cached storage no-op must not clear non-storage config blocks."""
+        """Cached storage no-op must not clear workload status."""
         self._setup_ready_charm()
         add_disk_match_cmd.return_value = "configured"
 
@@ -410,15 +423,16 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
             db_wipe=False,
             db_encrypt=False,
         )
-        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+        self.assertIsInstance(self._workload_status(), BlockedStatus)
         self.assertEqual(
-            self.harness.charm.status.status.message,
+            self._workload_status().message,
             "Improper value for config enable-rgw",
         )
+        self.assertIsInstance(self._storage_config_status(), ActiveStatus)
 
     @patch("storage.microceph.add_disk_match_cmd")
     def test_unrelated_blocked_status_survives_storage_apply(self, add_disk_match_cmd):
-        """Storage reconciliation should still run without clearing unrelated blocks."""
+        """Storage reconciliation should use its own status slot."""
         self._setup_ready_charm()
         add_disk_match_cmd.return_value = "configured"
 
@@ -443,11 +457,39 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
             db_encrypt=False,
         )
         self.assertTrue(self.storage._stored.last_storage_config_signature)
-        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+        self.assertIsInstance(self._workload_status(), BlockedStatus)
         self.assertEqual(
-            self.harness.charm.status.status.message,
+            self._workload_status().message,
             "Improper value for config enable-rgw",
         )
+        self.assertIsInstance(self._storage_config_status(), ActiveStatus)
+
+    @patch("storage.microceph.add_disk_match_cmd")
+    def test_storage_failure_uses_storage_config_status_slot(self, add_disk_match_cmd):
+        """Storage failures should block storage-config without clobbering workload."""
+        self._setup_ready_charm()
+        add_disk_match_cmd.side_effect = CalledProcessError(
+            returncode=1,
+            cmd=["microceph"],
+            stderr="WAL carrier overlaps selected OSD device",
+        )
+
+        self.harness.update_config(
+            {
+                "enable-rgw": "invalid",
+                "osd-devices": "eq(@type,'nvme')",
+                "wal-devices": "eq(@type,'ssd')",
+                "wal-size": "20GiB",
+            }
+        )
+
+        self.assertIsInstance(self._workload_status(), BlockedStatus)
+        self.assertEqual(
+            self._workload_status().message,
+            "Improper value for config enable-rgw",
+        )
+        self.assertIsInstance(self._storage_config_status(), BlockedStatus)
+        self.assertIn("WAL carrier overlaps", self._storage_config_status().message)
 
     @patch("storage.microceph.add_disk_match_cmd")
     def test_missing_wal_size_blocks_without_snap_call(self, add_disk_match_cmd):
@@ -463,8 +505,8 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         )
 
         add_disk_match_cmd.assert_not_called()
-        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
-        self.assertIn("wal-size", self.harness.charm.status.status.message)
+        self.assertIsInstance(self._storage_config_status(), BlockedStatus)
+        self.assertIn("wal-size", self._storage_config_status().message)
 
     @patch("storage.microceph.add_disk_match_cmd")
     def test_reverting_to_cached_request_clears_storage_block(self, add_disk_match_cmd):
@@ -473,7 +515,7 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         add_disk_match_cmd.return_value = "configured"
 
         self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
-        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
+        self.assertIsInstance(self._storage_config_status(), ActiveStatus)
 
         self.harness.update_config(
             {
@@ -481,13 +523,13 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
                 "wal-size": "",
             }
         )
-        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+        self.assertIsInstance(self._storage_config_status(), BlockedStatus)
 
         self.harness.update_config({"wal-devices": "", "wal-size": ""})
 
         self.assertEqual(add_disk_match_cmd.call_count, 1)
-        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
-        self.assertEqual(self.harness.charm.status.status.message, "charm is ready")
+        self.assertIsInstance(self._storage_config_status(), ActiveStatus)
+        self.assertEqual(self._storage_config_status().message, "")
 
     @patch("storage.microceph.add_disk_match_cmd")
     def test_clearing_osd_devices_clears_storage_block(self, add_disk_match_cmd):
@@ -504,14 +546,14 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
                 "wal-size": "",
             }
         )
-        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+        self.assertIsInstance(self._storage_config_status(), BlockedStatus)
 
         self.harness.update_config({"osd-devices": "", "wal-devices": "", "wal-size": ""})
 
         self.assertEqual(self.storage._stored.last_storage_config_signature, "")
         self.assertEqual(add_disk_match_cmd.call_count, 1)
-        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
-        self.assertEqual(self.harness.charm.status.status.message, "charm is ready")
+        self.assertIsInstance(self._storage_config_status(), ActiveStatus)
+        self.assertEqual(self._storage_config_status().message, "")
 
     @patch("storage.microceph.add_disk_match_cmd")
     def test_missing_db_size_blocks_without_snap_call(self, add_disk_match_cmd):
@@ -527,8 +569,8 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         )
 
         add_disk_match_cmd.assert_not_called()
-        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
-        self.assertIn("db-size", self.harness.charm.status.status.message)
+        self.assertIsInstance(self._storage_config_status(), BlockedStatus)
+        self.assertIn("db-size", self._storage_config_status().message)
 
     @patch("storage.microceph.add_disk_match_cmd")
     def test_invalid_flags_block_without_snap_call(self, add_disk_match_cmd):
@@ -540,8 +582,8 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         )
 
         add_disk_match_cmd.assert_not_called()
-        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
-        self.assertIn("Invalid device-add-flags", self.harness.charm.status.status.message)
+        self.assertIsInstance(self._storage_config_status(), BlockedStatus)
+        self.assertIn("Invalid device-add-flags", self._storage_config_status().message)
 
     @patch("storage.microceph.add_disk_match_cmd")
     def test_snap_validation_failure_blocks(self, add_disk_match_cmd):
@@ -561,5 +603,5 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
             }
         )
 
-        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
-        self.assertIn("WAL carrier overlaps", self.harness.charm.status.status.message)
+        self.assertIsInstance(self._storage_config_status(), BlockedStatus)
+        self.assertIn("WAL carrier overlaps", self._storage_config_status().message)

--- a/tests/unit/test_storage_osd_config.py
+++ b/tests/unit/test_storage_osd_config.py
@@ -417,6 +417,39 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         )
 
     @patch("storage.microceph.add_disk_match_cmd")
+    def test_unrelated_blocked_status_survives_storage_apply(self, add_disk_match_cmd):
+        """Storage reconciliation should still run without clearing unrelated blocks."""
+        self._setup_ready_charm()
+        add_disk_match_cmd.return_value = "configured"
+
+        self.harness.update_config(
+            {
+                "enable-rgw": "invalid",
+                "osd-devices": "eq(@type,'nvme')",
+            }
+        )
+
+        add_disk_match_cmd.assert_called_once_with(
+            osd_match="eq(@type,'nvme')",
+            wal_match=None,
+            wal_size=None,
+            db_match=None,
+            db_size=None,
+            wipe=False,
+            encrypt=False,
+            wal_wipe=False,
+            wal_encrypt=False,
+            db_wipe=False,
+            db_encrypt=False,
+        )
+        self.assertTrue(self.storage._stored.last_storage_config_signature)
+        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+        self.assertEqual(
+            self.harness.charm.status.status.message,
+            "Improper value for config enable-rgw",
+        )
+
+    @patch("storage.microceph.add_disk_match_cmd")
     def test_missing_wal_size_blocks_without_snap_call(self, add_disk_match_cmd):
         """wal-devices requires wal-size."""
         self._setup_ready_charm()

--- a/tests/unit/test_storage_osd_config.py
+++ b/tests/unit/test_storage_osd_config.py
@@ -12,19 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for StorageHandler._on_config_changed_osd_devices."""
+"""Unit tests for StorageHandler config-driven storage reconciliation."""
 
-from subprocess import CalledProcessError, TimeoutExpired
+from subprocess import CalledProcessError
 from unittest.mock import MagicMock, patch
 
 import ops_sunbeam.test_utils as test_utils
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from unit import testbase
 
 import charm
 
 
-class TestConfigChangedOsdDevices(testbase.TestBaseCharm):
-    """Tests for the osd-devices config-changed handler."""
+class TestConfigDrivenStorage(testbase.TestBaseCharm):
+    """Tests for the config-changed storage handler."""
 
     PATCHES = ["subprocess"]
 
@@ -42,234 +43,295 @@ class TestConfigChangedOsdDevices(testbase.TestBaseCharm):
         )
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+        self.storage = self.harness.charm.storage
+
+        patcher = patch.object(self.harness.charm, "ready_for_service", return_value=False)
+        self.ready_for_service = patcher.start()
+        self.addCleanup(patcher.stop)
 
     def _setup_ready_charm(self):
         """Set up peer relation and mock ready_for_service to return True."""
         test_utils.add_complete_peer_relation(self.harness)
         self.harness._charm.peers.interface.state.joined = True
-        self.harness.charm.ready_for_service = MagicMock(return_value=True)
+        self.ready_for_service.return_value = True
 
     def _call_handler(self, event=None):
-        """Call the osd-devices config-changed handler with a mock event."""
+        """Call the config-changed handler with a mock event."""
         if event is None:
             event = MagicMock()
-        self.harness.charm.storage._on_config_changed_osd_devices(event)
+        self.storage._on_config_changed_osd_devices(event)
         return event
 
-    # --- Skip when not configured ---
-
-    def test_empty_osd_devices_skips(self):
-        """Handler returns early when osd-devices is empty."""
-        self.harness.update_config({"osd-devices": ""})
-        event = self._call_handler()
-        event.defer.assert_not_called()
-
-    def test_whitespace_osd_devices_skips(self):
-        """Handler returns early when osd-devices is whitespace."""
-        self.harness.update_config({"osd-devices": "   "})
-        event = self._call_handler()
-        event.defer.assert_not_called()
-
-    @patch("utils.subprocess")
-    def test_unchanged_config_skips_snap_call(self, subprocess):
-        """Handler skips snap call when osd-devices config is unchanged."""
-        self._setup_ready_charm()
+    def test_normalize_storage_config_trims_and_includes_waldb(self):
+        """Normalization trims whitespace and includes WAL/DB settings."""
         self.harness.update_config(
-            {"osd-devices": "eq(@type,'nvme')", "device-add-flags": "wipe:osd"}
+            {
+                "osd-devices": "  eq(@type,'nvme')  ",
+                "wal-devices": " eq(@type,'ssd') ",
+                "db-devices": " eq(@type,'hdd') ",
+                "wal-size": " 20GiB ",
+                "db-size": " 40GiB ",
+                "device-add-flags": " wipe:osd , encrypt:wal , wipe:db ",
+            }
         )
-        self.harness.charm.storage._stored.last_osd_devices = "eq(@type,'nvme')"
-        self.harness.charm.storage._stored.last_wipe_osd = True
-        self.harness.charm.storage._stored.last_encrypt_osd = False
 
-        subprocess.run.reset_mock()
-        self._call_handler()
+        self.assertEqual(
+            self.storage._normalize_storage_config(),
+            {
+                "osd_match": "eq(@type,'nvme')",
+                "wal_match": "eq(@type,'ssd')",
+                "db_match": "eq(@type,'hdd')",
+                "wal_size": "20GiB",
+                "db_size": "40GiB",
+                "flags": {
+                    "wipe_osd": True,
+                    "encrypt_osd": False,
+                    "wipe_wal": False,
+                    "encrypt_wal": True,
+                    "wipe_db": True,
+                    "encrypt_db": False,
+                },
+            },
+        )
 
-        subprocess.run.assert_not_called()
+    def test_normalize_storage_config_ignores_waldb_without_osd(self):
+        """WAL/DB config is ignored entirely when osd-devices is empty."""
+        self.harness.update_config(
+            {
+                "osd-devices": "   ",
+                "wal-devices": "eq(@type,'ssd')",
+                "db-devices": "eq(@type,'hdd')",
+                "wal-size": "20GiB",
+                "db-size": "40GiB",
+                "device-add-flags": "wipe:wal,encrypt:db",
+            }
+        )
 
-    def test_empty_osd_devices_resets_config_cache(self):
-        """Handler clears cached config when osd-devices is empty."""
-        self.harness.charm.storage._stored.last_osd_devices = "eq(@type,'nvme')"
-        self.harness.charm.storage._stored.last_wipe_osd = True
-        self.harness.charm.storage._stored.last_encrypt_osd = True
-        self.harness.update_config({"osd-devices": "", "device-add-flags": "wipe:osd"})
+        self.assertEqual(
+            self.storage._normalize_storage_config(),
+            {
+                "osd_match": None,
+                "wal_match": None,
+                "db_match": None,
+                "wal_size": None,
+                "db_size": None,
+                "flags": {
+                    "wipe_osd": False,
+                    "encrypt_osd": False,
+                    "wipe_wal": False,
+                    "encrypt_wal": False,
+                    "wipe_db": False,
+                    "encrypt_db": False,
+                },
+            },
+        )
 
-        self._call_handler()
+    def test_empty_osd_devices_resets_signature_cache(self):
+        """Clearing osd-devices clears the cached storage signature."""
+        self.storage._stored.last_storage_config_signature = "cached-signature"
 
-        self.assertEqual(self.harness.charm.storage._stored.last_osd_devices, "")
-        self.assertFalse(self.harness.charm.storage._stored.last_wipe_osd)
-        self.assertFalse(self.harness.charm.storage._stored.last_encrypt_osd)
+        self.harness.update_config(
+            {
+                "osd-devices": "",
+                "wal-devices": "eq(@type,'ssd')",
+                "wal-size": "20GiB",
+                "device-add-flags": "wipe:wal",
+            }
+        )
 
-    # --- Defer when not ready ---
+        self.assertEqual(self.storage._stored.last_storage_config_signature, "")
 
-    @patch("microceph.is_ready", return_value=False)
-    def test_not_ready_defers(self, _is_ready):
-        """Handler defers when cluster is not ready."""
+    def test_not_ready_defers(self):
+        """Configured storage defers while the cluster is not ready."""
         self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
+
         event = self._call_handler()
+
         event.defer.assert_called_once()
 
-    # --- Successful OSD enrollment ---
-
-    @patch("utils.subprocess")
-    def test_success_calls_add_osd_match(self, subprocess):
-        """Handler calls microceph disk add with the DSL expression."""
-        self._setup_ready_charm()
-        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
-
-        self._call_handler()
-
-        subprocess.run.assert_called_with(
-            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')"],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=900,
-        )
-
-    @patch("utils.subprocess")
-    def test_success_with_wipe_flag(self, subprocess):
-        """Handler passes --wipe when wipe:osd flag is set."""
-        self._setup_ready_charm()
+    @patch("storage.microceph.add_disk_match_cmd")
+    def test_unchanged_signature_skips_snap_call(self, add_disk_match_cmd):
+        """Cached storage config is not applied again."""
         self.harness.update_config(
-            {"osd-devices": "eq(@type,'nvme')", "device-add-flags": "wipe:osd"}
+            {
+                "osd-devices": "eq(@type,'nvme')",
+                "wal-devices": "eq(@type,'ssd')",
+                "wal-size": "20GiB",
+                "device-add-flags": "wipe:osd,encrypt:wal",
+            }
         )
+        request = self.storage._normalize_storage_config()
+        self.storage._stored.last_storage_config_signature = (
+            self.storage._storage_config_signature(request)
+        )
+        self._setup_ready_charm()
 
         self._call_handler()
 
-        subprocess.run.assert_called_with(
-            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--wipe"],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=900,
-        )
+        add_disk_match_cmd.assert_not_called()
 
-    @patch("utils.subprocess")
-    def test_success_with_encrypt_flag(self, subprocess):
-        """Handler passes --encrypt when encrypt:osd flag is set."""
+    @patch("storage.microceph.add_disk_match_cmd")
+    def test_waldb_change_reruns_reconciliation(self, add_disk_match_cmd):
+        """Changing WAL/DB settings invalidates the cache."""
         self._setup_ready_charm()
+        add_disk_match_cmd.return_value = "configured"
+
         self.harness.update_config(
-            {"osd-devices": "eq(@type,'nvme')", "device-add-flags": "encrypt:osd"}
+            {
+                "osd-devices": "eq(@type,'nvme')",
+                "wal-devices": "eq(@type,'ssd')",
+                "wal-size": "20GiB",
+            }
+        )
+        add_disk_match_cmd.reset_mock()
+
+        self.harness.update_config({"wal-size": "30GiB"})
+
+        add_disk_match_cmd.assert_called_once_with(
+            osd_match="eq(@type,'nvme')",
+            wal_match="eq(@type,'ssd')",
+            wal_size="30GiB",
+            db_match=None,
+            db_size=None,
+            wipe=False,
+            encrypt=False,
+            wal_wipe=False,
+            wal_encrypt=False,
+            db_wipe=False,
+            db_encrypt=False,
         )
 
-        self._call_handler()
-
-        subprocess.run.assert_called_with(
-            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')", "--encrypt"],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=900,
-        )
-
-    @patch("utils.subprocess")
-    def test_success_with_all_flags(self, subprocess):
-        """Handler passes both --wipe and --encrypt when both flags are set."""
+    @patch("storage.microceph.add_disk_match_cmd")
+    def test_success_passes_waldb_request_and_updates_status(self, add_disk_match_cmd):
+        """Successful reconciliation sends normalized flags to microceph."""
         self._setup_ready_charm()
+        add_disk_match_cmd.return_value = (
+            "WAL match expression resolved to no devices; proceeding without WAL"
+        )
+
+        with patch.object(
+            self.harness.charm.status, "set", wraps=self.harness.charm.status.set
+        ) as set_status:
+            self.harness.update_config(
+                {
+                    "osd-devices": " eq(@type,'nvme') ",
+                    "wal-devices": " eq(@type,'ssd') ",
+                    "db-devices": " eq(@type,'hdd') ",
+                    "wal-size": " 20GiB ",
+                    "db-size": " 40GiB ",
+                    "device-add-flags": "wipe:osd,encrypt:wal,wipe:db",
+                }
+            )
+
+        add_disk_match_cmd.assert_called_once_with(
+            osd_match="eq(@type,'nvme')",
+            wal_match="eq(@type,'ssd')",
+            wal_size="20GiB",
+            db_match="eq(@type,'hdd')",
+            db_size="40GiB",
+            wipe=True,
+            encrypt=False,
+            wal_wipe=False,
+            wal_encrypt=True,
+            db_wipe=True,
+            db_encrypt=False,
+        )
+        self.assertTrue(self.storage._stored.last_storage_config_signature)
+        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
+        self.assertEqual(self.harness.charm.status.status.message, "charm is ready")
+        self.assertTrue(
+            any(
+                isinstance(call.args[0], MaintenanceStatus)
+                and call.args[0].message == "Processing storage config"
+                for call in set_status.call_args_list
+            )
+        )
+        self.assertTrue(
+            any(
+                isinstance(call.args[0], ActiveStatus) and call.args[0].message == "charm is ready"
+                for call in set_status.call_args_list
+            )
+        )
+
+    @patch("storage.microceph.add_disk_match_cmd")
+    def test_no_devices_matched_stays_active(self, add_disk_match_cmd):
+        """No matching OSD devices is treated as a no-op, not a failure."""
+        self._setup_ready_charm()
+        add_disk_match_cmd.side_effect = CalledProcessError(
+            returncode=1,
+            cmd=["microceph"],
+            stderr="Error: no devices matched the expression",
+        )
+
+        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
+
+        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
+        self.assertTrue(self.storage._stored.last_storage_config_signature)
+
+    @patch("storage.microceph.add_disk_match_cmd")
+    def test_missing_wal_size_blocks_without_snap_call(self, add_disk_match_cmd):
+        """wal-devices requires wal-size."""
+        self._setup_ready_charm()
+
         self.harness.update_config(
-            {"osd-devices": "eq(@type,'nvme')", "device-add-flags": "wipe:osd,encrypt:osd"}
+            {
+                "osd-devices": "eq(@type,'nvme')",
+                "wal-devices": "eq(@type,'ssd')",
+                "wal-size": "",
+            }
         )
 
-        self._call_handler()
+        add_disk_match_cmd.assert_not_called()
+        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+        self.assertIn("wal-size", self.harness.charm.status.status.message)
 
-        subprocess.run.assert_called_with(
-            [
-                "microceph",
-                "disk",
-                "add",
-                "--osd-match",
-                "eq(@type,'nvme')",
-                "--wipe",
-                "--encrypt",
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=900,
-        )
-
-    @patch("utils.subprocess")
-    def test_strips_whitespace_from_dsl(self, subprocess):
-        """Handler strips leading/trailing whitespace from the DSL expression."""
+    @patch("storage.microceph.add_disk_match_cmd")
+    def test_missing_db_size_blocks_without_snap_call(self, add_disk_match_cmd):
+        """db-devices requires db-size."""
         self._setup_ready_charm()
-        self.harness.update_config({"osd-devices": "  eq(@type,'nvme')  "})
 
-        self._call_handler()
-
-        subprocess.run.assert_called_with(
-            ["microceph", "disk", "add", "--osd-match", "eq(@type,'nvme')"],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=900,
-        )
-
-    # --- No devices matched (not an error) ---
-
-    @patch("utils.subprocess")
-    def test_no_devices_matched_stays_active(self, subprocess):
-        """Handler does not defer or crash when snap reports no devices matched."""
-        self._setup_ready_charm()
-        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
-
-        subprocess.CalledProcessError = CalledProcessError
-        subprocess.run.side_effect = CalledProcessError(
-            returncode=1, cmd=["microceph"], stderr="Error: no devices matched the expression"
-        )
-
-        event = self._call_handler()
-        event.defer.assert_not_called()
-
-    # --- CalledProcessError (real error) ---
-
-    @patch("utils.subprocess")
-    def test_snap_error_does_not_crash(self, subprocess):
-        """Handler handles snap failure without unhandled exception."""
-        self._setup_ready_charm()
-        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
-
-        subprocess.CalledProcessError = CalledProcessError
-        subprocess.run.side_effect = CalledProcessError(
-            returncode=1, cmd=["microceph"], stderr="Error: some snap failure"
-        )
-
-        event = self._call_handler()
-        event.defer.assert_not_called()
-
-    @patch("utils.subprocess")
-    def test_snap_error_with_empty_stderr(self, subprocess):
-        """Handler handles CalledProcessError with empty stderr without crash."""
-        self._setup_ready_charm()
-        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
-
-        subprocess.CalledProcessError = CalledProcessError
-        subprocess.run.side_effect = CalledProcessError(returncode=1, cmd=["microceph"], stderr="")
-
-        event = self._call_handler()
-        event.defer.assert_not_called()
-
-    @patch("utils.subprocess")
-    def test_snap_timeout_does_not_crash(self, subprocess):
-        """Handler handles snap timeout without unhandled exception."""
-        self._setup_ready_charm()
-        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
-
-        subprocess.CalledProcessError = CalledProcessError
-        subprocess.TimeoutExpired = TimeoutExpired
-        subprocess.run.side_effect = TimeoutExpired(cmd=["microceph"], timeout=180)
-
-        event = self._call_handler()
-        event.defer.assert_not_called()
-
-    # --- Invalid device-add-flags ---
-
-    @patch("utils.subprocess")
-    def test_invalid_flags_does_not_call_snap(self, subprocess):
-        """Handler does not call snap when device-add-flags are invalid."""
-        self._setup_ready_charm()
         self.harness.update_config(
-            {"osd-devices": "eq(@type,'nvme')", "device-add-flags": "invalid:flag"}
+            {
+                "osd-devices": "eq(@type,'nvme')",
+                "db-devices": "eq(@type,'hdd')",
+                "db-size": "",
+            }
         )
 
-        self._call_handler()
-        subprocess.run.assert_not_called()
+        add_disk_match_cmd.assert_not_called()
+        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+        self.assertIn("db-size", self.harness.charm.status.status.message)
+
+    @patch("storage.microceph.add_disk_match_cmd")
+    def test_invalid_flags_block_without_snap_call(self, add_disk_match_cmd):
+        """Invalid device-add-flags block before any snap call."""
+        self._setup_ready_charm()
+
+        self.harness.update_config(
+            {"osd-devices": "eq(@type,'nvme')", "device-add-flags": "encrypt:wla"}
+        )
+
+        add_disk_match_cmd.assert_not_called()
+        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+        self.assertIn("Invalid device-add-flags", self.harness.charm.status.status.message)
+
+    @patch("storage.microceph.add_disk_match_cmd")
+    def test_snap_validation_failure_blocks(self, add_disk_match_cmd):
+        """Snap validation errors surface as blocked status."""
+        self._setup_ready_charm()
+        add_disk_match_cmd.side_effect = CalledProcessError(
+            returncode=1,
+            cmd=["microceph"],
+            stderr="WAL carrier overlaps selected OSD device",
+        )
+
+        self.harness.update_config(
+            {
+                "osd-devices": "eq(@type,'nvme')",
+                "wal-devices": "eq(@type,'ssd')",
+                "wal-size": "20GiB",
+            }
+        )
+
+        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+        self.assertIn("WAL carrier overlaps", self.harness.charm.status.status.message)

--- a/tests/unit/test_storage_osd_config.py
+++ b/tests/unit/test_storage_osd_config.py
@@ -252,9 +252,7 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         self.assertEqual(self.harness.charm.status.status.message, "charm is ready")
 
     @patch("storage.microceph.add_disk_match_cmd")
-    def test_clearing_auxiliary_match_without_osd_delta_skips_snap_call(
-        self, add_disk_match_cmd
-    ):
+    def test_clearing_auxiliary_match_without_osd_delta_skips_snap_call(self, add_disk_match_cmd):
         """Removing WAL/DB selectors alone does not re-emit the snap command."""
         self._setup_ready_charm()
         add_disk_match_cmd.return_value = "configured"
@@ -375,6 +373,48 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
 
         self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
         self.assertTrue(self.storage._stored.last_storage_config_signature)
+
+    def test_unrelated_blocked_status_survives_empty_osd_idle_path(self):
+        """Storage idle handling must not clear non-storage config blocks."""
+        self._setup_ready_charm()
+
+        self.harness.update_config({"enable-rgw": "invalid"})
+
+        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+        self.assertEqual(
+            self.harness.charm.status.status.message,
+            "Improper value for config enable-rgw",
+        )
+
+    @patch("storage.microceph.add_disk_match_cmd")
+    def test_unrelated_blocked_status_survives_cached_osd_idle_path(self, add_disk_match_cmd):
+        """Cached storage no-op must not clear non-storage config blocks."""
+        self._setup_ready_charm()
+        add_disk_match_cmd.return_value = "configured"
+
+        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
+        self.assertTrue(self.storage._stored.last_storage_config_signature)
+
+        self.harness.update_config({"enable-rgw": "invalid"})
+
+        add_disk_match_cmd.assert_called_once_with(
+            osd_match="eq(@type,'nvme')",
+            wal_match=None,
+            wal_size=None,
+            db_match=None,
+            db_size=None,
+            wipe=False,
+            encrypt=False,
+            wal_wipe=False,
+            wal_encrypt=False,
+            db_wipe=False,
+            db_encrypt=False,
+        )
+        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+        self.assertEqual(
+            self.harness.charm.status.status.message,
+            "Improper value for config enable-rgw",
+        )
 
     @patch("storage.microceph.add_disk_match_cmd")
     def test_missing_wal_size_blocks_without_snap_call(self, add_disk_match_cmd):

--- a/tests/unit/test_storage_osd_config.py
+++ b/tests/unit/test_storage_osd_config.py
@@ -159,7 +159,10 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         )
 
     def test_empty_osd_devices_resets_signature_cache(self):
-        """Clearing osd-devices clears the cached storage signature."""
+        """Clearing osd-devices clears both legacy and signature cache fields."""
+        self.storage._stored.last_osd_devices = "eq(@type,'nvme')"
+        self.storage._stored.last_wipe_osd = True
+        self.storage._stored.last_encrypt_osd = True
         self.storage._stored.last_storage_config_signature = "cached-signature"
 
         self.harness.update_config(
@@ -171,6 +174,9 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
             }
         )
 
+        self.assertEqual(self.storage._stored.last_osd_devices, "")
+        self.assertFalse(self.storage._stored.last_wipe_osd)
+        self.assertFalse(self.storage._stored.last_encrypt_osd)
         self.assertEqual(self.storage._stored.last_storage_config_signature, "")
 
     def test_not_ready_defers(self):
@@ -203,8 +209,30 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         add_disk_match_cmd.assert_not_called()
 
     @patch("storage.microceph.add_disk_match_cmd")
-    def test_waldb_change_reruns_reconciliation(self, add_disk_match_cmd):
-        """Changing WAL/DB settings invalidates the cache."""
+    def test_legacy_osd_cache_fields_skip_waldb_only_change(self, add_disk_match_cmd):
+        """Legacy OSD cache fields still suppress WAL/DB-only replays after upgrade."""
+        self.harness.update_config(
+            {
+                "osd-devices": "eq(@type,'nvme')",
+                "wal-devices": "eq(@type,'ssd')",
+                "wal-size": "20GiB",
+            }
+        )
+        self.storage._stored.last_osd_devices = "eq(@type,'nvme')"
+        self.storage._stored.last_wipe_osd = False
+        self.storage._stored.last_encrypt_osd = False
+        self.storage._stored.last_storage_config_signature = ""
+        self._setup_ready_charm()
+
+        self.harness.update_config({"wal-size": "30GiB"})
+        self._call_handler()
+
+        add_disk_match_cmd.assert_not_called()
+        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
+
+    @patch("storage.microceph.add_disk_match_cmd")
+    def test_waldb_change_without_osd_delta_skips_snap_call(self, add_disk_match_cmd):
+        """Changing WAL/DB settings alone does not re-emit the snap command."""
         self._setup_ready_charm()
         add_disk_match_cmd.return_value = "configured"
 
@@ -219,23 +247,15 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
 
         self.harness.update_config({"wal-size": "30GiB"})
 
-        add_disk_match_cmd.assert_called_once_with(
-            osd_match="eq(@type,'nvme')",
-            wal_match="eq(@type,'ssd')",
-            wal_size="30GiB",
-            db_match=None,
-            db_size=None,
-            wipe=False,
-            encrypt=False,
-            wal_wipe=False,
-            wal_encrypt=False,
-            db_wipe=False,
-            db_encrypt=False,
-        )
+        add_disk_match_cmd.assert_not_called()
+        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
+        self.assertEqual(self.harness.charm.status.status.message, "charm is ready")
 
     @patch("storage.microceph.add_disk_match_cmd")
-    def test_clearing_auxiliary_match_discards_stale_auxiliary_settings(self, add_disk_match_cmd):
-        """Removing WAL/DB selectors also drops stale sizes and flags."""
+    def test_clearing_auxiliary_match_without_osd_delta_skips_snap_call(
+        self, add_disk_match_cmd
+    ):
+        """Removing WAL/DB selectors alone does not re-emit the snap command."""
         self._setup_ready_charm()
         add_disk_match_cmd.return_value = "configured"
 
@@ -251,13 +271,37 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
 
         self.harness.update_config({"wal-devices": "", "wal-size": "20GiB"})
 
+        add_disk_match_cmd.assert_not_called()
+        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
+        self.assertEqual(self.harness.charm.status.status.message, "charm is ready")
+
+    @patch("storage.microceph.add_disk_match_cmd")
+    def test_osd_change_applies_latest_waldb_settings(self, add_disk_match_cmd):
+        """The next OSD delta reuses the latest WAL/DB settings."""
+        self._setup_ready_charm()
+        add_disk_match_cmd.return_value = "configured"
+
+        self.harness.update_config(
+            {
+                "osd-devices": "eq(@type,'nvme')",
+                "wal-devices": "eq(@vendor,'intel')",
+                "wal-size": "20GiB",
+            }
+        )
+        add_disk_match_cmd.reset_mock()
+
+        self.harness.update_config({"wal-size": "30GiB"})
+        add_disk_match_cmd.assert_not_called()
+
+        self.harness.update_config({"osd-devices": "eq(@type,'ssd')"})
+
         add_disk_match_cmd.assert_called_once_with(
-            osd_match="eq(@type,'nvme')",
-            wal_match=None,
-            wal_size=None,
+            osd_match="eq(@type,'ssd')",
+            wal_match="eq(@vendor,'intel')",
+            wal_size="30GiB",
             db_match=None,
             db_size=None,
-            wipe=True,
+            wipe=False,
             encrypt=False,
             wal_wipe=False,
             wal_encrypt=False,

--- a/tests/unit/test_storage_osd_config.py
+++ b/tests/unit/test_storage_osd_config.py
@@ -66,9 +66,61 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         """Return the storage-config status slot."""
         return self.storage.storage_config_status.status
 
+    def _storage_status(self):
+        """Return the storage status slot."""
+        return self.storage.storage_status.status
+
     def _workload_status(self):
         """Return the shared workload status slot."""
         return self.harness.charm.status.status
+
+    def test_attached_storage_restores_ready_workload_message(self):
+        """Successful Juju storage events should restore a human-readable ready message."""
+        self._setup_ready_charm()
+        self.harness.charm.status.set(ActiveStatus(""))
+        event = MagicMock()
+
+        with (
+            patch.object(self.storage, "_clean_stale_osd_data"),
+            patch.object(
+                self.storage,
+                "_fetch_filtered_storages",
+                return_value=["osd-standalone/6"],
+            ),
+            patch.object(self.storage, "_get_osd_id", return_value=None),
+            patch.object(self.storage, "_enroll_disks_in_batch"),
+        ):
+            self.storage._on_osd_standalone_attached(event)
+
+        event.defer.assert_not_called()
+        self.assertIsInstance(self._storage_status(), ActiveStatus)
+        self.assertEqual(self._storage_status().message, "")
+        self.assertIsInstance(self._workload_status(), ActiveStatus)
+        self.assertEqual(self._workload_status().message, "charm is ready")
+
+    def test_attached_storage_does_not_clobber_blocked_workload_status(self):
+        """Storage attach should not clear unrelated workload failures."""
+        self._setup_ready_charm()
+        self.harness.charm.status.set(BlockedStatus("Improper value for config enable-rgw"))
+        event = MagicMock()
+
+        with (
+            patch.object(self.storage, "_clean_stale_osd_data"),
+            patch.object(
+                self.storage,
+                "_fetch_filtered_storages",
+                return_value=["osd-standalone/6"],
+            ),
+            patch.object(self.storage, "_get_osd_id", return_value=None),
+            patch.object(self.storage, "_enroll_disks_in_batch"),
+        ):
+            self.storage._on_osd_standalone_attached(event)
+
+        self.assertIsInstance(self._workload_status(), BlockedStatus)
+        self.assertEqual(
+            self._workload_status().message,
+            "Improper value for config enable-rgw",
+        )
 
     def test_normalize_storage_config_trims_and_includes_waldb(self):
         """Normalization trims whitespace and includes WAL/DB settings."""

--- a/tests/unit/test_storage_osd_config.py
+++ b/tests/unit/test_storage_osd_config.py
@@ -286,6 +286,53 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         self.assertIn("wal-size", self.harness.charm.status.status.message)
 
     @patch("storage.microceph.add_disk_match_cmd")
+    def test_reverting_to_cached_request_clears_storage_block(self, add_disk_match_cmd):
+        """Returning to the last good request clears stale blocked status."""
+        self._setup_ready_charm()
+        add_disk_match_cmd.return_value = "configured"
+
+        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
+        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
+
+        self.harness.update_config(
+            {
+                "wal-devices": "eq(@type,'ssd')",
+                "wal-size": "",
+            }
+        )
+        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+
+        self.harness.update_config({"wal-devices": "", "wal-size": ""})
+
+        self.assertEqual(add_disk_match_cmd.call_count, 1)
+        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
+        self.assertEqual(self.harness.charm.status.status.message, "charm is ready")
+
+    @patch("storage.microceph.add_disk_match_cmd")
+    def test_clearing_osd_devices_clears_storage_block(self, add_disk_match_cmd):
+        """Clearing config-driven storage activation removes stale storage blocks."""
+        self._setup_ready_charm()
+        add_disk_match_cmd.return_value = "configured"
+
+        self.harness.update_config({"osd-devices": "eq(@type,'nvme')"})
+        self.assertTrue(self.storage._stored.last_storage_config_signature)
+
+        self.harness.update_config(
+            {
+                "wal-devices": "eq(@type,'ssd')",
+                "wal-size": "",
+            }
+        )
+        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+
+        self.harness.update_config({"osd-devices": "", "wal-devices": "", "wal-size": ""})
+
+        self.assertEqual(self.storage._stored.last_storage_config_signature, "")
+        self.assertEqual(add_disk_match_cmd.call_count, 1)
+        self.assertIsInstance(self.harness.charm.status.status, ActiveStatus)
+        self.assertEqual(self.harness.charm.status.status.message, "charm is ready")
+
+    @patch("storage.microceph.add_disk_match_cmd")
     def test_missing_db_size_blocks_without_snap_call(self, add_disk_match_cmd):
         """db-devices requires db-size."""
         self._setup_ready_charm()

--- a/tests/unit/test_storage_osd_config.py
+++ b/tests/unit/test_storage_osd_config.py
@@ -126,6 +126,38 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
             },
         )
 
+    def test_normalize_storage_config_discards_inactive_auxiliary_settings(self):
+        """WAL/DB sizes and flags are ignored when their device selectors are unset."""
+        self.harness.update_config(
+            {
+                "osd-devices": "eq(@type,'nvme')",
+                "wal-devices": "",
+                "db-devices": "   ",
+                "wal-size": "20GiB",
+                "db-size": "40GiB",
+                "device-add-flags": "wipe:osd,wipe:wal,encrypt:wal,wipe:db,encrypt:db",
+            }
+        )
+
+        self.assertEqual(
+            self.storage._normalize_storage_config(),
+            {
+                "osd_match": "eq(@type,'nvme')",
+                "wal_match": None,
+                "db_match": None,
+                "wal_size": None,
+                "db_size": None,
+                "flags": {
+                    "wipe_osd": True,
+                    "encrypt_osd": False,
+                    "wipe_wal": False,
+                    "encrypt_wal": False,
+                    "wipe_db": False,
+                    "encrypt_db": False,
+                },
+            },
+        )
+
     def test_empty_osd_devices_resets_signature_cache(self):
         """Clearing osd-devices clears the cached storage signature."""
         self.storage._stored.last_storage_config_signature = "cached-signature"
@@ -194,6 +226,38 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
             db_match=None,
             db_size=None,
             wipe=False,
+            encrypt=False,
+            wal_wipe=False,
+            wal_encrypt=False,
+            db_wipe=False,
+            db_encrypt=False,
+        )
+
+    @patch("storage.microceph.add_disk_match_cmd")
+    def test_clearing_auxiliary_match_discards_stale_auxiliary_settings(self, add_disk_match_cmd):
+        """Removing WAL/DB selectors also drops stale sizes and flags."""
+        self._setup_ready_charm()
+        add_disk_match_cmd.return_value = "configured"
+
+        self.harness.update_config(
+            {
+                "osd-devices": "eq(@type,'nvme')",
+                "wal-devices": "eq(@type,'ssd')",
+                "wal-size": "20GiB",
+                "device-add-flags": "wipe:osd,wipe:wal,encrypt:wal",
+            }
+        )
+        add_disk_match_cmd.reset_mock()
+
+        self.harness.update_config({"wal-devices": "", "wal-size": "20GiB"})
+
+        add_disk_match_cmd.assert_called_once_with(
+            osd_match="eq(@type,'nvme')",
+            wal_match=None,
+            wal_size=None,
+            db_match=None,
+            db_size=None,
+            wipe=True,
             encrypt=False,
             wal_wipe=False,
             wal_encrypt=False,


### PR DESCRIPTION
This branch adds declarative storage support for MicroCeph by extending the osd-devices workflow to also provision WAL/DB devices via new wal-devices, db-devices, wal-size, and db-size config options. 

- expands device-add-flags with WAL/DB wipe and encryption controls
- refactors storage reconciliation to be normalized (repeated application does not trigger anew)
- adds a new command builder that only emits WAL/DB CLI arguments when explicitly requested

WAL/DB devices are only requested if there is an actual OSD change (we do not add WAL/DB devices to already-existing OSDs).

Expanded test suite with new unit and integration coverage for happy-path provisioning, validation failures, overlap handling, idempotent reapplication, and coexistence with the action-based OSD flow.

## Intent

Let operators declaratively describe a full storage layout:

 - which devices become OSDs
 - which devices back WAL
 - which devices back DB
 - optional wipe/encryption behavior for each class

## What changed

New config surface for WAL/DB provisioning

In config.yaml, the branch adds:

- wal-devices
- db-devices
- wal-size
- db-size

It also expands device-add-flags to support:

- wipe:wal
- encrypt:wal
- wipe:db
- encrypt:db

Device flag parsing now supports OSD and WAL/DB

Storage reconciliation was generalized. In src/storage.py, the old OSD-only handling was refactored into a config-driven storage request flow. MicroCeph command construction now supports WAL/DB. In src/microceph.py, a new command builder was added. 

Note, WAL/DB flags and sizes are only passed if WAL/DB matching is actually requested.

Upgrade semantics: new reconciliation path falls back to the legacy stored cache fields (last_osd_devices, last_wipe_osd, last_encrypt_osd) when the new  normalized-request signature is not yet present. 
