### PR TITLE
fix: sync keystone lib and pin ops-sunbeam to upstream main

### DIFF
--- a/lib/charms/keystone_k8s/v1/identity_service.py
+++ b/lib/charms/keystone_k8s/v1/identity_service.py
@@ -77,6 +77,9 @@ class IdentityServiceClientCharm(CharmBase):
 
 import json
 import logging
+from typing import (
+    Any,
+)
 
 from ops import ModelError
 from ops.framework import (
@@ -101,7 +104,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -147,12 +150,14 @@ class IdentityServiceRequires(Object):
         relation_name: str,
         service_endpoints: list[dict],
         region: str,
+        extra_roles: list[str] | None = None,
     ):
         super().__init__(charm, relation_name)
         self.charm = charm
         self.relation_name = relation_name
         self.service_endpoints = service_endpoints
         self.region = region
+        self.extra_roles = extra_roles or []
         self.framework.observe(
             self.charm.on[relation_name].relation_joined,
             self._on_identity_service_relation_joined,
@@ -174,7 +179,9 @@ class IdentityServiceRequires(Object):
         """IdentityService relation joined."""
         logging.debug("IdentityService on_joined")
         self.on.connected.emit()
-        self.register_services(self.service_endpoints, self.region)
+        self.register_services(
+            self.service_endpoints, self.region, self.extra_roles
+        )
 
     def _on_identity_service_relation_changed(self, event):
         """IdentityService relation changed."""
@@ -358,8 +365,20 @@ class IdentityServiceRequires(Object):
         """Return the admin_role."""
         return self.get_remote_app_data("admin-role")
 
+    @property
+    def region_name(self) -> str:
+        """Return the identity region name.
+
+        In multi-region environments, this may be different than
+        the region of the requester.
+        """
+        return self.get_remote_app_data("region")
+
     def register_services(
-        self, service_endpoints: list[dict], region: str
+        self,
+        service_endpoints: list[dict],
+        region: str,
+        extra_roles: list[str] | None = None,
     ) -> None:
         """Request access to the IdentityService server."""
         if self.model.unit.is_leader():
@@ -369,6 +388,10 @@ class IdentityServiceRequires(Object):
                 service_endpoints, sort_keys=True
             )
             app_data["region"] = region
+            if extra_roles:
+                app_data["extra-roles"] = json.dumps(extra_roles)
+            else:
+                app_data.pop("extra-roles", None)
 
 
 class HasIdentityServiceClientsEvent(EventBase):
@@ -388,6 +411,7 @@ class ReadyIdentityServiceClientsEvent(EventBase):
         service_endpoints,
         region,
         client_app_name,
+        extra_roles,
     ):
         super().__init__(handle)
         self.relation_id = relation_id
@@ -395,6 +419,7 @@ class ReadyIdentityServiceClientsEvent(EventBase):
         self.service_endpoints = service_endpoints
         self.region = region
         self.client_app_name = client_app_name
+        self.extra_roles = extra_roles
 
     def snapshot(self):
         return {
@@ -403,6 +428,7 @@ class ReadyIdentityServiceClientsEvent(EventBase):
             "service_endpoints": self.service_endpoints,
             "client_app_name": self.client_app_name,
             "region": self.region,
+            "extra_roles": self.extra_roles,
         }
 
     def restore(self, snapshot):
@@ -412,6 +438,7 @@ class ReadyIdentityServiceClientsEvent(EventBase):
         self.service_endpoints = snapshot["service_endpoints"]
         self.region = snapshot["region"]
         self.client_app_name = snapshot["client_app_name"]
+        self.extra_roles = snapshot.get("extra_roles", [])
 
 
 class IdentityServiceClientEvents(ObjectEvents):
@@ -467,18 +494,34 @@ class IdentityServiceProvides(Object):
             service_eps = json.loads(
                 event.relation.data[event.relation.app]["service-endpoints"]
             )
+            extra_roles = self._load_extra_roles(
+                event.relation.data[event.relation.app].get("extra-roles")
+            )
             self.on.ready_identity_service_clients.emit(
                 event.relation.id,
                 event.relation.name,
                 service_eps,
                 event.relation.data[event.relation.app]["region"],
                 event.relation.app.name,
+                extra_roles,
             )
 
     def _on_identity_service_relation_broken(self, event):
         """Handle IdentityService broken."""
         logging.debug("IdentityServiceProvides on_departed")
         # TODO clear data on the relation
+
+    @staticmethod
+    def _load_extra_roles(raw_extra_roles: str | None) -> list[str]:
+        """Load extra roles from requirer relation data."""
+        if not raw_extra_roles:
+            return []
+        extra_roles: Any = json.loads(raw_extra_roles)
+        if not isinstance(extra_roles, list) or not all(
+            isinstance(role, str) and role for role in extra_roles
+        ):
+            raise ValueError("extra-roles must be a JSON list of strings")
+        return extra_roles
 
     def set_identity_service_credentials(
         self,
@@ -505,6 +548,7 @@ class IdentityServiceProvides(Object):
         public_auth_url: str,
         service_credentials: str,
         admin_role: str,
+        region: str,
     ):
         logging.debug("Setting identity_service connection information.")
         _identity_service_rel = None
@@ -541,3 +585,4 @@ class IdentityServiceProvides(Object):
         app_data["public-auth-url"] = public_auth_url
         app_data["service-credentials"] = service_credentials
         app_data["admin-role"] = admin_role
+        app_data["region"] = region

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ dependencies = [
     "pydantic>=2.12,<2.13",
     "cosl==0.0.55",
     "requests<2.32",
-    "ops_sunbeam@git+https://opendev.org/openstack/sunbeam-charms#subdirectory=ops-sunbeam",
-    "charms.ceph@git+https://github.com/canonical/ceph-charms#subdirectory=charms.ceph",
+    "ops_sunbeam@git+https://opendev.org/openstack/sunbeam-charms@69ec637504645053adee8c89f8e83f24c065745d#subdirectory=ops-sunbeam",
+    "charms.ceph@git+https://github.com/canonical/ceph-charms@f427e7e4a1b7b3d0d2d0f3df3a4537a4b39980e2#subdirectory=charms.ceph",
     "requests-unixsocket",
     "urllib3<2",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,9 @@ jinja2
 pydantic>=2.12,<2.13 
 cosl==0.0.55
 requests<2.32 # https://github.com/psf/requests/issues/6707 (similar issue with http+unix)
-git+https://opendev.org/openstack/sunbeam-charms#egg=ops-sunbeam&subdirectory=ops-sunbeam
-git+https://github.com/canonical/ceph-charms#egg=charms_ceph&subdirectory=charms.ceph
+# Pinned to match uv.lock; bump together via `uv lock --upgrade-package ...`
+git+https://opendev.org/openstack/sunbeam-charms@69ec637504645053adee8c89f8e83f24c065745d#egg=ops-sunbeam&subdirectory=ops-sunbeam
+git+https://github.com/canonical/ceph-charms@f427e7e4a1b7b3d0d2d0f3df3a4537a4b39980e2#egg=charms_ceph&subdirectory=charms.ceph
 
 # Used for communication with snapd socket
 requests-unixsocket # Apache 2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,4 +7,5 @@ ops<3.4
 pydantic>=2.12,<2.13 
 cosl==0.0.55
 
-git+https://github.com/canonical/ceph-charms#egg=charms_ceph&subdirectory=charms.ceph
+# Pinned to match uv.lock; bump together via `uv lock --upgrade-package ...`
+git+https://github.com/canonical/ceph-charms@f427e7e4a1b7b3d0d2d0f3df3a4537a4b39980e2#egg=charms_ceph&subdirectory=charms.ceph

--- a/uv.lock
+++ b/uv.lock
@@ -114,7 +114,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/5a/f5/2ed2c938671e1305f
 [[package]]
 name = "charms-ceph"
 version = "0.0.1.dev1"
-source = { git = "https://github.com/canonical/ceph-charms?subdirectory=charms.ceph#a6ea066f989eefe1d77bc932e24cf988698db9a5" }
+source = { git = "https://github.com/canonical/ceph-charms?subdirectory=charms.ceph&rev=f427e7e4a1b7b3d0d2d0f3df3a4537a4b39980e2#f427e7e4a1b7b3d0d2d0f3df3a4537a4b39980e2" }
 dependencies = [
     { name = "charmhelpers" },
     { name = "pyudev" },
@@ -505,14 +505,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "charms-ceph", git = "https://github.com/canonical/ceph-charms?subdirectory=charms.ceph" },
+    { name = "charms-ceph", git = "https://github.com/canonical/ceph-charms?subdirectory=charms.ceph&rev=f427e7e4a1b7b3d0d2d0f3df3a4537a4b39980e2" },
     { name = "cosl", specifier = "==0.0.55" },
     { name = "cryptography" },
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "netifaces" },
     { name = "ops", specifier = "<3.4" },
-    { name = "ops-sunbeam", git = "https://opendev.org/openstack/sunbeam-charms?subdirectory=ops-sunbeam" },
+    { name = "ops-sunbeam", git = "https://opendev.org/openstack/sunbeam-charms?subdirectory=ops-sunbeam&rev=69ec637504645053adee8c89f8e83f24c065745d" },
     { name = "pydantic", specifier = ">=2.12,<2.13" },
     { name = "pyroute2" },
     { name = "requests", specifier = "<2.32" },
@@ -566,7 +566,7 @@ wheels = [
 [[package]]
 name = "ops-sunbeam"
 version = "0.0.1.dev1"
-source = { git = "https://opendev.org/openstack/sunbeam-charms?subdirectory=ops-sunbeam#1f744182d7f11cbc3fa4262b06da08910e9d72f3" }
+source = { git = "https://opendev.org/openstack/sunbeam-charms?subdirectory=ops-sunbeam&rev=69ec637504645053adee8c89f8e83f24c065745d#69ec637504645053adee8c89f8e83f24c065745d" }
 dependencies = [
     { name = "lightkube" },
     { name = "lightkube-models" },


### PR DESCRIPTION
# Description

ops-sunbeam changed upstream on main. Its identity-service handler now passes an `extra_roles` arg when it builds `IdentityServiceRequires`, but our vendored keystone lib was too old to accept it. That broke charm setup and unit tests with a `TypeError` about too many arguments.

On top of that the build and the tests were pulling ops-sunbeam from different places: the build used the commit pinned in `uv.lock`, while tox/pip just grabbed whatever was on main. So they could drift apart and break like this again.

This PR:

- Bumps the vendored `lib/charms/keystone_k8s/v1/identity_service.py` to LIBPATCH 7 to match ops-sunbeam main. `extra_roles` is optional so nothing else changes.
- Pins ops-sunbeam (`69ec6375?`) and charms.ceph (`a6ea066`) to the exact commits from `uv.lock` in `requirements.txt`, `test-requirements.txt` and `pyproject.toml`, so every path installs the same thing. Bump them later with `uv lock --upgrade-package`.

Fixes #306

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran `tox -e py3` a fresh env. All unit tests pass. `uv lock --check` is clean.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.