### PR TITLE
fix: Remove cluster without error on remove-application

### DIFF
--- a/src/ceph_nfs.py
+++ b/src/ceph_nfs.py
@@ -348,6 +348,10 @@ class CephNfsProviderHandler(RelationHandler):
         ceph.create_fs_volume(volume_name)
 
     def _on_ceph_nfs_departed(self, event: EventBase) -> None:
+        if utils.is_departing(self.charm.app):
+            logger.debug("Application is being removed; skipping ceph-nfs departed cleanup")
+            return
+
         if not self.model.unit.is_leader():
             return
 

--- a/src/ceph_nfs.py
+++ b/src/ceph_nfs.py
@@ -118,6 +118,9 @@ class CephNfsProvides(Object):
 
     def _on_ceph_peers(self, event):
         """Handle ceph peers relation events."""
+        if utils.is_departing(self.charm.app):
+            logger.debug("Application is being removed; skipping ceph-nfs reconcile")
+            return
         if not self.model.unit.is_leader():
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -795,6 +795,10 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
     def handle_traefik_ready(self, event: ops.framework.EventBase):
         """Handle Traefik route ready callback."""
+        if utils.is_departing(self.app):
+            logger.debug("Application is being removed; skipping traefik route update")
+            return
+
         if not self.unit.is_leader():
             logger.debug("Not a leader unit, not updating traefik route config")
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -147,6 +147,13 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
     def _on_stop(self, event: ops.StopEvent):
         """Removes departing unit from the MicroCeph cluster forcefully."""
         hostname = gethostname()
+
+        # Whole-application teardown: when the entire application is removed quorum
+        # can be lost if nodes race - skip cleanup
+        if utils.is_departing(self.app, context="stop"):
+            logger.info("Application is being removed; skipping cluster removal for %s", hostname)
+            return
+
         try:
             if microceph.cluster_member_count() <= 1:
                 logger.info("Skipping cluster removal for last MicroCeph member %s", hostname)
@@ -154,6 +161,10 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         except Exception as e:
             logger.warning("Could not determine MicroCeph cluster size during stop: %s", e)
 
+        self._remove_self(hostname)
+
+    def _remove_self(self, hostname: str) -> None:
+        """Forcefully remove this host from the cluster, tolerating benign errors."""
         try:
             microceph.remove_cluster_member(hostname, is_force=True)
         except (CalledProcessError, TimeoutExpired) as e:
@@ -168,6 +179,10 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
     def _on_update_status(self, event: ops.framework.EventBase) -> None:
         """Update status event handler."""
+        if utils.is_departing(self.app):
+            logger.info("Application is being removed; skipping update-status")
+            return
+
         snap_chan = self.model.config.get("snap-channel")
         # Cleanup can run on all units, including units that are no longer leader.
         self._clear_resolved_upgrade_blocked_status(snap_chan)
@@ -226,6 +241,18 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
     def _on_peer_relation_departed(self, event: ops.framework.EventBase) -> None:
         self.handle_traefik_ready(event)
+
+    def configure_charm(self, event: ops.framework.EventBase) -> None:
+        """Reconcile the charm, unless the application is being torn down.
+
+        A departing unit must not reconcile: the cluster loses quorum during
+        teardown, so the cluster calls made here would error or hang. Gating the
+        main reconcile entry point keeps a departing unit inert.
+        """
+        if utils.is_departing(self.app):
+            logger.info("Application is being removed; skipping reconcile")
+            return
+        super().configure_charm(event)
 
     def configure_unit(self, event: ops.framework.EventBase) -> None:
         """Run configuration on this unit."""

--- a/src/microceph_remote.py
+++ b/src/microceph_remote.py
@@ -219,6 +219,10 @@ class MicroCephRemoteHandler(RelationHandler):
 
     def _on_departed(self, event):
         """Handle integration cleanup."""
+        if utils.is_departing(self.charm.app):
+            logger.debug("Application is being removed; skipping remote departed cleanup")
+            return
+
         logger.debug("Handling remote departed event")
         remote_relation_data = event.relation.data.get(event.relation.app)
         remote_site_name = remote_relation_data.get(RemoteRelationDataKeys.site_name.value, None)

--- a/src/microceph_remote.py
+++ b/src/microceph_remote.py
@@ -32,6 +32,7 @@ from ops.framework import (
 from ops_sunbeam.relation_handlers import RelationHandler
 
 import microceph
+import utils
 
 logger = logging.getLogger(__name__)
 
@@ -164,6 +165,10 @@ class MicroCephRemote(Object):
                 self.on.microceph_remote_reconcile.emit(event.relation)
 
     def _on_peer_updated(self, event):
+        if utils.is_departing(self.charm.app):
+            logger.debug("Application is being removed; skipping remote update")
+            return
+
         if not self.model.unit.is_leader():
             logger.debug("Not the leader, ignoring remote update event")
             return

--- a/src/relation_handlers.py
+++ b/src/relation_handlers.py
@@ -621,6 +621,9 @@ class CephClientProvides(Object):
     def _on_ceph_peers(self, _event):
         """Handle ceph peers relation events."""
         # Mon addrs might have changed, update the relation data
+        if utils.is_departing(self.charm.app):
+            logger.debug("Application is being removed; skipping mon address update")
+            return
         if not self.model.unit.is_leader():
             return
         mon_key = "ceph-mon-public-addresses"

--- a/src/storage.py
+++ b/src/storage.py
@@ -30,6 +30,7 @@ from ops.model import ActiveStatus, MaintenanceStatus
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 import microceph
+import utils
 from device_flags import DeviceAddFlags, parse_device_add_flags
 
 logger = logging.getLogger(__name__)
@@ -129,6 +130,14 @@ class StorageHandler(Object):
 
         logger.debug(f"OSD ID for: {event.storage.full_id} is {osd_num}")
         if osd_num is None:
+            return
+
+        # Whole-application teardown: when the entire application is being removed
+        # the cluster is being destroyed, so removing OSDs from it is pointless and
+        # will hang once the cluster drops below quorum (the disk operations are
+        # dqlite-backed). Skip and let Juju deprovision the storage.
+        if utils.is_departing(self.charm.app, context="storage detach"):
+            logger.info("Application is being removed; skipping OSD removal for osd.%s", osd_num)
             return
 
         with sunbeam_guard.guard(self._storage_guard, self.name):

--- a/src/utils.py
+++ b/src/utils.py
@@ -73,6 +73,22 @@ def snap_has_connection(snap_name: str, plug_or_slot: str) -> bool:
     raise subprocess.CalledProcessError(result.returncode, cmd, result.stdout, result.stderr)
 
 
+def is_departing(app, context: str = "") -> bool:
+    """Return True when the application is being removed.
+
+    ``planned_units()`` is the application's goal unit count, which Juju drives
+    to 0 on ``remove-application`` (and scale-to-zero). On any failure to read
+    it we fail safe to False so the unit keeps reconciling normally. ``context``
+    is an optional caller hint included in the warning log line.
+    """
+    try:
+        return app.planned_units() == 0
+    except Exception as e:
+        suffix = f" during {context}" if context else ""
+        logger.warning("Could not determine planned units%s: %s", suffix, e)
+        return False
+
+
 def get_mon_addresses():
     """Get the Ceph mon addresses."""
     client = Client.from_socket()

--- a/tests/unit/test_ceph_nfs.py
+++ b/tests/unit/test_ceph_nfs.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 
 import ops_sunbeam.test_utils as test_utils
 from ops.model import ActiveStatus, BlockedStatus
@@ -452,6 +452,23 @@ class TestCephNfsClientProvides(testbase.TestBaseCharm):
         caps = {"mon": ["allow r"], "mgr": ["allow rw"]}
         self.get_named_key.assert_called_once_with("client.another-app", caps)
         self.assertIsInstance(ceph_nfs_status.status, ActiveStatus)
+
+    def test_ceph_nfs_departed_inert_on_whole_app_teardown(self):
+        """ceph-nfs departed cleanup must not run while the whole app is being removed.
+
+        The cleanup lists services and disables NFS on the cluster, both of which
+        would hang once teardown drops the cluster below quorum.
+        """
+        self.harness.set_leader()
+        # planned_units() == 0 is how the handler detects whole-app teardown.
+        self.harness.set_planned_units(0)
+
+        # Fire the departed handler directly (event payload is irrelevant here).
+        self.harness.charm.ceph_nfs._on_ceph_nfs_departed(MagicMock())
+
+        # Guard fired before touching the (quorum-less) cluster.
+        self.disable_nfs.assert_not_called()
+        self.remove_named_key.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -60,6 +60,82 @@ class TestCharm(testbase.TestBaseCharm):
         remove_cluster_member.assert_not_called()
 
     @patch("charm.gethostname", return_value="host-a")
+    @patch.object(microceph, "remove_cluster_member")
+    @patch.object(microceph, "cluster_member_count")
+    def test_stop_skips_cluster_remove_on_whole_app_teardown(
+        self, cluster_member_count, remove_cluster_member, _gethostname
+    ):
+        """Full teardown skips cluster removal entirely and exits immediately.
+
+        Draining members during a whole-application removal is not safe: Juju
+        destroys each machine as soon as `stop` returns, leaving dead voters, and
+        coordinating an ordered removal needs the quorum teardown is destroying.
+        """
+        # planned_units() == 0 is how the charm detects whole-app teardown.
+        self.harness.set_planned_units(0)
+
+        # Fire the stop hook handler directly (event payload is irrelevant here).
+        self.harness.charm._on_stop(MagicMock())
+
+        # The is_departing() guard returns before the cluster is touched at all:
+        # neither the size probe nor the member removal runs.
+        remove_cluster_member.assert_not_called()
+        cluster_member_count.assert_not_called()
+
+    def test_configure_charm_inert_when_application_removed(self):
+        """A departing unit must not reconcile (it would hang/err on the dead cluster)."""
+        # Simulate whole-app teardown.
+        self.harness.set_planned_units(0)
+
+        # configure_charm() overrides the base class only to add the guard; patch the
+        # super() implementation so we can assert whether real reconcile would run.
+        with patch("ops_sunbeam.charm.OSBaseOperatorCharm.configure_charm") as super_cfg:
+            self.harness.charm.configure_charm(MagicMock())
+
+        # Guard fired: the base-class reconcile was never delegated to.
+        super_cfg.assert_not_called()
+
+    def test_configure_charm_reconciles_when_not_removed(self):
+        """When the app is not being removed, reconcile proceeds as normal."""
+        # Not a teardown (one unit remains), so the guard must let reconcile through.
+        self.harness.set_planned_units(1)
+
+        with patch("ops_sunbeam.charm.OSBaseOperatorCharm.configure_charm") as super_cfg:
+            self.harness.charm.configure_charm(MagicMock())
+
+        # Guard passed: reconcile is delegated to the base class exactly once.
+        super_cfg.assert_called_once()
+
+    def test_update_status_inert_when_application_removed(self):
+        """update-status must not reconcile a departing app (its cluster lost quorum)."""
+        # Simulate whole-app teardown.
+        self.harness.set_planned_units(0)
+
+        # _clear_resolved_upgrade_blocked_status is the first thing _on_update_status
+        # does after the guard, so patching it lets us detect whether we got past the
+        # guard at all.
+        with patch.object(
+            self.harness.charm, "_clear_resolved_upgrade_blocked_status"
+        ) as clear_status:
+            self.harness.charm._on_update_status(MagicMock())
+
+        # Guard fired: the handler returned before reaching any real work.
+        clear_status.assert_not_called()
+
+    def test_update_status_runs_when_not_removed(self):
+        """When the app is not being removed, update-status proceeds past the guard."""
+        # Not a teardown, so update-status must run normally.
+        self.harness.set_planned_units(1)
+
+        with patch.object(
+            self.harness.charm, "_clear_resolved_upgrade_blocked_status"
+        ) as clear_status:
+            self.harness.charm._on_update_status(MagicMock())
+
+        # Guard passed: the handler proceeded into its body.
+        clear_status.assert_called_once()
+
+    @patch("charm.gethostname", return_value="host-a")
     @patch.object(microceph, "is_cluster_member")
     @patch.object(microceph, "cluster_member_count", return_value=2)
     def test_stop_ignores_benign_cluster_remove_errors(
@@ -117,6 +193,24 @@ class TestCharm(testbase.TestBaseCharm):
         with patch.object(microceph, "remove_cluster_member", side_effect=error):
             with self.assertRaises(CalledProcessError):
                 self.harness.charm._on_stop(MagicMock())
+
+    @patch("charm.gethostname", return_value="host-a")
+    @patch.object(microceph, "is_cluster_member", return_value=False)
+    @patch.object(microceph, "remove_cluster_member")
+    @patch.object(microceph, "cluster_member_count", return_value=2)
+    def test_stop_removes_self_on_partial_scale_down(
+        self, _cluster_member_count, remove_cluster_member, _is_cluster_member, _gethostname
+    ):
+        """When the app is not being torn down, a departing unit removes itself."""
+        # planned_units() == 2 -> partial scale-down, NOT whole-app teardown, so the
+        # is_departing() guard does not fire. cluster_member_count() is mocked to 2
+        # (above quorum-of-one), and is_cluster_member -> False so no error is raised.
+        self.harness.set_planned_units(2)
+
+        self.harness.charm._on_stop(MagicMock())
+
+        # The departing unit forcibly removes itself from the surviving cluster.
+        remove_cluster_member.assert_called_once_with("host-a", is_force=True)
 
     @patch.object(ceph_cos_agent, "CephCOSAgentProvider")
     @patch.object(ceph_cos_agent, "ceph_utils")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -212,6 +212,42 @@ class TestCharm(testbase.TestBaseCharm):
         # The departing unit forcibly removes itself from the surviving cluster.
         remove_cluster_member.assert_called_once_with("host-a", is_force=True)
 
+    def test_traefik_ready_inert_when_application_removed(self):
+        """handle_traefik_ready must not run for a departing app (it can call the cluster)."""
+        # Simulate whole-app teardown.
+        self.harness.set_planned_units(0)
+
+        # is_leader() is the first thing handle_traefik_ready does after the guard, so a
+        # non-call proves the guard short-circuited before any traefik/cluster work.
+        with patch.object(self.harness.charm.unit, "is_leader") as is_leader:
+            self.harness.charm.handle_traefik_ready(MagicMock())
+
+        is_leader.assert_not_called()
+
+    def test_traefik_ready_runs_when_not_removed(self):
+        """When the app is not being removed, handle_traefik_ready proceeds past the guard."""
+        # Not a teardown, so the guard must let the handler through.
+        self.harness.set_planned_units(1)
+
+        # Return False from is_leader so the handler exits right after the guard without
+        # needing a real traefik relation; the call itself proves the guard passed.
+        with patch.object(self.harness.charm.unit, "is_leader", return_value=False) as is_leader:
+            self.harness.charm.handle_traefik_ready(MagicMock())
+
+        is_leader.assert_called_once()
+
+    def test_remote_departed_inert_when_application_removed(self):
+        """Remote departed cleanup must not run for a departing app (it calls the cluster)."""
+        # Simulate whole-app teardown.
+        self.harness.set_planned_units(0)
+
+        # remove_remote_cluster() is the cluster call the departed handler would make;
+        # the guard must short-circuit before reaching it.
+        with patch("microceph_remote.remove_remote_cluster") as remove_remote_cluster:
+            self.harness.charm.remote_provider._on_departed(MagicMock())
+
+        remove_remote_cluster.assert_not_called()
+
     @patch.object(ceph_cos_agent, "CephCOSAgentProvider")
     @patch.object(ceph_cos_agent, "ceph_utils")
     @patch.object(microceph, "Client")

--- a/tests/unit/test_storage_osd_config.py
+++ b/tests/unit/test_storage_osd_config.py
@@ -98,6 +98,25 @@ class TestConfigDrivenStorage(testbase.TestBaseCharm):
         self.assertIsInstance(self._workload_status(), ActiveStatus)
         self.assertEqual(self._workload_status().message, "charm is ready")
 
+    def test_storage_detaching_skips_osd_removal_on_whole_app_teardown(self):
+        """Storage detaching should skip OSD removal when the whole app is removed."""
+        # planned_units() == 0 is how the handler detects whole-app teardown.
+        self.harness.set_planned_units(0)
+        # full_id identifies the detaching storage; _get_osd_id below maps it to an OSD.
+        event = MagicMock()
+        event.storage.full_id = "osd-standalone/0"
+
+        # _get_osd_id -> 5 ensures we get past the "no OSD for this storage" early return,
+        # so the only thing that can stop remove_osd is the teardown guard itself.
+        with (
+            patch.object(self.storage, "_get_osd_id", return_value=5),
+            patch.object(self.storage, "remove_osd") as remove_osd,
+        ):
+            self.storage._on_storage_detaching(event)
+
+        # Guard fired: it short-circuits before touching the (quorum-less) cluster.
+        remove_osd.assert_not_called()
+
     def test_attached_storage_does_not_clobber_blocked_workload_status(self):
         """Storage attach should not clear unrelated workload failures."""
         self._setup_ready_charm()


### PR DESCRIPTION
# Description

When we remove multiple nodes simultaneously in microcluster there is a race condition due to a lack of quorum that is needed for someone to successfully exit the cluster. Nodes start removing themselves and transferring leader ownership around to the point where they get stuck and end up with context deadlines being exceeded. At this point nothing can progress. This is due to multiple members racing to leave and not being able to get adequate acknowledgments based on the quorum that the cluster currently requires. 

Our options look like: 

* Serialize removal within microceph itself 
* Serialize removal within microcluster 
* Serialize removal within the charm 
* Ignore failures essentially let juju clean things up 

I hesitantly went for the last option. I did not see a downside, however I am curious if there's something I did not see. 

Basically if the target is removed all nodes we skip removal on cleanup and we skip the relevant hooks since we know we're going to target zero. 

This is the simplest option I could think of. The other options will work but they require some synchronization to make sure quorum continues to be fulfilled. 

The one caveat with this implementation is if the simultaneously tries to remove two (or multiple) nodes we could still face the race condition that this is trying to fix. If we're not happy with this being possible, and we want to support simultaneous removal of some but not all nodes I believe we need to implement some sort of serialization instead of this implementation 

Fixes #258

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

* Added regression integration test demonstrating fail and recovery after fix
* Added unit tests exercising new paths

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
