### PR TITLE
fix: only advertise mgr scrape target on mgr-hosting units (#301) [backport stable/squid]

### DIFF
--- a/lib/charms/ceph_mon/v0/ceph_cos_agent.py
+++ b/lib/charms/ceph_mon/v0/ceph_cos_agent.py
@@ -19,14 +19,14 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 logger = logging.getLogger(__name__)
 
 
 class CephCOSAgentProvider(cos_agent.COSAgentProvider):
     def __init__(self, charm, refresh_cb=None, departed_cb=None, is_ready_cb=None,
-                 mgr_config_set_cb=None):
+                 mgr_config_set_cb=None, is_mgr_available_cb=None):
         super().__init__(
             charm,
             metrics_rules_dir="./files/prometheus_alert_rules",
@@ -38,6 +38,9 @@ class CephCOSAgentProvider(cos_agent.COSAgentProvider):
         self._departed_cb = departed_cb
         self._is_ready_cb = is_ready_cb
         self._mgr_config_set_cb = mgr_config_set_cb
+        # Optional () -> bool: does ceph-mgr run on this host? False suppresses
+        # the mgr scrape job; unset always advertises it (historic behavior).
+        self._is_mgr_available_cb = is_mgr_available_cb
 
         events = self._charm.on[cos_agent.DEFAULT_RELATION_NAME]
         self.framework.observe(
@@ -89,7 +92,36 @@ class CephCOSAgentProvider(cos_agent.COSAgentProvider):
                 ceph_utils.mgr_disable_module("prometheus")
         logger.debug("module_disabled")
 
+    @property
+    def _scrape_jobs(self):
+        """Like the base property but keeps an empty list instead of
+        substituting ``DEFAULT_SCRAPE_CONFIG`` (``localhost:80``): a unit with
+        no local exporter must advertise no scrape job, not a bogus target.
+        """
+        scrape_configs = self._custom_scrape_configs()
+
+        # Convert "metrics_endpoints" to standard scrape_configs, and add them in
+        for endpoint in self._metrics_endpoints:
+            scrape_configs.append(
+                {
+                    "metrics_path": endpoint["path"],
+                    "static_configs": [{"targets": [f"localhost:{endpoint['port']}"]}],
+                }
+            )
+
+        # Augment job name to include the app name and a unique id (index).
+        for idx, scrape_config in enumerate(scrape_configs):
+            scrape_config["job_name"] = "_".join(
+                [self._charm.app.name, str(idx), scrape_config.get("job_name", "default")]
+            )
+
+        return scrape_configs
+
     def _custom_scrape_configs(self):
+        """Return the mgr scrape config, or nothing on a non-mgr host."""
+        if self._is_mgr_available_cb is not None and not self._is_mgr_available_cb():
+            return []
+
         fqdn = socket.getfqdn()
         fqdn_parts = fqdn.split('.')
         domain = '.'.join(fqdn_parts[1:]) if len(fqdn_parts) > 1 else fqdn

--- a/lib/charms/keystone_k8s/v1/identity_service.py
+++ b/lib/charms/keystone_k8s/v1/identity_service.py
@@ -77,6 +77,9 @@ class IdentityServiceClientCharm(CharmBase):
 
 import json
 import logging
+from typing import (
+    Any,
+)
 
 from ops import ModelError
 from ops.framework import (
@@ -101,7 +104,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -147,12 +150,14 @@ class IdentityServiceRequires(Object):
         relation_name: str,
         service_endpoints: list[dict],
         region: str,
+        extra_roles: list[str] | None = None,
     ):
         super().__init__(charm, relation_name)
         self.charm = charm
         self.relation_name = relation_name
         self.service_endpoints = service_endpoints
         self.region = region
+        self.extra_roles = extra_roles or []
         self.framework.observe(
             self.charm.on[relation_name].relation_joined,
             self._on_identity_service_relation_joined,
@@ -174,7 +179,9 @@ class IdentityServiceRequires(Object):
         """IdentityService relation joined."""
         logging.debug("IdentityService on_joined")
         self.on.connected.emit()
-        self.register_services(self.service_endpoints, self.region)
+        self.register_services(
+            self.service_endpoints, self.region, self.extra_roles
+        )
 
     def _on_identity_service_relation_changed(self, event):
         """IdentityService relation changed."""
@@ -358,8 +365,20 @@ class IdentityServiceRequires(Object):
         """Return the admin_role."""
         return self.get_remote_app_data("admin-role")
 
+    @property
+    def region_name(self) -> str:
+        """Return the identity region name.
+
+        In multi-region environments, this may be different than
+        the region of the requester.
+        """
+        return self.get_remote_app_data("region")
+
     def register_services(
-        self, service_endpoints: list[dict], region: str
+        self,
+        service_endpoints: list[dict],
+        region: str,
+        extra_roles: list[str] | None = None,
     ) -> None:
         """Request access to the IdentityService server."""
         if self.model.unit.is_leader():
@@ -369,6 +388,10 @@ class IdentityServiceRequires(Object):
                 service_endpoints, sort_keys=True
             )
             app_data["region"] = region
+            if extra_roles:
+                app_data["extra-roles"] = json.dumps(extra_roles)
+            else:
+                app_data.pop("extra-roles", None)
 
 
 class HasIdentityServiceClientsEvent(EventBase):
@@ -388,6 +411,7 @@ class ReadyIdentityServiceClientsEvent(EventBase):
         service_endpoints,
         region,
         client_app_name,
+        extra_roles,
     ):
         super().__init__(handle)
         self.relation_id = relation_id
@@ -395,6 +419,7 @@ class ReadyIdentityServiceClientsEvent(EventBase):
         self.service_endpoints = service_endpoints
         self.region = region
         self.client_app_name = client_app_name
+        self.extra_roles = extra_roles
 
     def snapshot(self):
         return {
@@ -403,6 +428,7 @@ class ReadyIdentityServiceClientsEvent(EventBase):
             "service_endpoints": self.service_endpoints,
             "client_app_name": self.client_app_name,
             "region": self.region,
+            "extra_roles": self.extra_roles,
         }
 
     def restore(self, snapshot):
@@ -412,6 +438,7 @@ class ReadyIdentityServiceClientsEvent(EventBase):
         self.service_endpoints = snapshot["service_endpoints"]
         self.region = snapshot["region"]
         self.client_app_name = snapshot["client_app_name"]
+        self.extra_roles = snapshot.get("extra_roles", [])
 
 
 class IdentityServiceClientEvents(ObjectEvents):
@@ -467,18 +494,34 @@ class IdentityServiceProvides(Object):
             service_eps = json.loads(
                 event.relation.data[event.relation.app]["service-endpoints"]
             )
+            extra_roles = self._load_extra_roles(
+                event.relation.data[event.relation.app].get("extra-roles")
+            )
             self.on.ready_identity_service_clients.emit(
                 event.relation.id,
                 event.relation.name,
                 service_eps,
                 event.relation.data[event.relation.app]["region"],
                 event.relation.app.name,
+                extra_roles,
             )
 
     def _on_identity_service_relation_broken(self, event):
         """Handle IdentityService broken."""
         logging.debug("IdentityServiceProvides on_departed")
         # TODO clear data on the relation
+
+    @staticmethod
+    def _load_extra_roles(raw_extra_roles: str | None) -> list[str]:
+        """Load extra roles from requirer relation data."""
+        if not raw_extra_roles:
+            return []
+        extra_roles: Any = json.loads(raw_extra_roles)
+        if not isinstance(extra_roles, list) or not all(
+            isinstance(role, str) and role for role in extra_roles
+        ):
+            raise ValueError("extra-roles must be a JSON list of strings")
+        return extra_roles
 
     def set_identity_service_credentials(
         self,
@@ -505,6 +548,7 @@ class IdentityServiceProvides(Object):
         public_auth_url: str,
         service_credentials: str,
         admin_role: str,
+        region: str,
     ):
         logging.debug("Setting identity_service connection information.")
         _identity_service_rel = None
@@ -541,3 +585,4 @@ class IdentityServiceProvides(Object):
         app_data["public-auth-url"] = public_auth_url
         app_data["service-credentials"] = service_credentials
         app_data["admin-role"] = admin_role
+        app_data["region"] = region

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ dependencies = [
     "pydantic>=2.12,<2.13",
     "cosl==0.0.55",
     "requests<2.32",
-    "ops_sunbeam@git+https://opendev.org/openstack/sunbeam-charms#subdirectory=ops-sunbeam",
-    "charms.ceph@git+https://github.com/canonical/ceph-charms#subdirectory=charms.ceph",
+    "ops_sunbeam@git+https://opendev.org/openstack/sunbeam-charms@69ec637504645053adee8c89f8e83f24c065745d#subdirectory=ops-sunbeam",
+    "charms.ceph@git+https://github.com/canonical/ceph-charms@f427e7e4a1b7b3d0d2d0f3df3a4537a4b39980e2#subdirectory=charms.ceph",
     "requests-unixsocket",
     "urllib3<2",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,9 @@ jinja2
 pydantic>=2.12,<2.13 
 cosl==0.0.55
 requests<2.32 # https://github.com/psf/requests/issues/6707 (similar issue with http+unix)
-git+https://opendev.org/openstack/sunbeam-charms#egg=ops-sunbeam&subdirectory=ops-sunbeam
-git+https://github.com/canonical/ceph-charms#egg=charms_ceph&subdirectory=charms.ceph
+# Pinned to match uv.lock; bump together via `uv lock --upgrade-package ...`
+git+https://opendev.org/openstack/sunbeam-charms@69ec637504645053adee8c89f8e83f24c065745d#egg=ops-sunbeam&subdirectory=ops-sunbeam
+git+https://github.com/canonical/ceph-charms@f427e7e4a1b7b3d0d2d0f3df3a4537a4b39980e2#egg=charms_ceph&subdirectory=charms.ceph
 
 # Used for communication with snapd socket
 requests-unixsocket # Apache 2

--- a/src/charm.py
+++ b/src/charm.py
@@ -92,6 +92,7 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             departed_cb=microceph.cos_agent_departed_cb,
             is_ready_cb=self.ready_for_service,
             mgr_config_set_cb=microceph.cos_agent_mgr_config_set_cb,
+            is_mgr_available_cb=microceph.cos_agent_is_mgr_available_cb,
         )
 
         # Initialise handlers for events.

--- a/src/microceph.py
+++ b/src/microceph.py
@@ -27,7 +27,11 @@ from charms.operator_libs_linux.v2 import snap
 
 import ceph
 import utils
-from microceph_client import Client, UnrecognizedClusterConfigOption
+from microceph_client import (
+    Client,
+    RemoteException,
+    UnrecognizedClusterConfigOption,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +111,28 @@ def cos_agent_departed_cb(event):
     ceph.disable_ceph_monitoring()
 
 
+def cos_agent_is_mgr_available_cb() -> bool:
+    """Whether ceph-mgr (the :9283 endpoint) runs on this host.
+
+    Gates the mgr scrape config so non-mgr units don't advertise a dead
+    target. Fails closed: an unreadable service list suppresses the target
+    rather than advertising one we can't confirm is up.
+
+    The cluster client only maps a handful of known errors to RemoteException
+    and re-raises the underlying requests error (e.g. HTTPError) for anything
+    else, so we also fail closed on any requests-layer failure.
+    """
+    try:
+        return is_mgr_enabled(gethostname())
+    except (RemoteException, requests.exceptions.RequestException) as e:
+        logger.warning(
+            "Could not determine local mgr presence for scrape config, "
+            "suppressing mgr scrape target: %s",
+            e,
+        )
+        return False
+
+
 def remove_cluster_member(name: str, is_force: bool) -> None:
     """Remove a cluster member."""
     cmd = ["microceph", "cluster", "remove", name]
@@ -160,6 +186,27 @@ def is_rgw_enabled(hostname: str) -> bool:
     services = client.cluster.list_services() or []
     for service in services:
         if service["service"] == "rgw" and service["location"] == hostname:
+            return True
+
+    return False
+
+
+@tenacity.retry(
+    retry=tenacity.retry_if_exception_type(RemoteException),
+    wait=tenacity.wait_fixed(2),
+    stop=tenacity.stop_after_attempt(3),
+    reraise=True,
+)
+def is_mgr_enabled(hostname: str) -> bool:
+    """Check if the ceph-mgr service runs on host.
+
+    Retries on transient cluster-unavailability; raises
+    ClusterServiceUnavailableException if it stays unavailable.
+    """
+    client = Client.from_socket()
+    services = client.cluster.list_services() or []
+    for service in services:
+        if service["service"] == "mgr" and service["location"] == hostname:
             return True
 
     return False

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,4 +7,5 @@ ops<3.4
 pydantic>=2.12,<2.13 
 cosl==0.0.55
 
-git+https://github.com/canonical/ceph-charms#egg=charms_ceph&subdirectory=charms.ceph
+# Pinned to match uv.lock; bump together via `uv lock --upgrade-package ...`
+git+https://github.com/canonical/ceph-charms@f427e7e4a1b7b3d0d2d0f3df3a4537a4b39980e2#egg=charms_ceph&subdirectory=charms.ceph

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -14,6 +14,7 @@
 
 """Tests for Microceph charm."""
 
+import json
 from pathlib import Path
 from subprocess import CalledProcessError
 from unittest.mock import MagicMock, PropertyMock, call, mock_open, patch
@@ -1038,6 +1039,70 @@ class TestCharm(testbase.TestBaseCharm):
         )
         # charms_ceph fallback should NOT be called
         ceph_utils.mgr_config_set.assert_not_called()
+
+    def _cos_agent_scrape_jobs(self, rel_id):
+        """Read this unit's metrics_scrape_jobs from the cos-agent databag."""
+        unit_data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        raw = unit_data.get("config")
+        if not raw:
+            return []
+        return json.loads(raw).get("metrics_scrape_jobs", [])
+
+    @patch("microceph.is_ready")
+    @patch("ceph.enable_mgr_module")
+    @patch("utils.subprocess")
+    @patch("ceph.ceph_config_set")
+    @patch("microceph.is_mgr_enabled", return_value=True)
+    @patch.object(ceph_cos_agent, "ceph_utils")
+    def test_cos_agent_scrape_target_present_on_mgr_unit(
+        self, ceph_utils, _is_mgr, ceph_config_set, _sub, enable_mgr_module, is_ready
+    ):
+        """An mgr-hosting unit advertises the :9283 scrape target."""
+        is_ready.return_value = True
+        self.harness.set_leader()
+
+        rel_id = self.harness.add_relation("cos-agent", "grafana-agent")
+        # Adding a related unit fires relation-joined, which triggers the
+        # provider to write this unit's scrape jobs into its databag.
+        self.harness.add_relation_unit(rel_id, "grafana-agent/0")
+
+        jobs = self._cos_agent_scrape_jobs(rel_id)
+        all_targets = [
+            t
+            for job in jobs
+            for sc in job.get("static_configs", [])
+            for t in sc.get("targets", [])
+        ]
+        self.assertIn("localhost:9283", all_targets)
+
+    @patch("microceph.is_ready")
+    @patch("ceph.enable_mgr_module")
+    @patch("utils.subprocess")
+    @patch("ceph.ceph_config_set")
+    @patch("microceph.is_mgr_enabled", return_value=False)
+    @patch.object(ceph_cos_agent, "ceph_utils")
+    def test_cos_agent_no_scrape_target_on_non_mgr_unit(
+        self, ceph_utils, _is_mgr, ceph_config_set, _sub, enable_mgr_module, is_ready
+    ):
+        """A non-mgr unit advertises no metrics scrape job (no :9283, no :80 default)."""
+        is_ready.return_value = True
+        self.harness.set_leader()
+
+        rel_id = self.harness.add_relation("cos-agent", "grafana-agent")
+        # Adding a related unit fires relation-joined, which triggers the
+        # provider to write this unit's scrape jobs into its databag.
+        self.harness.add_relation_unit(rel_id, "grafana-agent/0")
+
+        jobs = self._cos_agent_scrape_jobs(rel_id)
+        all_targets = [
+            t
+            for job in jobs
+            for sc in job.get("static_configs", [])
+            for t in sc.get("targets", [])
+        ]
+        self.assertEqual(jobs, [])
+        self.assertNotIn("localhost:9283", all_targets)
+        self.assertNotIn("localhost:80", all_targets)
 
     @patch("microceph.is_ready")
     @patch("ceph.enable_mgr_module")

--- a/tests/unit/test_microceph.py
+++ b/tests/unit/test_microceph.py
@@ -17,7 +17,10 @@
 import unittest
 from unittest.mock import call, patch
 
+from requests.exceptions import HTTPError
+
 import microceph
+from microceph_client import ClusterServiceUnavailableException
 
 
 class TestMicroCeph(unittest.TestCase):
@@ -53,6 +56,64 @@ class TestMicroCeph(unittest.TestCase):
             {"service": "rgw", "location": "fake-host-2"},
         ]
         self.assertFalse(microceph.is_rgw_enabled("fake-host"))
+
+    @patch("microceph.Client")
+    def test_is_mgr_enabled_service_not_running(self, cclient):
+        """Test is_mgr_enabled when mgr is not on the host."""
+        cclient.from_socket().cluster.list_services.return_value = [
+            {"service": "rgw", "location": "fake-host"},
+            {"service": "osd", "location": "fake-host"},
+        ]
+        self.assertFalse(microceph.is_mgr_enabled("fake-host"))
+
+    @patch("microceph.Client")
+    def test_is_mgr_enabled_service_running(self, cclient):
+        """Test is_mgr_enabled when mgr runs on the host."""
+        cclient.from_socket().cluster.list_services.return_value = [
+            {"service": "mds", "location": "fake-host"},
+            {"service": "mgr", "location": "fake-host"},
+            {"service": "mon", "location": "fake-host"},
+        ]
+        self.assertTrue(microceph.is_mgr_enabled("fake-host"))
+
+    @patch("microceph.Client")
+    def test_is_mgr_enabled_service_running_and_host_mismatch(self, cclient):
+        """Test is_mgr_enabled with host mismatch."""
+        cclient.from_socket().cluster.list_services.return_value = [
+            {"service": "mgr", "location": "other-host"},
+            {"service": "rgw", "location": "fake-host"},
+        ]
+        self.assertFalse(microceph.is_mgr_enabled("fake-host"))
+
+    @patch("microceph.gethostname", return_value="fake-host")
+    @patch("microceph.is_mgr_enabled", return_value=True)
+    def test_cos_agent_is_mgr_available_cb_mgr_host(self, _is_mgr, _hostname):
+        """On an mgr host, the cb reports mgr available."""
+        self.assertTrue(microceph.cos_agent_is_mgr_available_cb())
+
+    @patch("microceph.gethostname", return_value="fake-host")
+    @patch("microceph.is_mgr_enabled", return_value=False)
+    def test_cos_agent_is_mgr_available_cb_non_mgr_host(self, _is_mgr, _hostname):
+        """On a non-mgr host, the cb reports mgr not available."""
+        self.assertFalse(microceph.cos_agent_is_mgr_available_cb())
+
+    @patch("microceph.gethostname", return_value="fake-host")
+    @patch(
+        "microceph.is_mgr_enabled",
+        side_effect=ClusterServiceUnavailableException("boom"),
+    )
+    def test_cos_agent_is_mgr_available_cb_fails_closed_on_error(self, _is_mgr, _hostname):
+        """If mgr detection fails (after retries), report mgr not available."""
+        self.assertFalse(microceph.cos_agent_is_mgr_available_cb())
+
+    @patch("microceph.gethostname", return_value="fake-host")
+    @patch(
+        "microceph.is_mgr_enabled",
+        side_effect=HTTPError("unmapped HTTP error"),
+    )
+    def test_cos_agent_is_mgr_available_cb_fails_closed_on_http_error(self, _is_mgr, _hostname):
+        """The client re-raises bare HTTPError for unmapped errors; still fail closed."""
+        self.assertFalse(microceph.cos_agent_is_mgr_available_cb())
 
     @patch("microceph.Client")
     def test_update_cluster_configs(self, cclient):

--- a/uv.lock
+++ b/uv.lock
@@ -106,7 +106,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/5a/f5/2ed2c938671e1305f
 [[package]]
 name = "charms-ceph"
 version = "0.0.1.dev1"
-source = { git = "https://github.com/canonical/ceph-charms?subdirectory=charms.ceph#a6ea066f989eefe1d77bc932e24cf988698db9a5" }
+source = { git = "https://github.com/canonical/ceph-charms?subdirectory=charms.ceph&rev=f427e7e4a1b7b3d0d2d0f3df3a4537a4b39980e2#f427e7e4a1b7b3d0d2d0f3df3a4537a4b39980e2" }
 dependencies = [
     { name = "charmhelpers" },
     { name = "pyudev" },
@@ -464,14 +464,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "charms-ceph", git = "https://github.com/canonical/ceph-charms?subdirectory=charms.ceph" },
+    { name = "charms-ceph", git = "https://github.com/canonical/ceph-charms?subdirectory=charms.ceph&rev=f427e7e4a1b7b3d0d2d0f3df3a4537a4b39980e2" },
     { name = "cosl", specifier = "==0.0.55" },
     { name = "cryptography" },
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "netifaces" },
     { name = "ops", specifier = "<3.4" },
-    { name = "ops-sunbeam", git = "https://opendev.org/openstack/sunbeam-charms?subdirectory=ops-sunbeam" },
+    { name = "ops-sunbeam", git = "https://opendev.org/openstack/sunbeam-charms?subdirectory=ops-sunbeam&rev=69ec637504645053adee8c89f8e83f24c065745d" },
     { name = "pydantic", specifier = ">=2.12,<2.13" },
     { name = "pyroute2" },
     { name = "requests", specifier = "<2.32" },
@@ -525,7 +525,7 @@ wheels = [
 [[package]]
 name = "ops-sunbeam"
 version = "0.0.1.dev1"
-source = { git = "https://opendev.org/openstack/sunbeam-charms?subdirectory=ops-sunbeam#1f744182d7f11cbc3fa4262b06da08910e9d72f3" }
+source = { git = "https://opendev.org/openstack/sunbeam-charms?subdirectory=ops-sunbeam&rev=69ec637504645053adee8c89f8e83f24c065745d#69ec637504645053adee8c89f8e83f24c065745d" }
 dependencies = [
     { name = "lightkube" },
     { name = "lightkube-models" },


### PR DESCRIPTION
## Backport

Backports #303 to `stable/squid`.

Fixes #301 (CEPH-1801).

Cherry-picked from commit 3cb0b7f73dececfd0cb323a2e7ddb36c0189fc06 (merged to `main` via #303). The cherry-pick required one trivial conflict resolution in `src/microceph.py`: the new `cos_agent_is_mgr_available_cb` function was inserted next to `remove_cluster_member`, whose signature differs on `stable/squid` (no `timeout` param) versus `main`. Resolved by adding only the new function and leaving the existing `stable/squid` signature untouched. The resulting diff against `stable/squid` is identical to PR #303's change set (lib, `charm.py`, `microceph.py`, two test files).

## Problem

When MicroCeph is related to opentelemetry-collector / COS, the charm configured otelcol to scrape the ceph-mgr metrics endpoint (`localhost:9283`) on **every** MicroCeph unit. Because `cos-agent` is a *subordinate* relation, each principal unit writes its own scrape job into its own databag, so RGW/OSD-only units (which don't run ceph-mgr) advertised a scrape target nothing was listening on, generating continuous false "target down" alerts.

## Fix

Introduce an `is_mgr_available_cb` gate on `CephCOSAgentProvider`. The principal charm decides, per unit, whether to advertise the mgr scrape config:

- **lib (`ceph_cos_agent.py`)** - new `is_mgr_available_cb` kwarg; `_custom_scrape_configs` returns `[]` on non-mgr units; `_scrape_jobs` overridden so an empty list is written **verbatim** instead of falling back to `localhost:80`. LIBPATCH 5 -> 6.
- **charm (`microceph.py`)** - `is_mgr_enabled(hostname)` mirrors `is_rgw_enabled` (cluster service-list lookup) with a short tenacity retry on transient cluster errors; `cos_agent_is_mgr_available_cb()` returns whether ceph-mgr runs locally, **failing closed** after retries exhaust.
- **`charm.py`** - wires the callback in.

## Behavior after fix

| Unit | Advertised scrape jobs |
|------|------------------------|
| mgr-hosting (mon/mgr/mds) | 1 job -> `localhost:9283` |
| storage-only (rgw/osd) | none (no `:9283`, no `:80` default) |

## Tests

8 new unit tests carried over from #303. The `is_mgr_enabled` / `cos_agent_is_mgr_available_cb` logic tests in `test_microceph.py` pass locally; the two `test_charm.py` harness tests exercise the same code paths and run in CI.

## Follow-up

The `LIBPATCH 6` bump needs `charmcraft publish-lib` at release time.

---

Backport of #303.