### PR TITLE
docs: add Copilot review instructions

### DIFF
--- a/.github/instructions/charm-microceph.instructions.md
+++ b/.github/instructions/charm-microceph.instructions.md
@@ -1,0 +1,53 @@
+---
+applyTo: "**"
+---
+
+# Charm-MicroCeph review instructions
+
+Repo-wide guidance for Copilot review on `canonical/charm-microceph`. These rules are derived from incidents and lessons that have shipped in this repo. Apply them on every review pass before flagging style nits.
+
+## Project shape (read before reviewing)
+
+- Charmed operator wrapping the **MicroCeph** snap. Distributed as a charm via Charmhub.
+- Built with `charmcraft pack` against a multi-base `charmcraft.yaml` (currently amd64-only). Artifacts are named per (base, arch): `microceph_ubuntu-<series>-<arch>.charm`. There is **no** `microceph.charm` and there is **no** `rename.sh` — both were removed in the squid multi-base PR. Flag any reintroduction.
+- Snap-track convention: `<release>/<risk>` (eg `squid/stable`, `tentacle/edge`). Default channel lives in `config.yaml` and the Terraform module under `terraform/microceph/`.
+- Python is managed with `uv` and `pyproject.toml`. `requires-python` declares the supported range; tox envs in `tox.ini` must match it. Flag any `py3X` env outside the declared range.
+- Charmcraft version: builds require `charmcraft >= 4.1`. CI installs from `latest/candidate`. Local pytest uses `tests/helpers/__init__.py:ensure_charmcraft()` which asserts the version.
+
+## Review priorities
+
+Always check, in order:
+
+1. **Correctness on real input shapes**, not idealized ones (see "Common traps" below).
+2. **Idempotency of hook handlers**. Charm hooks fire repeatedly; any state-changing call must converge across re-fires. The microceph remote-import path is the canonical example — re-firing produces "already exists"; non-idempotent code leaves the unit in error state.
+3. **Cross-file consistency**. A `pyproject.toml` change must be reflected in `tox.ini` envs and `uv.lock`. A `charmcraft.yaml` platforms change must be reflected in CI artifact handling, bundle paths, and any test fixture filenames.
+4. **CI vs local-dev divergence**. Workflows pin `latest/candidate` charmcraft so a version check there is redundant; local helpers don't pin so they keep the assertion. Don't conflate the two.
+5. **Backwards-compat hacks** the codebase has explicitly chosen to drop (eg `rename.sh`, `microceph.charm`, py38/py39 envs). Flag any reintroduction.
+
+## Common traps (auto-flag if seen)
+
+These have all hit this repo. Treat any reappearance as a 🟡 risk minimum.
+
+- `built_charms = sorted(glob("*.charm"), key=mtime, reverse=True)[0]` then rename — multi-base produces multiple charms; mtime picks the wrong base. Require exact filename match.
+- `artifacts=$(printf '%s,' microceph_*.charm | sed ...)` — unmatched glob expands to the literal pattern, masking the no-artifacts case. Require `shopt -s nullglob` + bash array.
+- `grep -v <pattern> "$file" | grep -qxF <other>` under `set -e` — first grep returning 1 (no matches left) trips errexit before the second grep runs. Require `sed`-strip into a variable, then single grep.
+- `sed '/^\s*#/d'` — `\s` is GNU-only. Require `[[:space:]]` for POSIX/BSD/macOS portability.
+- `version=$(charmcraft version | awk '{print $2}')` — `charmcraft version` may print `X.Y.Z` or `charmcraft, version X.Y.Z` depending on snap revision. Require regex extraction.
+- Catching `subprocess.CalledProcessError` and matching stderr substrings without case-insensitivity or regex anchoring — CLI output wording shifts across versions. Require explicit pattern + version pin or a defensive comment.
+
+## Don't flag
+
+- Files in `lib/charms/` (vendored charm libs; managed by `charmcraft fetch-libs`).
+- `uv.lock` line-by-line. Trust `uv lock --check` in CI; only flag if the diff suggests deps fell out unexpectedly (the supported-python range change in PR #278 is the canonical example).
+- Style nits in test fixtures (data classes, mocked CA certs, hex blobs).
+
+## Severity guidance
+
+- 🔴 bug: incident-class. Mtime-newest rename, swallowed `CalledProcessError` that masks unrelated failure, CI step that silently passes when no artifacts exist.
+- 🟡 risk: works today, fragile. Substring matches without case folding, hardcoded mocks that drift from production defaults, version checks that the surrounding context already guarantees.
+- 🔵 nit: micro-optimization, naming, formatting. Comment count should not exceed 1-2 per review.
+- ❓ q: genuine ambiguity. Use sparingly; prefer to read `git log` / `git blame` first.
+
+## Output format
+
+One line per finding: `path:Lline: <emoji> <severity>: <problem>. <fix>.` No throat-clearing, no restating of what the diff does, no closing summary.

--- a/.github/instructions/ci.instructions.md
+++ b/.github/instructions/ci.instructions.md
@@ -1,0 +1,47 @@
+---
+applyTo: ".github/workflows/**,tests/scripts/**,charmcraft.yaml,tox.ini,pyproject.toml"
+---
+
+# CI / shell / charmcraft review instructions
+
+Supplements the repo-wide instructions for workflow files, shell helpers, and build/tooling configuration.
+
+## `charmcraft.yaml`
+
+- **Platforms matrix** is amd64-only by deliberate choice. The charmcraft `uv` plugin (4.2.x at time of writing) installs **host-arch wheels** into cross-built artifacts regardless of `build-for`, producing silently corrupt charms for arm64/ppc64el/s390x. Flag any PR that re-adds those arches without either:
+  - Citing a fixed charmcraft version that handles cross-builds, or
+  - Adding per-arch native runners in the workflow.
+- Each base requires its own `build-on`/`build-for` block. Multi-base output filenames are `microceph_ubuntu-<series>-<arch>.charm`. CI must consume those exact names.
+- Don't reintroduce a single-base `base: ubuntu@X.Y` shortcut — the charm is committed to multi-base.
+
+## GitHub Actions workflows (`.github/workflows/**`)
+
+- **Charmcraft install:** workflows pin `--channel=latest/candidate`. The version check that was once added (`awk '{print $2}'` then a Python regex) is **deliberately removed** because the channel pin already guarantees `>= 4.1`. Flag any reintroduction.
+- **Artifact glob expansion:** when listing packed charms, **always** use `shopt -s nullglob` + a bash array, then check `(( ${#charms[@]} == 0 ))`. The pattern `artifacts=$(printf '%s,' microceph_*.charm | ...)` silently passes when no charms were packed (the literal `microceph_*.charm` string is non-empty).
+- **`charmcraft version` parsing:** never `awk '{print $2}'` — output format varies across snap revisions (`X.Y.Z` vs `charmcraft, version X.Y.Z`). If a parse is genuinely needed, regex `(\d+)\.(\d+)` from the full output.
+- **Dual-channel publish (`main.yaml`):** each `upload-charm` call gets its own per-(base, arch) charmhub revision. The second upload sets `github-tag: false` to avoid colliding with tags created by the first. Don't claim "the same revisions" in comments — that's wrong.
+- **Retry loops** around `snap install` and `charmcraft pack` are intentional (network and lxd flakiness). Don't simplify them away.
+
+## Shell scripts (`tests/scripts/**`)
+
+- `set -e` + pipelines: `cmd_a | cmd_b` under errexit fails fast on `cmd_a` returning non-zero, even when the intent was for `cmd_b` to handle the empty case. Use `var=$(cmd_a)` then `cmd_b <<< "$var"`, or `set +o pipefail` locally.
+- `sed`/`grep` portability: use POSIX classes (`[[:space:]]`, `[[:digit:]]`) — never Perl-ish `\s`/`\d`. CI runs on GNU but local devs may be on macOS.
+- `trap '... $tmp_dir' RETURN` inside a function: clears any prior RETURN trap. Document if doing so.
+- `terragrunt --non-interactive <subcmd>` is broken on terragrunt 0.67+ (forwards the flag to terraform, rejected). Use `TERRAGRUNT_NON_INTERACTIVE=true terragrunt <subcmd>`.
+- Pinned tool versions (`TERRAFORM_VERSION`, `TERRAGRUNT_VERSION`) should be overridable via env var. Hardcoded versions without an override hook are a 🔵 nit.
+
+## `tox.ini`
+
+- `[testenv:pyXY]` envs must match `pyproject.toml:requires-python`. PR #277 dropped py38/py39 when the range moved to `>=3.10,<3.13`; PR #278 should drop py310/py311 and add py313/py314 when the range moves to `>=3.12,<3.15`. Flag drift.
+- `allowlist_externals = ... rename.sh` is deprecated and must not be reintroduced — `rename.sh` was deleted in the squid multi-base PR.
+
+## `pyproject.toml`
+
+- `requires-python` changes must be accompanied by a regenerated `uv.lock`. Run `uv lock --check` mentally: if dependencies that were Python-version-conditional drop out of the lockfile (eg `exceptiongroup` for >=3.11), that's expected, not a regression.
+- `dependencies` ordering and pinning style: pin upper bounds for known-breaking deps (`ops<3.4`, `pydantic>=2.12,<2.13`, `requests<2.32`, `urllib3<2`); do not loosen these without a `Why:` in the PR body.
+
+## What NOT to flag
+
+- Self-hosted runner labels (`self-hosted-linux-amd64-noble-xlarge`) — managed externally.
+- Sleep durations in retry loops — empirically tuned.
+- LXD seeding/setup blocks — they're known-flaky and intentionally verbose.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,41 @@
+---
+applyTo: "**/*.py"
+---
+
+# Python review instructions (charm-microceph)
+
+These rules supplement the repo-wide instructions for any Python file under `src/`, `tests/`, or top-level utilities.
+
+## Charm code (`src/`)
+
+- **Hooks must be idempotent.** Charm hooks fire repeatedly on the same relation events. Any state-changing call (snap install, microceph cluster join, remote import, OSD add) must either be a no-op on re-fire or explicitly catch the "already done" error. Flag new hook handlers that don't have this property.
+- **`subprocess.CalledProcessError` handling.** When catching it to recover from "already exists" / "already configured" style errors:
+  - Inspect both `exc.stdout` and `exc.stderr` (microceph CLI sometimes uses one, sometimes the other).
+  - Use case-insensitive `re.search` rather than `"foo" in str(...)` — wording drifts across snap revisions.
+  - Re-`raise` for any other returncode/message. Never swallow unconditionally.
+  - Add a comment naming the exact upstream message and the snap version where it was observed.
+- **Snap-track resolver (`src/microceph.py:MAJOR_VERSIONS`).** When adding a new release (eg `tentacle`), require:
+  - Entry added to `MAJOR_VERSIONS` with the correct numeric key.
+  - Test in `tests/unit/test_charm.py` covering `can_upgrade_snap("latest", "<new-track>")` with `mock_get_snap_info.return_value = {"latest": "<num>"}`.
+- **`logger.info / .debug / .error` lines that include user-controlled strings** (relation app name, remote name, token excerpts) must not include the token itself. Flag any `logger.*` that interpolates `remote_token` or similar.
+- **`ops` framework conventions:** charm classes inherit from a sunbeam-style base; observers register via `framework.observe(...)`. Don't add direct `self.on.X.observe(...)` calls in code paths that mix with sunbeam guards — flag and ask why.
+
+## Test code (`tests/`)
+
+- **`tests/conftest.py:_build_charm()`** must select the requested artifact by exact filename, not by mtime. Multi-base packing produces several `*.charm` files. Any "newest by mtime" pattern is a 🔴 bug.
+- **`tests/helpers/__init__.py:ensure_charmcraft()`** asserts `charmcraft >= 4.1`. Flag any change that drops the assertion. CI workflows can rely on `latest/candidate` pinning, but local test runs cannot.
+- **Harness mocks (`tests/unit/testbase.py`)**: `SnapCache` is patched to return a `MagicMock` with `.channel` set. The mock channel must match the charm's *current* default `snap-channel` from `config.yaml`. If `config.yaml` flips to `tentacle/edge`, the mock channel must move with it. Stale mocks let tests pass for the wrong reason.
+- **`patch.return_value.__getitem__.return_value`** returns the same mock for *every* key. If a test reads multiple snap names, prefer `side_effect = lambda key: <dispatch>` so non-matching lookups raise.
+- **Integration tests under `tests/integration/`** that call terragrunt: pass non-interactive via `TERRAGRUNT_NON_INTERACTIVE=true` env var, **not** `--non-interactive` flag. The flag form is forwarded to terraform on terragrunt 0.67+, which rejects it.
+
+## Imports & style
+
+- `subprocess` import must be at module top, not inside the function. If the function is the only consumer, still hoist it (this codebase prefers it).
+- `re` likewise — top of file.
+- Don't add `from __future__ import annotations` to modules that don't already have it; this codebase mixes both and lint accepts both.
+
+## What NOT to flag
+
+- Pydantic v1 patterns in `lib/charms/grafana_agent/v0/cos_agent.py` (vendored, deprecation warnings expected).
+- `unittest.mock.patch` placement vs. `pytest-mock` style — both are used.
+- Lack of type hints on tests — only flag missing hints in `src/`.


### PR DESCRIPTION
## Summary

Adds three path-scoped instruction files under `.github/instructions/` so the Copilot PR review agent has consistent, repo-aware guidance to apply on every review pass.

The content is a first draft and is up for team review. The patterns codified here come from issues that have already shipped or been caught in #277 / #278 — capturing them as instructions means Copilot's first-line review reproduces those checks instead of leaving them for a human reviewer to re-derive each time.

## Files

| Path | `applyTo` | Purpose |
|---|---|---|
| `.github/instructions/charm-microceph.instructions.md` | `**` | Repo-wide review heuristics, project shape, severity guidance, and a catalogue of traps that have already hit this repo. |
| `.github/instructions/python.instructions.md` | `**/*.py` | Python-specific: `subprocess.CalledProcessError` handling, snap-track resolver invariants, ops/Harness mocks, terragrunt env-var convention. |
| `.github/instructions/ci.instructions.md` | `.github/workflows/**, tests/scripts/**, charmcraft.yaml, tox.ini, pyproject.toml` | Workflow, shell, charmcraft, and tooling traps: amd64-only build rationale, channel pinning vs. version assertion, retry-loop intent, `requires-python` ↔ tox env alignment. |

## What I'd like reviewers to push back on

- **Tone / format.** I've written these in a deliberately terse, rule-list style ("flag X, fix Y") because that's what Copilot's review output ends up looking like. Open to a more prose-style if the team prefers.
- **Specific don't-flag exclusions.** I've told Copilot not to flag `lib/charms/` (vendored), `uv.lock` line-by-line, retry-loop sleep durations, and self-hosted runner labels. If any of those should *be* flagged, say so.
- **Coverage gaps.** I've captured the traps from #277 / #278; if you've got pet-peeve patterns Copilot has previously missed, add them.
- **Path globs.** `ci.instructions.md` is scoped to workflows + test scripts + a few config files. Move things in or out of that glob as needed.
- **Version-pin language.** I've embedded specifics like "charmcraft 4.2.x", "terragrunt 0.67+", "ops<3.4". These will rot. Want a convention for how often we re-sync these files vs. let them drift?

## Test plan

- [x] Three files render correctly in GitHub Markdown preview.
- [x] Frontmatter `applyTo` syntax matches Copilot's `.github/instructions/*.instructions.md` convention.
- [ ] Land this; trigger a Copilot review on a follow-up PR; sanity-check that the instructions actually load and that the review output reflects them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)