### PR TITLE
chore: ignore local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__/
 .terragrunt-cache/
 .terraform.lock.hcl
 /.pi/
+.worktrees/


### PR DESCRIPTION
## Summary
- Add `.worktrees/` to `.gitignore` so local git worktrees stay untracked.

## Test plan
- [ ] CI suite passes on main