### PR TITLE
fix: make scale down more robust

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -124,9 +124,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
         self.channel = self.model.config.get("snap-channel")
 
-    def _is_benign_cluster_remove_error(
-        self, error: CalledProcessError | TimeoutExpired
-    ) -> bool:
+    def _is_benign_cluster_remove_error(self, error: CalledProcessError | TimeoutExpired) -> bool:
         """Return True if a cluster-remove failure is safe to ignore during teardown."""
         stderr = error.stderr or ""
         if isinstance(stderr, bytes):

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,7 +26,7 @@ import os
 import subprocess
 from pathlib import Path
 from socket import gethostname
-from subprocess import CalledProcessError
+from subprocess import CalledProcessError, TimeoutExpired
 from typing import List
 
 import netifaces
@@ -124,9 +124,16 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
         self.channel = self.model.config.get("snap-channel")
 
-    def _is_benign_cluster_remove_error(self, error: CalledProcessError) -> bool:
+    def _is_benign_cluster_remove_error(
+        self, error: CalledProcessError | TimeoutExpired
+    ) -> bool:
         """Return True if a cluster-remove failure is safe to ignore during teardown."""
         stderr = error.stderr or ""
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode(errors="replace")
+        else:
+            stderr = str(stderr)
+
         if "Cannot leave a cluster with 1 members" in stderr:
             return True
 
@@ -150,7 +157,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
         try:
             microceph.remove_cluster_member(hostname, is_force=True)
-        except CalledProcessError as e:
+        except (CalledProcessError, TimeoutExpired) as e:
             if self._is_benign_cluster_remove_error(e):
                 logger.info("Ignoring benign cluster removal error during stop: %s", e.stderr)
                 return

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,6 +26,7 @@ import os
 import subprocess
 from pathlib import Path
 from socket import gethostname
+from subprocess import CalledProcessError
 from typing import List
 
 import netifaces
@@ -123,14 +124,40 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
         self.channel = self.model.config.get("snap-channel")
 
+    def _is_benign_cluster_remove_error(self, error: CalledProcessError) -> bool:
+        """Return True if a cluster-remove failure is safe to ignore during teardown."""
+        stderr = error.stderr or ""
+        if "Cannot leave a cluster with 1 members" in stderr:
+            return True
+
+        if "not found in dqlite or database" in stderr:
+            return True
+
+        if "cluster member" in stderr.lower() and "not found" in stderr.lower():
+            return True
+
+        return False
+
     def _on_stop(self, event: ops.StopEvent):
         """Removes departing unit from the MicroCeph cluster forcefully."""
+        hostname = gethostname()
         try:
-            microceph.remove_cluster_member(gethostname(), is_force=True)
-        except subprocess.CalledProcessError as e:
+            if microceph.cluster_member_count() <= 1:
+                logger.info("Skipping cluster removal for last MicroCeph member %s", hostname)
+                return
+        except Exception as e:
+            logger.warning("Could not determine MicroCeph cluster size during stop: %s", e)
+
+        try:
+            microceph.remove_cluster_member(hostname, is_force=True)
+        except CalledProcessError as e:
+            if self._is_benign_cluster_remove_error(e):
+                logger.info("Ignoring benign cluster removal error during stop: %s", e.stderr)
+                return
+
             # NOTE: Depending upon the state of the cluster, forcefully removing
             # a host may result in errors even if the request was successful.
-            if microceph.is_cluster_member(gethostname()):
+            if microceph.is_cluster_member(hostname):
                 raise e
 
     def _on_update_status(self, event: ops.framework.EventBase) -> None:

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -110,7 +110,7 @@ def cos_agent_departed_cb(event):
 def cluster_members() -> list[str]:
     """Return the hostnames of MicroCeph cluster members."""
     client = Client.from_socket()
-    members = client.cluster.list_members() or []
+    members = client.cluster.list_members()
     return [member["name"] for member in members if member.get("name")]
 
 

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -107,12 +107,24 @@ def cos_agent_departed_cb(event):
     ceph.disable_ceph_monitoring()
 
 
-def remove_cluster_member(name: str, is_force: bool) -> None:
+def cluster_members() -> list[str]:
+    """Return the hostnames of MicroCeph cluster members."""
+    client = Client.from_socket()
+    members = client.cluster.list_members() or []
+    return [member["name"] for member in members if member.get("name")]
+
+
+def cluster_member_count() -> int:
+    """Return the number of MicroCeph cluster members."""
+    return len(cluster_members())
+
+
+def remove_cluster_member(name: str, is_force: bool, timeout: int = 900) -> None:
     """Remove a cluster member."""
     cmd = ["microceph", "cluster", "remove", name]
     if is_force:
         cmd.append("--force")
-    utils.run_cmd(cmd)
+    utils.run_cmd(cmd, timeout=timeout)
 
 
 def get_mon_public_addresses() -> list:

--- a/src/microceph_client.py
+++ b/src/microceph_client.py
@@ -192,7 +192,7 @@ class ClusterService(BaseService):
     def list_members(self) -> List[dict]:
         """List all cluster members."""
         members = self._get("/1.0/cluster")
-        return members.get("metadata")
+        return members.get("metadata") or []
 
     def list_services(self) -> List[dict]:
         """List all services."""

--- a/src/microceph_client.py
+++ b/src/microceph_client.py
@@ -189,6 +189,11 @@ class ClusterService(BaseService):
     of using microceph cli subprocess.
     """
 
+    def list_members(self) -> List[dict]:
+        """List all cluster members."""
+        members = self._get("/1.0/cluster")
+        return members.get("metadata")
+
     def list_services(self) -> List[dict]:
         """List all services."""
         services = self._get("/1.0/services")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -46,6 +46,58 @@ class TestCharm(testbase.TestBaseCharm):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
+    @patch("charm.gethostname", return_value="host-a")
+    @patch.object(microceph, "remove_cluster_member")
+    @patch.object(microceph, "cluster_member_count", return_value=1)
+    def test_stop_skips_cluster_remove_for_last_member(
+        self, cluster_member_count, remove_cluster_member, _gethostname
+    ):
+        """Stop hook should not ask MicroCeph to remove the final member."""
+        self.harness.charm._on_stop(MagicMock())
+
+        cluster_member_count.assert_called_once_with()
+        remove_cluster_member.assert_not_called()
+
+    @patch("charm.gethostname", return_value="host-a")
+    @patch.object(microceph, "is_cluster_member")
+    @patch.object(microceph, "cluster_member_count", return_value=2)
+    def test_stop_ignores_benign_cluster_remove_errors(
+        self, cluster_member_count, is_cluster_member, _gethostname
+    ):
+        """Stop hook should ignore known idempotent Microcluster remove errors."""
+        benign_errors = (
+            "Error: Cannot leave a cluster with 1 members",
+            'Error: cluster member "host-a" not found',
+            'Error: Cluster member "host-a" with address "10.0.0.10:7443" not found in dqlite or database',
+        )
+
+        for stderr in benign_errors:
+            with self.subTest(stderr=stderr):
+                error = CalledProcessError(1, ["microceph", "cluster", "remove"], stderr=stderr)
+                with patch.object(microceph, "remove_cluster_member", side_effect=error) as remove:
+                    self.harness.charm._on_stop(MagicMock())
+
+                remove.assert_called_once_with("host-a", is_force=True)
+
+        assert cluster_member_count.call_count == len(benign_errors)
+        is_cluster_member.assert_not_called()
+
+    @patch("charm.gethostname", return_value="host-a")
+    @patch.object(microceph, "is_cluster_member", return_value=True)
+    @patch.object(microceph, "cluster_member_count", return_value=2)
+    def test_stop_reraises_non_benign_remove_error_when_still_member(
+        self, _cluster_member_count, _is_cluster_member, _gethostname
+    ):
+        """Stop hook should still fail for unexpected errors when node remains a member."""
+        error = CalledProcessError(
+            1,
+            ["microceph", "cluster", "remove"],
+            stderr="Error: unexpected failure",
+        )
+        with patch.object(microceph, "remove_cluster_member", side_effect=error):
+            with self.assertRaises(CalledProcessError):
+                self.harness.charm._on_stop(MagicMock())
+
     @patch.object(ceph_cos_agent, "CephCOSAgentProvider")
     @patch.object(ceph_cos_agent, "ceph_utils")
     @patch.object(microceph, "Client")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -15,7 +15,7 @@
 """Tests for Microceph charm."""
 
 from pathlib import Path
-from subprocess import CalledProcessError
+from subprocess import CalledProcessError, TimeoutExpired
 from unittest.mock import MagicMock, PropertyMock, call, mock_open, patch
 
 import ops_sunbeam.test_utils as test_utils
@@ -80,6 +80,25 @@ class TestCharm(testbase.TestBaseCharm):
                 remove.assert_called_once_with("host-a", is_force=True)
 
         assert cluster_member_count.call_count == len(benign_errors)
+        is_cluster_member.assert_not_called()
+
+    @patch("charm.gethostname", return_value="host-a")
+    @patch.object(microceph, "is_cluster_member")
+    @patch.object(microceph, "cluster_member_count", return_value=2)
+    def test_stop_ignores_benign_timeout_expired_with_bytes_stderr(
+        self, cluster_member_count, is_cluster_member, _gethostname
+    ):
+        """Stop hook should decode TimeoutExpired stderr before matching benign errors."""
+        error = TimeoutExpired(
+            ["microceph", "cluster", "remove"],
+            900,
+            stderr=b'Error: cluster member "host-a" not found',
+        )
+        with patch.object(microceph, "remove_cluster_member", side_effect=error) as remove:
+            self.harness.charm._on_stop(MagicMock())
+
+        cluster_member_count.assert_called_once_with()
+        remove.assert_called_once_with("host-a", is_force=True)
         is_cluster_member.assert_not_called()
 
     @patch("charm.gethostname", return_value="host-a")

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -23,6 +23,17 @@ import microceph
 class TestMicroCeph(unittest.TestCase):
 
     @patch("microceph.Client")
+    def test_cluster_members(self, cclient):
+        """Test fetching cluster member names from the MicroCeph API."""
+        cclient.from_socket().cluster.list_members.return_value = [
+            {"name": "host-a", "address": "10.0.0.10:7443"},
+            {"name": "host-b", "address": "10.0.0.11:7443"},
+        ]
+
+        self.assertEqual(microceph.cluster_members(), ["host-a", "host-b"])
+        self.assertEqual(microceph.cluster_member_count(), 2)
+
+    @patch("microceph.Client")
     def test_is_rgw_enabled_service_not_running(self, cclient):
         """Test is_rgw_enabled when service is not running."""
         cclient.from_socket().cluster.list_services.return_value = [


### PR DESCRIPTION
# Description

don't try to have last snap self-remove, microcluster doesn't allow that

don't treat some common errors or timeouts as fatal on removal

Fixes #170 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

unit test


## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
