### PR TITLE
ci: grant contents:write to release-to-charmhub job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,6 +30,8 @@ jobs:
 
   release-to-charmhub:
     name: Release to CharmHub
+    permissions:
+      contents: write          # allow charming-actions to create the git tag
     needs:
       - lint
       - unit-test


### PR DESCRIPTION
# Description

Every push to `main` reports the **Release to CharmHub** job in
`.github/workflows/main.yaml` as failed, even though the charm publishes
successfully (uploaded, scanned, approved, and released to `tentacle/edge`).
The job fails on the final step with:

```
{ "revision": 266 }
##[error]Resource not accessible by integration
##[error]HttpError: Resource not accessible by integration
```

`canonical/charming-actions/upload-charm@2.7.0` is configured with
`tag-prefix: tentacle`, so after publishing it creates a GitHub git tag via
the REST API (`POST /repos/.../git/refs`). That call requires the workflow's
automatic `GITHUB_TOKEN` to have the `contents: write` scope.

`main.yaml` declared **no `permissions:` block**, so the token fell back to
the repo/org default (read-only) and the tag-creation call was rejected.
This worked before because the earlier workflow used `upload-charm@2.4.0`
with no `tag-prefix`, which never attempted any GitHub write.

The fix adds a job-scoped `permissions: contents: write` block to the
`release-to-charmhub` job only (least privilege — the `lint` and `unit-test`
jobs keep read-only tokens).

> **Caveat:** if the org/repo policy at *Settings -> Actions -> General ->
> Workflow permissions* is locked to read-only and forbids jobs from
> requesting write, this job-level block alone will not be honoured and that
> setting must also be changed. Most Canonical repos allow per-job write.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This is a CI workflow permissions change with no functional code change, so
no unit/functional tests apply. It will be verified on the next push to
`main`:

- The **Release to CharmHub** job completes successfully (green).
- A tag of the form `tentacle-<revision>` is created in the repo.
- The charm is still published to `tentacle/edge` (unchanged behaviour).

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes. (N/A — CI only)
- [ ] added tests to verify effectiveness of this change. (N/A — CI workflow permissions change)
