### PR TITLE
chore: mark secondary provides endpoints optional

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -30,16 +30,22 @@ provides:
     interface: ceph-client
   ceph-nfs:
     interface: ceph-nfs-client
+    optional: true
   ceph-rgw-ready:
     interface: ceph-rgw-client
+    optional: true
   radosgw:
     interface: ceph-radosgw
+    optional: true
   mds:
     interface: ceph-mds
+    optional: true
   cos-agent:
     interface: cos_agent
+    optional: true
   remote-provider:
     interface: microceph-remote
+    optional: true
 
 requires:
   traefik-route-rgw:


### PR DESCRIPTION
All provides endpoints except `ceph` use no-op handlers and do not affect charm status when absent. Mark them `optional: true` so bundle solvers and deployment tools do not treat them as required integrations.