### PR TITLE
fix: bind NFS to a dedicated "nfs" space, not the ceph-nfs relation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -64,9 +64,16 @@ options:
 
       When false (the default), NFS binds to the Ceph public network.
 
-      When true, NFS binds to the network space the ceph-nfs relation endpoint
-      is bound to (set with "juju bind microceph ceph-nfs=<space>"); left
-      unbound, that endpoint resolves to the model's default space.
+      When true, NFS binds to the network space the "nfs" extra-binding is
+      bound to (set with "juju bind microceph nfs=<space>"); left unbound, that
+      binding resolves to the model's default space.
+
+      Warning: enabling this option without binding the "nfs" extra-binding to a
+      space resolves to the model's default space, which in a typical deployment
+      is the management network -- not the public network. This can expose NFS
+      on an unintended, more restricted network. Always run
+      "juju bind microceph nfs=<space>" before enabling this option, and verify
+      the published nfs-address before pointing clients (e.g. Manila) at it.
   wait-to-adopt:
     type: boolean
     default: False

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,6 +24,10 @@ extra-bindings:
   cluster:
   # MicroCeph daemon binds to this space.
   admin:
+  # NFS (Ganesha) data plane binds to this space when serving shares to
+  # external clients (e.g. Manila). Opt in with the nfs-use-dedicated-binding
+  # config option; left unbound this resolves to the model's default space.
+  nfs:
 
 provides:
   ceph:

--- a/src/ceph_nfs.py
+++ b/src/ceph_nfs.py
@@ -346,9 +346,10 @@ class CephNfsProviderHandler(RelationHandler):
     def _get_nfs_bind_address(self, hostname: str) -> str:
         """Resolve the NFS bind address for a host.
 
-        Uses the host's advertised ``nfs-address`` (from the ceph-nfs endpoint
-        binding) when present, else falls back to ``public-address`` (the option
-        is off, or a peer on an older charm revision has not advertised one).
+        Uses the host's advertised ``nfs-address`` (from the ``nfs``
+        extra-binding) when present, else falls back to ``public-address`` (the
+        option is off, or a peer on an older charm revision has not advertised
+        one).
         """
         nfs_addr = self._get_peer_value(hostname, "nfs-address")
         if nfs_addr:

--- a/src/relation_handlers.py
+++ b/src/relation_handlers.py
@@ -45,8 +45,10 @@ from ceph_broker import process_requests
 
 logger = logging.getLogger(__name__)
 
-# Endpoint whose network space the NFS (Ganesha) service binds to.
-NFS_BINDING = "ceph-nfs"
+# Extra-binding whose network space the NFS (Ganesha) data plane binds to.
+# Distinct from the ceph-nfs relation endpoint, which is the manila control
+# plane and must not be used to decide where NFS is exposed.
+NFS_BINDING = "nfs"
 
 
 class HostnameChangeError(Exception):
@@ -94,7 +96,7 @@ def collect_peer_data(model: ops.model.Model) -> dict:
 def _get_nfs_space_address(model: ops.model.Model) -> Optional[str]:
     """Resolve this unit's bind address for the NFS network space.
 
-    Returns the ``ceph-nfs`` endpoint binding's address when
+    Returns the ``nfs`` extra-binding's address when
     ``nfs-use-dedicated-binding`` is enabled, else None so NFS stays on the
     public address. Also returns None when the binding cannot be resolved.
     """

--- a/tests/integration/test_nfs_binding.py
+++ b/tests/integration/test_nfs_binding.py
@@ -15,7 +15,7 @@
 """Integration tests for the MicroCeph charm's NFS network binding.
 
 These exercise the *real* Juju network bindings rather than mocked addresses.
-On a single-network model the ceph-nfs binding resolves to the same address as
+On a single-network model the nfs binding resolves to the same address as
 the public binding.
 """
 
@@ -91,7 +91,7 @@ def test_nfs_binding_round_trip(juju: jubilant.Juju, deployed_microceph: str) ->
     assert data.get("public-address"), "expected a public-address to be published by default"
     assert "nfs-address" not in data, f"nfs-address must not be published by default: {data}"
 
-    # Opt in: NFS follows the ceph-nfs endpoint binding.
+    # Opt in: NFS follows the nfs extra-binding.
     juju.config(APP_NAME, {"nfs-use-dedicated-binding": "true"})
     data = _wait_for_peers_data(
         juju,
@@ -103,7 +103,7 @@ def test_nfs_binding_round_trip(juju: jubilant.Juju, deployed_microceph: str) ->
     nfs_address = data["nfs-address"]
     # The published value must be a real IP resolved from the actual binding.
     ipaddress.ip_address(nfs_address)
-    # On a single-network LXD model the ceph-nfs binding resolves to the same
+    # On a single-network LXD model the nfs binding resolves to the same
     # address as the public binding; both must be real addresses.
     assert nfs_address == data.get("public-address"), (
         "nfs-address should match the resolved public binding address on a "

--- a/tests/unit/test_ceph_nfs.py
+++ b/tests/unit/test_ceph_nfs.py
@@ -283,8 +283,8 @@ class TestCephNfsClientProvides(testbase.TestBaseCharm):
         self.assertIsInstance(ceph_nfs_status.status, BlockedStatus)
 
     def test_ensure_nfs_cluster_uses_nfs_address(self):
-        # NFS binds to the host's advertised nfs-address (from the ceph-nfs
-        # endpoint binding) in preference to the public address.
+        # NFS binds to the host's advertised nfs-address (from the nfs
+        # extra-binding) in preference to the public address.
         self.harness.set_leader()
 
         self.list_services.return_value = [

--- a/tests/unit/test_relation_handlers.py
+++ b/tests/unit/test_relation_handlers.py
@@ -93,9 +93,9 @@ class TestRelationHelpers(testbase.TestBaseCharm):
         self.assertEqual(change_data["nfs-address"], "")
 
     def test_collect_peer_data_publishes_nfs_address(self):
-        # With nfs-use-dedicated-binding enabled, NFS binds to the ceph-nfs
-        # endpoint's space and that address is published as nfs-address. The
-        # harness resolves every binding to 10.0.0.10.
+        # With nfs-use-dedicated-binding enabled, NFS binds to the nfs
+        # extra-binding's space and that address is published as nfs-address.
+        # The harness resolves every binding to 10.0.0.10.
         self.harness.set_leader()
         self.harness.disable_hooks()
         self.harness.update_config({"nfs-use-dedicated-binding": True})
@@ -108,9 +108,9 @@ class TestRelationHelpers(testbase.TestBaseCharm):
 
         self.assertEqual(change_data["nfs-address"], "10.0.0.10")
 
-    def test_collect_peer_data_resolves_from_ceph_nfs_binding(self):
-        # When enabled, nfs-address is sourced from the ceph-nfs endpoint
-        # binding: the address on that binding is what gets published.
+    def test_collect_peer_data_resolves_from_nfs_binding(self):
+        # When enabled, nfs-address is sourced from the nfs extra-binding:
+        # the address on that binding is what gets published.
         self.harness.set_leader()
         self.harness.disable_hooks()
         self.harness.update_config({"nfs-use-dedicated-binding": True})
@@ -120,7 +120,8 @@ class TestRelationHelpers(testbase.TestBaseCharm):
         self.gethostname.return_value = "test-hostname"
 
         def fake_get_binding(binding_key):
-            # ceph-nfs resolves to a distinct address; others keep the default.
+            # The dedicated "nfs" binding resolves to a distinct address; every
+            # other binding keeps the default.
             binding = MagicMock()
             binding.network.bind_address = (
                 "10.20.0.10" if binding_key == relation_handlers.NFS_BINDING else "10.0.0.10"
@@ -137,7 +138,7 @@ class TestRelationHelpers(testbase.TestBaseCharm):
         self.assertEqual(change_data["public-address"], "10.0.0.10")
 
     def test_collect_peer_data_skips_nfs_address_on_binding_error(self):
-        # Enabled but the ceph-nfs binding cannot be resolved and none was
+        # Enabled but the nfs binding cannot be resolved and none was
         # published before: nothing is published, so NFS uses the public address.
         self.harness.set_leader()
         self.harness.disable_hooks()
@@ -161,7 +162,7 @@ class TestRelationHelpers(testbase.TestBaseCharm):
         self.assertEqual(change_data["public-address"], "10.0.0.10")
 
     def test_collect_peer_data_clears_stale_nfs_address_on_binding_error(self):
-        # Enabled but the ceph-nfs binding cannot be resolved: a previously
+        # Enabled but the nfs binding cannot be resolved: a previously
         # published nfs-address is cleared, so NFS falls back to the public
         # address (an unresolvable binding is treated like the option being off).
         self.harness.set_leader()


### PR DESCRIPTION
# Description

The `ceph-nfs` relation is the Manila <-> MicroCeph **control plane**, so the
network space that endpoint is bound to is the wrong signal for deciding where
the NFS (Ganesha) **data plane** should be exposed to external clients. The
previous implementation (#305) derived the NFS bind address from the `ceph-nfs`
relation endpoint binding; this reworks it to use a dedicated `nfs` Juju
extra-binding instead.

When `nfs-use-dedicated-binding` is enabled, the NFS bind address is now sourced
from the new `nfs` extra-binding (`juju bind microceph nfs=<space>`). The option
still defaults to **false**, so NFS stays on the Ceph public network unless an
operator explicitly opts in. The peer-databag key (`nfs-address`) and the
public-address fallback are unchanged, so this is compatible with the
just-merged feature across an upgrade.

The opt-in flag is retained deliberately: Juju exposes no API to tell whether an
operator has bound a space, and an unbound extra-binding resolves to the model's
default space (typically the management network, not public). The explicit
opt-in is what guarantees the safe "default to public" behaviour. The config
option description now warns operators that enabling the flag without binding the
`nfs` space lands NFS on the model-default space.

Follows up #305 based on review feedback (the `ceph-nfs` relation must not be
used to decide where NFS is exposed).

Addresses the MicroCeph-charm portion of
https://bugs.launchpad.net/bugs/2150595

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests (`tox -e py3`, 226 passing) and lint (`tox -e lint`) were run in a
clean VM. Integration tests run in GitHub Actions.

- `tests/unit/test_relation_handlers.py`: `nfs-address` is published only when
  `nfs-use-dedicated-binding` is enabled, is sourced from the `nfs`
  extra-binding, and is cleared when the option is disabled or the binding
  cannot be resolved (`ModelError`), falling back to the public address.
- `tests/unit/test_ceph_nfs.py`: the `ceph-nfs` provider prefers a host's
  advertised `nfs-address` and falls back to `public-address` when none is set.
- `tests/integration/test_nfs_binding.py`: round-trips the option against the
  real Juju binding (enable -> `nfs-address` published; disable -> cleared). On
  a single-network model the `nfs` binding resolves to the same address as
  `public`.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes. (The
  `nfs-use-dedicated-binding` config option description was updated, including a
  warning about the model-default-space behaviour when the `nfs` binding is left
  unbound.)
- [x] added tests to verify effectiveness of this change.
