### PR TITLE
fix: add mgr_config_set_cb to ceph_cos_agent for microceph.ceph support

### DIFF
--- a/lib/charms/ceph_mon/v0/ceph_cos_agent.py
+++ b/lib/charms/ceph_mon/v0/ceph_cos_agent.py
@@ -19,13 +19,14 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 
 
 class CephCOSAgentProvider(cos_agent.COSAgentProvider):
-    def __init__(self, charm, refresh_cb=None, departed_cb=None, is_ready_cb=None):
+    def __init__(self, charm, refresh_cb=None, departed_cb=None, is_ready_cb=None,
+                 mgr_config_set_cb=None):
         super().__init__(
             charm,
             metrics_rules_dir="./files/prometheus_alert_rules",
@@ -36,6 +37,7 @@ class CephCOSAgentProvider(cos_agent.COSAgentProvider):
         self._refresh_cb = refresh_cb
         self._departed_cb = departed_cb
         self._is_ready_cb = is_ready_cb
+        self._mgr_config_set_cb = mgr_config_set_cb
 
         events = self._charm.on[cos_agent.DEFAULT_RELATION_NAME]
         self.framework.observe(
@@ -136,6 +138,11 @@ class CephCOSAgentProvider(cos_agent.COSAgentProvider):
     def mgr_config_set_rbd_stats_pools(self):
         """Update ceph mgr config with the value from rbd-status-pools config
         """
+        if callable(self._mgr_config_set_cb):
+            self._mgr_config_set_cb(self._charm.model.config)
+            return
+
+        # ceph mon fallback
         rbd_stats_pools = self._charm.model.config.get('rbd-stats-pools')
         if rbd_stats_pools:
             ceph_utils.mgr_config_set(
@@ -145,5 +152,5 @@ class CephCOSAgentProvider(cos_agent.COSAgentProvider):
         enable_perf_metrics = self._charm.model.config.get('enable-perf-metrics', False)
         ceph_utils.mgr_config_set(
             'mgr/prometheus/exclude_perf_counters',
-            str(not enable_perf_metrics)  # flip the charm config value 
+            str(not enable_perf_metrics)  # flip the charm config value
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -90,6 +90,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             refresh_cb=microceph.cos_agent_refresh_cb,
             departed_cb=microceph.cos_agent_departed_cb,
             is_ready_cb=self.ready_for_service,
+            mgr_config_set_cb=microceph.cos_agent_mgr_config_set_cb,
         )
 
         # Initialise handlers for events.

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -69,6 +69,23 @@ def cos_agent_refresh_cb(event):
     ceph.enable_ceph_monitoring()
 
 
+def cos_agent_mgr_config_set_cb(model_config):
+    """Callback to set mgr config using microceph.ceph.
+
+    :param model_config: the charm's model config dict.
+    """
+    rbd_stats_pools = model_config.get("rbd-stats-pools")
+    if rbd_stats_pools:
+        ceph.ceph_config_set("mgr", "mgr/prometheus/rbd_stats_pools", rbd_stats_pools)
+
+    enable_perf_metrics = model_config.get("enable-perf-metrics", False)
+    ceph.ceph_config_set(
+        "mgr",
+        "mgr/prometheus/exclude_perf_counters",
+        str(not enable_perf_metrics),
+    )
+
+
 def cos_agent_departed_cb(event):
     """Callback for cos-agent relation departed event."""
     logger.info("Entered CEPH COS AGENT DEPARTED")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1018,8 +1018,9 @@ class TestCharm(testbase.TestBaseCharm):
     @patch("microceph.is_ready")
     @patch("ceph.enable_mgr_module")
     @patch("utils.subprocess")
+    @patch("ceph.ceph_config_set")
     @patch.object(ceph_cos_agent, "ceph_utils")
-    def test_cos_integration(self, ceph_utils, _sub, enable_mgr_module, is_ready):
+    def test_cos_integration(self, ceph_utils, ceph_config_set, _sub, enable_mgr_module, is_ready):
         """Test integration for COS agent."""
         is_ready.return_value = True
         self.harness.set_leader()
@@ -1027,20 +1028,45 @@ class TestCharm(testbase.TestBaseCharm):
 
         self.add_cos_agent_integration(self.harness)
         enable_mgr_module.assert_called_once_with("prometheus")
-        ceph_utils.mgr_config_set.assert_has_calls(
+        # With mgr_config_set_cb, the callback uses ceph.ceph_config_set
+        # (microceph.ceph) instead of charms_ceph ceph_utils.mgr_config_set
+        ceph_config_set.assert_has_calls(
             [
-                call("mgr/prometheus/rbd_stats_pools", "abcd"),
-                call("mgr/prometheus/exclude_perf_counters", "False"),
+                call("mgr", "mgr/prometheus/rbd_stats_pools", "abcd"),
+                call("mgr", "mgr/prometheus/exclude_perf_counters", "False"),
             ]
         )
+        # charms_ceph fallback should NOT be called
+        ceph_utils.mgr_config_set.assert_not_called()
+
+    @patch("microceph.is_ready")
+    @patch("ceph.enable_mgr_module")
+    @patch("utils.subprocess")
+    @patch("ceph.ceph_config_set")
+    @patch.object(ceph_cos_agent, "ceph_utils")
+    def test_cos_integration_mgr_config_set_cb_no_rbd_pools(
+        self, ceph_utils, ceph_config_set, _sub, enable_mgr_module, is_ready
+    ):
+        """Test mgr_config_set_cb skips rbd_stats_pools when not configured."""
+        is_ready.return_value = True
+        self.harness.set_leader()
+        self.harness.update_config({"enable-perf-metrics": False})
+
+        self.add_cos_agent_integration(self.harness)
+        # Only exclude_perf_counters should be set (no rbd-stats-pools)
+        ceph_config_set.assert_called_once_with(
+            "mgr", "mgr/prometheus/exclude_perf_counters", "True"
+        )
+        ceph_utils.mgr_config_set.assert_not_called()
 
     @patch("microceph.is_ready")
     @patch("ceph.enable_mgr_module")
     @patch("ceph.disable_mgr_module")
     @patch("utils.subprocess")
+    @patch("ceph.ceph_config_set")
     @patch.object(ceph_cos_agent, "ceph_utils")
     def test_cos_agent_relation_departed_leader(
-        self, ceph_utils, _sub, disable_mgr_module, enable_mgr_module, is_ready
+        self, ceph_utils, ceph_config_set, _sub, disable_mgr_module, enable_mgr_module, is_ready
     ):
         """Test that prometheus module is disabled when cos-agent relation departs on leader."""
         is_ready.return_value = True
@@ -1083,6 +1109,33 @@ class TestCharm(testbase.TestBaseCharm):
 
         # Verify prometheus module is NOT disabled on non-leader
         disable_mgr_module.assert_not_called()
+
+    @patch("ceph.ceph_config_set")
+    def test_cos_agent_mgr_config_set_cb_with_pools(self, mock_ceph_config_set):
+        """Test cos_agent_mgr_config_set_cb sets both rbd pools and perf counters."""
+        from microceph import cos_agent_mgr_config_set_cb
+
+        config = {"rbd-stats-pools": "pool1,pool2", "enable-perf-metrics": True}
+        cos_agent_mgr_config_set_cb(config)
+
+        mock_ceph_config_set.assert_has_calls(
+            [
+                call("mgr", "mgr/prometheus/rbd_stats_pools", "pool1,pool2"),
+                call("mgr", "mgr/prometheus/exclude_perf_counters", "False"),
+            ]
+        )
+
+    @patch("ceph.ceph_config_set")
+    def test_cos_agent_mgr_config_set_cb_without_pools(self, mock_ceph_config_set):
+        """Test cos_agent_mgr_config_set_cb skips rbd pools when not set."""
+        from microceph import cos_agent_mgr_config_set_cb
+
+        config = {"enable-perf-metrics": False}
+        cos_agent_mgr_config_set_cb(config)
+
+        mock_ceph_config_set.assert_called_once_with(
+            "mgr", "mgr/prometheus/exclude_perf_counters", "True"
+        )
 
     @patch.object(ceph_cos_agent, "ceph_utils")
     @patch("ceph.enable_mgr_module")

--- a/tests/unit/testbase.py
+++ b/tests/unit/testbase.py
@@ -63,11 +63,15 @@ class _MicroCephCharm(charm.MicroCephCharm):
             ceph_cos_agent.CephCOSAgentProvider, "__init__", patched_init
         )
         self._cos_agent_patch.start()
+        # Patch ceph.ceph_config_set to avoid calling microceph.ceph in tests
+        self._ceph_config_set_patch = patch("ceph.ceph_config_set")
+        self._ceph_config_set_patch.start()
         super().__init__(framework)
 
     def tearDown(self):
         """Stop the patches."""
         self._cos_agent_patch.stop()
+        self._ceph_config_set_patch.stop()
 
     def configure_ceph(self, event):
         return


### PR DESCRIPTION
# Description

Fixes the code in ceph_cos_agent.py where mgr_config_set_rbd_stats_pools( ) calls ceph instead of microceph via charms_ceph.utils.mgr_config_set(), which fails on microceph deployments because /etc/ceph/ceph.conf doesn't exist.
Encountered the issue when deploying microceph + k8s + ceph-csi from a deployment bundle.
Deploying microceph and waiting for the charm to stabilize before deploying k8s+ceph-csi did not cause problems.

Fixes #192


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests were added.
Change was tested by deploying the following bundle to LXD VMs:

 ```yaml
   machines:
     "0":
       constraints: virt-type=virtual-machine root-disk=40G mem=8G
     "1":
       constraints: virt-type=virtual-machine root-disk=40G mem=8G
     "2":
       constraints: virt-type=virtual-machine root-disk=40G mem=8G

   applications:
     microceph:
       charm: ./microceph_amd64.charm
       num_units: 3
       to: ["0", "1", "2"]
       storage:
         osd-standalone: loop,4G,3
       config:
         snap-channel: squid/stable

     k8s:
       charm: k8s
       channel: 1.35/stable
       num_units: 3
       to: ["0", "1", "2"]

     ceph-csi:
       charm: ceph-csi
       channel: latest/edge

   relations:
     - [k8s:juju-info, ceph-csi:kubernetes]
     - [ceph-csi:ceph-client, microceph:ceph]
 ```

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

 - tests/unit/test_charm.py: Updated test_cos_integration to verify callback is used instead of charms_ceph; added test_cos_integration_mgr_config
 _set_cb_no_rbd_pools, test_cos_agent_mgr_config_set_c b_with_pools, test_cos_agent_mgr_config_set_c b_without_pools.
 - tests/unit/testbase.py: Global ceph.ceph_config_set mock so tests that trigger the callback don't hit microceph.ceph.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] added tests to verify effectiveness of this change.
