### PR TITLE
fix/feat: Add support for additional NFS network space

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -55,6 +55,18 @@ options:
     default: ""
     description: |
       The local site name. This should be unique amongst the connected remote microceph clusters.
+  nfs-use-dedicated-binding:
+    type: boolean
+    default: false
+    description: |
+      Controls which network the NFS (Ganesha) service binds to when serving
+      shares (e.g. to Manila clients).
+
+      When false (the default), NFS binds to the Ceph public network.
+
+      When true, NFS binds to the network space the ceph-nfs relation endpoint
+      is bound to (set with "juju bind microceph ceph-nfs=<space>"); left
+      unbound, that endpoint resolves to the model's default space.
   wait-to-adopt:
     type: boolean
     default: False

--- a/src/ceph_nfs.py
+++ b/src/ceph_nfs.py
@@ -290,15 +290,15 @@ class CephNfsProviderHandler(RelationHandler):
 
         for candidate in candidates:
             try:
-                public_addr = self._get_public_address(candidate)
-                if not public_addr:
+                bind_addr = self._get_nfs_bind_address(candidate)
+                if not bind_addr:
                     logger.warning(
-                        "Could not find the public address of '%s' in the peer relation data.",
+                        "Could not find the NFS bind address of '%s' in the peer relation data.",
                         candidate,
                     )
                     continue
 
-                microceph.enable_nfs(candidate, cluster_id, public_addr)
+                microceph.enable_nfs(candidate, cluster_id, bind_addr)
 
                 nodes_in_cluster += 1
                 if nodes_in_cluster == 3:
@@ -324,16 +324,34 @@ class CephNfsProviderHandler(RelationHandler):
         logger.info("NFS cluster '%s' is enabled on 3 / 3 nodes.", cluster_id)
         return True
 
-    def _get_public_address(self, hostname: str) -> str:
+    def _get_peer_value(self, hostname: str, key: str) -> str:
+        """Read a value from the peer databag of the unit running on `hostname`."""
         rel = self.model.get_relation("peers")
+        if rel is None:
+            return ""
+
         for unit in itertools.chain(rel.units, [self.model.unit]):
             rel_data = rel.data[unit]
+            # Each unit stores its own hostname keyed by its unit name.
             unit_hostname = rel_data.get(unit.name)
 
             if hostname == unit_hostname:
-                return rel_data.get("public-address")
+                return rel_data.get(key) or ""
 
         return ""
+
+    def _get_nfs_bind_address(self, hostname: str) -> str:
+        """Resolve the NFS bind address for a host.
+
+        Uses the host's advertised ``nfs-address`` (from the ceph-nfs endpoint
+        binding) when present, else falls back to ``public-address`` (the option
+        is off, or a peer on an older charm revision has not advertised one).
+        """
+        nfs_addr = self._get_peer_value(hostname, "nfs-address")
+        if nfs_addr:
+            return nfs_addr
+
+        return self._get_peer_value(hostname, "public-address")
 
     def _ensure_fs_volume(self, volume_name: str) -> None:
         """Create the FS Volume if it doesn't exist."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -247,6 +247,12 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
             self.configure_charm(event)
 
+            # Refresh peer data on config-changed so binding-derived addresses
+            # (e.g. nfs-address) are published or cleared as config changes,
+            # without waiting for a peers relation event.
+            if self.model.get_relation("peers"):
+                self.peers.set_unit_data(collect_peer_data(self.model))
+
     def _handle_receive_ca_cert(self, event: ops.framework.EventBase) -> None:
         contexts = self.contexts()
         cacert_path = Path(CACERT_FILE)

--- a/src/relation_handlers.py
+++ b/src/relation_handlers.py
@@ -45,6 +45,9 @@ from ceph_broker import process_requests
 
 logger = logging.getLogger(__name__)
 
+# Endpoint whose network space the NFS (Ganesha) service binds to.
+NFS_BINDING = "ceph-nfs"
+
 
 class HostnameChangeError(Exception):
     """Exception raised when the hostname changes unexpectedly."""
@@ -75,7 +78,39 @@ def collect_peer_data(model: ops.model.Model) -> dict:
         if current_data.get("public-address") != str(public_address):
             to_update["public-address"] = str(public_address)
 
+    # Publish the NFS bind address when dedicated binding is enabled; otherwise
+    # (option disabled or binding unresolved) drop any previously published
+    # value so the NFS provider falls back to the public address.
+    nfs_address = _get_nfs_space_address(model)
+    if nfs_address:
+        if current_data.get("nfs-address") != nfs_address:
+            to_update["nfs-address"] = nfs_address
+    elif current_data.get("nfs-address"):
+        to_update["nfs-address"] = ""
+
     return to_update
+
+
+def _get_nfs_space_address(model: ops.model.Model) -> Optional[str]:
+    """Resolve this unit's bind address for the NFS network space.
+
+    Returns the ``ceph-nfs`` endpoint binding's address when
+    ``nfs-use-dedicated-binding`` is enabled, else None so NFS stays on the
+    public address. Also returns None when the binding cannot be resolved.
+    """
+    if not model.config.get("nfs-use-dedicated-binding"):
+        return None
+
+    try:
+        bind_address = model.get_binding(binding_key=NFS_BINDING).network.bind_address
+    except ops.model.ModelError as ex:
+        logger.warning("Could not resolve '%s' binding: %s", NFS_BINDING, ex)
+        return None
+
+    if not bind_address:
+        return None
+
+    return str(bind_address)
 
 
 class MicroClusterNewNodeEvent(RelationEvent):

--- a/tests/integration/test_nfs_binding.py
+++ b/tests/integration/test_nfs_binding.py
@@ -1,0 +1,123 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the MicroCeph charm's NFS network binding.
+
+These exercise the *real* Juju network bindings rather than mocked addresses.
+On a single-network model the ceph-nfs binding resolves to the same address as
+the public binding.
+"""
+
+import ipaddress
+import logging
+import time
+from pathlib import Path
+from typing import Callable
+
+import jubilant
+import pytest
+import yaml
+
+from tests import helpers
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+APP_NAME = METADATA["name"]
+
+
+def _peers_self_data(juju: jubilant.Juju, unit: str) -> dict[str, str]:
+    """Return the data a unit has published about itself on the peers relation.
+
+    Uses ``relation-get`` via ``juju exec`` (which runs with a hook-tool
+    context) so the result is the canonical databag, independent of how
+    ``juju show-unit`` happens to format its output.
+    """
+    # relation-get all keys ("-") of {unit}'s own databag on the peers relation;
+    # the relation id comes from `relation-ids peers`.
+    script = f'relation-get --format=yaml -r "$(relation-ids peers | head -n1)" - {unit}'
+    task = juju.exec(script, unit=unit)
+    task.raise_on_failure()
+    return yaml.safe_load(task.stdout) or {}
+
+
+def _wait_for_peers_data(
+    juju: jubilant.Juju,
+    unit: str,
+    predicate: Callable[[dict[str, str]], bool],
+    *,
+    description: str,
+    timeout: int = 600,
+    interval: int = 10,
+) -> dict[str, str]:
+    """Poll the unit's peers self-data until *predicate* holds, then return it."""
+    deadline = time.time() + timeout
+    last: dict[str, str] = {}
+    with helpers.fast_forward(juju):
+        while time.time() < deadline:
+            last = _peers_self_data(juju, unit)
+            if predicate(last):
+                return last
+            time.sleep(interval)
+    raise AssertionError(f"Timed out waiting for peers data to {description}; last: {last}")
+
+
+@pytest.fixture(scope="module")
+def deployed_microceph(juju: jubilant.Juju, microceph_charm: Path) -> str:
+    """Deploy a single-unit MicroCeph cluster (no OSDs needed for this test)."""
+    helpers.deploy_microceph(juju, microceph_charm, APP_NAME, timeout=1500)
+    return APP_NAME
+
+
+@pytest.mark.abort_on_fail
+def test_nfs_binding_round_trip(juju: jubilant.Juju, deployed_microceph: str) -> None:
+    """nfs-address tracks nfs-use-dedicated-binding against the real binding."""
+    unit = helpers.first_unit_name(juju.status(), APP_NAME)
+
+    # Default: option disabled -> public-address published, nfs-address absent.
+    data = _peers_self_data(juju, unit)
+    logger.info("Default peers data for %s: %s", unit, data)
+    assert data.get("public-address"), "expected a public-address to be published by default"
+    assert "nfs-address" not in data, f"nfs-address must not be published by default: {data}"
+
+    # Opt in: NFS follows the ceph-nfs endpoint binding.
+    juju.config(APP_NAME, {"nfs-use-dedicated-binding": "true"})
+    data = _wait_for_peers_data(
+        juju,
+        unit,
+        lambda d: bool(d.get("nfs-address")),
+        description="publish nfs-address",
+    )
+    logger.info("Peers data with nfs-use-dedicated-binding=true: %s", data)
+    nfs_address = data["nfs-address"]
+    # The published value must be a real IP resolved from the actual binding.
+    ipaddress.ip_address(nfs_address)
+    # On a single-network LXD model the ceph-nfs binding resolves to the same
+    # address as the public binding; both must be real addresses.
+    assert nfs_address == data.get("public-address"), (
+        "nfs-address should match the resolved public binding address on a "
+        f"single-network model: {data}"
+    )
+
+    # Opt back out: the stale nfs-address must be cleared.
+    juju.config(APP_NAME, {"nfs-use-dedicated-binding": "false"})
+    data = _wait_for_peers_data(
+        juju,
+        unit,
+        lambda d: not d.get("nfs-address"),
+        description="clear nfs-address",
+    )
+    logger.info("Peers data after disabling nfs-use-dedicated-binding: %s", data)
+    assert not data.get("nfs-address"), f"nfs-address should be cleared once disabled: {data}"
+    assert data.get("public-address"), "public-address must remain after disabling the option"

--- a/tests/unit/test_ceph_nfs.py
+++ b/tests/unit/test_ceph_nfs.py
@@ -120,8 +120,10 @@ class TestCephNfsClientProvides(testbase.TestBaseCharm):
             {"service": "mon", "location": host},
         ]
 
+        # Advertise both addresses plus the unit-name -> hostname mapping.
         unit_data = {
             "public-address": f"pub-addr-{number}",
+            "nfs-address": f"nfs-addr-{number}",
             unit_name: f"foo{number}",
         }
         self.add_unit(self.harness, rel_id, unit_name, unit_data)
@@ -213,7 +215,7 @@ class TestCephNfsClientProvides(testbase.TestBaseCharm):
         rel_id = self.add_complete_peer_relation(self.harness, unit_data)
         self._add_peer_unit(rel_id, 1)
 
-        self.enable_nfs.assert_called_once_with("foo1", "manila-cephfs", "pub-addr-1")
+        self.enable_nfs.assert_called_once_with("foo1", "manila-cephfs", "nfs-addr-1")
         self.create_fs_volume.assert_called_once_with("manila-cephfs-vol")
         caps = {"mon": ["allow r"], "mgr": ["allow rw"]}
         self.get_named_key.assert_called_once_with("client.manila-cephfs", caps)
@@ -237,9 +239,9 @@ class TestCephNfsClientProvides(testbase.TestBaseCharm):
 
         self.enable_nfs.assert_has_calls(
             [
-                call("foo1", "manila-cephfs", "pub-addr-1"),
-                call("foo2", "manila-cephfs", "pub-addr-2"),
-                call("foo3", "manila-cephfs", "pub-addr-3"),
+                call("foo1", "manila-cephfs", "nfs-addr-1"),
+                call("foo2", "manila-cephfs", "nfs-addr-2"),
+                call("foo3", "manila-cephfs", "nfs-addr-3"),
             ]
         )
         self.create_fs_volume.assert_not_called()
@@ -256,7 +258,7 @@ class TestCephNfsClientProvides(testbase.TestBaseCharm):
         # Add a new relation, should use the 4th node.
         another_nfs_rel_id = self.add_ceph_nfs_relation(self.harness, "another-app")
 
-        self.enable_nfs.assert_called_with("foo4", "another-app", "pub-addr-4")
+        self.enable_nfs.assert_called_with("foo4", "another-app", "nfs-addr-4")
         self.create_fs_volume.assert_called_once_with("another-app-vol")
         rel_data = self.harness.get_relation_data(another_nfs_rel_id, self.harness.model.app)
         expected_data = {
@@ -279,6 +281,71 @@ class TestCephNfsClientProvides(testbase.TestBaseCharm):
         self.enable_nfs.assert_not_called()
         self.create_fs_volume.assert_not_called()
         self.assertIsInstance(ceph_nfs_status.status, BlockedStatus)
+
+    def test_ensure_nfs_cluster_uses_nfs_address(self):
+        # NFS binds to the host's advertised nfs-address (from the ceph-nfs
+        # endpoint binding) in preference to the public address.
+        self.harness.set_leader()
+
+        self.list_services.return_value = [
+            {"service": "mon", "location": "foo1"},
+            {"service": "mgr", "location": "foo1"},
+            {"service": "osd", "location": "foo1"},
+            {"service": "mds", "location": "foo1"},
+        ]
+
+        unit_data = {
+            "public-address": "pub-addr-1",
+            "nfs-address": "nfs-addr-1",
+            "microceph/1": "foo1",
+        }
+        rel_id = self.add_complete_peer_relation(self.harness, unit_data)
+        self._add_peer_unit(rel_id, 1)
+
+        self.add_ceph_nfs_relation(self.harness)
+
+        self.enable_nfs.assert_called_once_with("foo1", "manila-cephfs", "nfs-addr-1")
+
+    def test_ensure_nfs_cluster_falls_back_to_public_when_no_nfs_address(self):
+        # Host has not advertised an nfs-address yet: fall back to public.
+        self.harness.set_leader()
+
+        self.list_services.return_value = [
+            {"service": "mon", "location": "foo1"},
+            {"service": "mgr", "location": "foo1"},
+            {"service": "osd", "location": "foo1"},
+            {"service": "mds", "location": "foo1"},
+        ]
+
+        unit_data = {
+            "public-address": "pub-addr-1",
+            "microceph/1": "foo1",
+        }
+        rel_id = self.add_complete_peer_relation(self.harness, unit_data)
+        # add_unit directly (not _add_peer_unit) to omit nfs-address.
+        self.add_unit(
+            self.harness,
+            rel_id,
+            "microceph/1",
+            {"public-address": "pub-addr-1", "microceph/1": "foo1"},
+        )
+
+        self.add_ceph_nfs_relation(self.harness)
+
+        self.enable_nfs.assert_called_once_with("foo1", "manila-cephfs", "pub-addr-1")
+
+    def test_get_nfs_bind_address_falls_back_when_nfs_address_empty(self):
+        # _get_nfs_bind_address must fall back to public when _get_peer_value
+        # yields "" for nfs-address. _get_peer_value returns "" for an absent
+        # key; a stored "" can't occur (Juju/harness delete ""-valued keys), so
+        # this exercises that contract at the method level.
+        handler = self.harness.charm.ceph_nfs
+
+        def fake_peer_value(hostname, key):
+            return {"nfs-address": "", "public-address": "pub-addr-1"}[key]
+
+        with patch.object(handler, "_get_peer_value", side_effect=fake_peer_value):
+            self.assertEqual(handler._get_nfs_bind_address("foo1"), "pub-addr-1")
 
     def test_relation_data_clear(self):
         self.harness.set_leader()
@@ -367,7 +434,7 @@ class TestCephNfsClientProvides(testbase.TestBaseCharm):
         # Add the ceph-nfs relation. It should use the available node.
         nfs_rel_id = self.add_ceph_nfs_relation(self.harness)
 
-        self.enable_nfs.assert_called_once_with("foo1", "manila-cephfs", "pub-addr-1")
+        self.enable_nfs.assert_called_once_with("foo1", "manila-cephfs", "nfs-addr-1")
         self.create_fs_volume.assert_called_once_with("manila-cephfs-vol")
         rel_data = self.harness.get_relation_data(nfs_rel_id, self.harness.model.app)
         expected_data = {
@@ -407,9 +474,9 @@ class TestCephNfsClientProvides(testbase.TestBaseCharm):
 
         self.enable_nfs.assert_has_calls(
             [
-                call("foo1", "manila-cephfs", "pub-addr-1"),
-                call("foo2", "manila-cephfs", "pub-addr-2"),
-                call("foo3", "manila-cephfs", "pub-addr-3"),
+                call("foo1", "manila-cephfs", "nfs-addr-1"),
+                call("foo2", "manila-cephfs", "nfs-addr-2"),
+                call("foo3", "manila-cephfs", "nfs-addr-3"),
             ],
             any_order=True,
         )
@@ -442,9 +509,9 @@ class TestCephNfsClientProvides(testbase.TestBaseCharm):
         self.remove_named_key.assert_called_once_with("client.manila-cephfs")
         self.enable_nfs.assert_has_calls(
             [
-                call("foo1", "another-app", "pub-addr-1"),
-                call("foo2", "another-app", "pub-addr-2"),
-                call("foo3", "another-app", "pub-addr-3"),
+                call("foo1", "another-app", "nfs-addr-1"),
+                call("foo2", "another-app", "nfs-addr-2"),
+                call("foo3", "another-app", "nfs-addr-3"),
             ],
             any_order=True,
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -163,6 +163,46 @@ class TestCharm(testbase.TestBaseCharm):
         # Assert RGW update configs is not called
         cclient.from_socket().cluster.update_config.assert_not_called()
 
+    @patch.object(ceph_cos_agent, "CephCOSAgentProvider")
+    @patch.object(ceph_cos_agent, "ceph_utils")
+    @patch.object(microceph, "Client")
+    @patch("utils.subprocess")
+    @patch.object(Path, "chmod")
+    @patch.object(Path, "write_bytes")
+    @patch("builtins.open", new_callable=mock_open, read_data="mon host dummy-ip")
+    def test_config_changed_republishes_nfs_address(
+        self,
+        mock_file,
+        mock_path_wb,
+        mock_path_chmod,
+        subprocess,
+        cclient,
+        _utils,
+        _cos_agent,
+    ):
+        """Enabling nfs-use-dedicated-binding republishes nfs-address.
+
+        Peer data is published when the peers relation is created, but the
+        config-changed hook must (re)publish it when an operator enables the
+        option after deploy, even though the peers relation already exists
+        (config-changed, not relation-created).
+        """
+        cclient.from_socket().cluster.list_services.return_value = []
+
+        self.harness.set_leader()
+        rel_id = self.add_complete_peer_relation(self.harness)
+        unit_name = self.harness.charm.unit.name
+
+        # Default (option disabled): NFS stays on public, no nfs-address.
+        data = self.harness.get_relation_data(rel_id, unit_name)
+        self.assertNotIn("nfs-address", data)
+
+        # Enabling the option fires config-changed, which must publish the
+        # binding-derived nfs-address even though the peers relation exists.
+        self.harness.update_config({"nfs-use-dedicated-binding": True})
+        data = self.harness.get_relation_data(rel_id, unit_name)
+        self.assertEqual(data.get("nfs-address"), "10.0.0.10")
+
     @patch.object(ceph_cos_agent, "ceph_utils")
     @patch.object(microceph, "Client")
     @patch("utils.subprocess")

--- a/tests/unit/test_relation_handlers.py
+++ b/tests/unit/test_relation_handlers.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import MagicMock, patch
 
+import ops
 import ops_sunbeam.test_utils as test_utils
 from unit import testbase
 
@@ -61,6 +63,129 @@ class TestRelationHelpers(testbase.TestBaseCharm):
         # assert that collect_peer_data raises an exception
         with self.assertRaises(relation_handlers.HostnameChangeError):
             relation_handlers.collect_peer_data(self.harness.model)
+
+    def test_collect_peer_data_no_nfs_address_by_default(self):
+        # nfs-use-dedicated-binding defaults to false: NFS stays on the public
+        # address and no nfs-address is published.
+        self.harness.set_leader()
+        rel_id = self.add_complete_peer_relation(self.harness)
+        unit_name = self.harness.model.unit.name
+        self.harness.update_relation_data(rel_id, "microceph/0", {unit_name: "test-hostname"})
+        self.gethostname.return_value = "test-hostname"
+
+        change_data = relation_handlers.collect_peer_data(self.harness.model)
+
+        self.assertNotIn("nfs-address", change_data)
+
+    def test_collect_peer_data_clears_stale_nfs_address_when_disabled(self):
+        # With the option disabled, a previously published nfs-address is cleared
+        # so the NFS provider reverts to the public address.
+        self.harness.set_leader()
+        rel_id = self.add_complete_peer_relation(self.harness)
+        unit_name = self.harness.model.unit.name
+        self.harness.update_relation_data(
+            rel_id, unit_name, {unit_name: "test-hostname", "nfs-address": "10.20.0.10"}
+        )
+        self.gethostname.return_value = "test-hostname"
+
+        change_data = relation_handlers.collect_peer_data(self.harness.model)
+
+        self.assertEqual(change_data["nfs-address"], "")
+
+    def test_collect_peer_data_publishes_nfs_address(self):
+        # With nfs-use-dedicated-binding enabled, NFS binds to the ceph-nfs
+        # endpoint's space and that address is published as nfs-address. The
+        # harness resolves every binding to 10.0.0.10.
+        self.harness.set_leader()
+        self.harness.disable_hooks()
+        self.harness.update_config({"nfs-use-dedicated-binding": True})
+        rel_id = self.add_complete_peer_relation(self.harness)
+        unit_name = self.harness.model.unit.name
+        self.harness.update_relation_data(rel_id, "microceph/0", {unit_name: "test-hostname"})
+        self.gethostname.return_value = "test-hostname"
+
+        change_data = relation_handlers.collect_peer_data(self.harness.model)
+
+        self.assertEqual(change_data["nfs-address"], "10.0.0.10")
+
+    def test_collect_peer_data_resolves_from_ceph_nfs_binding(self):
+        # When enabled, nfs-address is sourced from the ceph-nfs endpoint
+        # binding: the address on that binding is what gets published.
+        self.harness.set_leader()
+        self.harness.disable_hooks()
+        self.harness.update_config({"nfs-use-dedicated-binding": True})
+        rel_id = self.add_complete_peer_relation(self.harness)
+        unit_name = self.harness.model.unit.name
+        self.harness.update_relation_data(rel_id, "microceph/0", {unit_name: "test-hostname"})
+        self.gethostname.return_value = "test-hostname"
+
+        def fake_get_binding(binding_key):
+            # ceph-nfs resolves to a distinct address; others keep the default.
+            binding = MagicMock()
+            binding.network.bind_address = (
+                "10.20.0.10" if binding_key == relation_handlers.NFS_BINDING else "10.0.0.10"
+            )
+            return binding
+
+        with patch.object(
+            self.harness.model, "get_binding", side_effect=fake_get_binding
+        ) as get_binding:
+            change_data = relation_handlers.collect_peer_data(self.harness.model)
+
+        get_binding.assert_any_call(binding_key=relation_handlers.NFS_BINDING)
+        self.assertEqual(change_data["nfs-address"], "10.20.0.10")
+        self.assertEqual(change_data["public-address"], "10.0.0.10")
+
+    def test_collect_peer_data_skips_nfs_address_on_binding_error(self):
+        # Enabled but the ceph-nfs binding cannot be resolved and none was
+        # published before: nothing is published, so NFS uses the public address.
+        self.harness.set_leader()
+        self.harness.disable_hooks()
+        self.harness.update_config({"nfs-use-dedicated-binding": True})
+        rel_id = self.add_complete_peer_relation(self.harness)
+        unit_name = self.harness.model.unit.name
+        self.harness.update_relation_data(rel_id, "microceph/0", {unit_name: "test-hostname"})
+        self.gethostname.return_value = "test-hostname"
+
+        def fake_get_binding(binding_key):
+            if binding_key == relation_handlers.NFS_BINDING:
+                raise ops.model.ModelError("boom")
+            binding = MagicMock()
+            binding.network.bind_address = "10.0.0.10"
+            return binding
+
+        with patch.object(self.harness.model, "get_binding", side_effect=fake_get_binding):
+            change_data = relation_handlers.collect_peer_data(self.harness.model)
+
+        self.assertNotIn("nfs-address", change_data)
+        self.assertEqual(change_data["public-address"], "10.0.0.10")
+
+    def test_collect_peer_data_clears_stale_nfs_address_on_binding_error(self):
+        # Enabled but the ceph-nfs binding cannot be resolved: a previously
+        # published nfs-address is cleared, so NFS falls back to the public
+        # address (an unresolvable binding is treated like the option being off).
+        self.harness.set_leader()
+        self.harness.disable_hooks()
+        self.harness.update_config({"nfs-use-dedicated-binding": True})
+        rel_id = self.add_complete_peer_relation(self.harness)
+        unit_name = self.harness.model.unit.name
+        self.harness.update_relation_data(
+            rel_id, unit_name, {unit_name: "test-hostname", "nfs-address": "10.20.0.10"}
+        )
+        self.gethostname.return_value = "test-hostname"
+
+        def fake_get_binding(binding_key):
+            if binding_key == relation_handlers.NFS_BINDING:
+                raise ops.model.ModelError("boom")
+            binding = MagicMock()
+            binding.network.bind_address = "10.0.0.10"
+            return binding
+
+        with patch.object(self.harness.model, "get_binding", side_effect=fake_get_binding):
+            change_data = relation_handlers.collect_peer_data(self.harness.model)
+
+        self.assertEqual(change_data["nfs-address"], "")
+        self.assertEqual(change_data["public-address"], "10.0.0.10")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

It is not currently possible to bind NFS to its own custom juju [space](https://documentation.ubuntu.com/juju/3.6/reference/space/). 

Add a new binding 'nfs', which enables binding NFS to a alternative network space. 

Add a new configuration option that causes nfs to bind to a chosens space: 'nfs-bind-network: {space}'.  

A cleaner implementation would not include the configuration option, however this would break backward compatibility. For backward compatibility, follow the existing behavior of having nfs on the public space. This way existing deployments do not get modified unexpectedly, and switched to the default space if nfs binding were to be unset. Potentially deprecate the configuration option (even though we just added it) as an explicit warning that the old functionality will not remain - eventually move towards no configuration.

Fixes #lp-2150595

Note:  Will rebase on main and drop https://github.com/canonical/charm-microceph/pull/305/commits/dce5dd5065f75b27bfcd3b468f993b103401bb04 after keystone fix (#307) merged

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added unit & integration tests exercising feature

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
