### PR TITLE
fix: advertise all ceph mons to clients regardless of leadership

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ log_cli_level = "INFO"
 markers = [
     "abort_on_fail: stop the test session immediately when the marked test fails",
     "smoke: quick integration checks",
+    "regression: heavier multi-unit regression reproductions (run on demand, not in CI)",
     "incremental: treat tests in a class as dependent and skip the rest after first failure",
     "slow: tests that take longer",
     "sunbeam: end-to-end tests that attach to a Sunbeam-provisioned Juju model",

--- a/src/ceph.py
+++ b/src/ceph.py
@@ -30,6 +30,7 @@ https://github.com/juju/charm-helpers/blob/master/charmhelpers/contrib/storage/l
 import collections
 import enum
 import functools
+import ipaddress
 import json
 import logging
 import math
@@ -37,6 +38,7 @@ import socket
 import subprocess
 from subprocess import CalledProcessError, check_call, check_output
 from typing import Dict, List, Tuple, TypeAlias
+from urllib.parse import urlsplit
 
 from tenacity import retry, stop_after_attempt, wait_fixed
 
@@ -265,6 +267,60 @@ def is_leader():
         return True
     else:
         return False
+
+
+def _addr_to_ip(addr: str) -> str:
+    """Return the canonical bare IP from a Ceph messenger address.
+
+    Handles bare IPs and ``host:port`` / ``[host]:port`` forms (with an
+    optional ``/nonce`` suffix) for both IPv4 and IPv6. Returns "" if no valid
+    IP can be parsed.
+    """
+    if not addr:
+        return ""
+    candidate = addr.split("/", 1)[0]  # drop any trailing "/nonce"
+    # A bare IP parses directly; this also covers bare IPv6, which the URL
+    # authority parser below would mishandle.
+    try:
+        return str(ipaddress.ip_address(candidate))
+    except ValueError:
+        pass
+    # Otherwise treat it as a URL authority so urlsplit peels the host off the
+    # port and strips any IPv6 brackets; then validate/normalise it.
+    try:
+        host = urlsplit("//" + candidate).hostname or ""
+        return str(ipaddress.ip_address(host))
+    except ValueError:
+        return ""
+
+
+def get_live_mon_ips() -> set:
+    """Return mon public IPs from the live monmap (``ceph mon dump``).
+
+    Used to cross-check the addresses reported by the microceph service API,
+    which is not refreshed when a mon leaves the cluster out-of-band and can
+    therefore advertise dead mons. Returns an empty set on any error so callers
+    can safely fall back to the unfiltered list.
+    """
+    cmd = ["microceph.ceph", "mon", "dump", "--format", "json"]
+    ips = set()
+    try:
+        result = json.loads(str(check_output(cmd).decode("UTF-8")))
+        for mon in result.get("mons", []):
+            ip = _addr_to_ip(mon.get("public_addr", ""))
+            if ip:
+                ips.add(ip)
+            for entry in mon.get("public_addrs", {}).get("addrvec", []):
+                ip = _addr_to_ip(entry.get("addr", ""))
+                if ip:
+                    ips.add(ip)
+    except (CalledProcessError, OSError, ValueError, AttributeError, TypeError):
+        # Command failed, microceph.ceph missing, non-JSON output, or an
+        # unexpected JSON shape (e.g. a bare ``null`` or list rather than the
+        # expected object). Honour the "empty set on any error" contract so
+        # callers fall back to the unfiltered list.
+        return set()
+    return ips
 
 
 def monitor_key_get(service, key):

--- a/src/charm.py
+++ b/src/charm.py
@@ -34,7 +34,6 @@ import ops.framework
 import ops_sunbeam.charm as sunbeam_charm
 import ops_sunbeam.guard as sunbeam_guard
 import ops_sunbeam.relation_handlers as sunbeam_rhandlers
-import requests
 from charms.ceph_mon.v0 import ceph_cos_agent
 from charms.operator_libs_linux.v2 import snap
 from ops.main import main
@@ -44,7 +43,6 @@ import ceph
 import cluster
 import maintenance
 import microceph
-import microceph_client
 import utils
 from ceph_nfs import CephNfsProviderHandler
 from ceph_rgw import CEPH_RGW_READY_RELATION, CephRgwProviderHandler
@@ -553,13 +551,10 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
     def get_ceph_info_from_configs(self, service_name, caps=None) -> dict:
         """Update ceph info from configuration."""
-        # public address should be updated once config public-network is supported
-        client = microceph_client.Client.from_socket()
-        try:
-            public_addrs = client.cluster.get_mon_addresses()
-        except requests.HTTPError:
-            logger.debug("Mon api call failed, fall back to legacy method")
-            public_addrs = microceph.get_mon_public_addresses()
+        # public address should be updated once config public-network is supported.
+        # get_mon_addresses() cross-checks the live monmap so the published list
+        # never advertises a dead mon.
+        public_addrs = utils.get_mon_addresses()
         return {
             "auth": "cephx",
             "ceph-public-address": self._lookup_system_interfaces(public_addrs),

--- a/src/relation_handlers.py
+++ b/src/relation_handlers.py
@@ -467,8 +467,13 @@ class CephClientProvides(Object):
         self.framework.observe(
             charm.on[self.relation_name].relation_changed, self._on_relation_changed
         )
-        # React to ceph peers relation departed
+        # React to ceph peers relation changes so the published mon list tracks
+        # mons being added or removed.
+        self.framework.observe(charm.on["peers"].relation_changed, self._on_ceph_peers)
         self.framework.observe(charm.on["peers"].relation_departed, self._on_ceph_peers)
+        # Periodically reconcile so a fresh deploy self-heals even if the first
+        # ceph relation event arrived before the service was ready.
+        self.framework.observe(charm.on.update_status, self._on_update_status)
 
     def _on_relation_changed(self, event):
         """Prepare relation for data from requiring side."""
@@ -479,6 +484,10 @@ class CephClientProvides(Object):
             logger.info("Not processing request as service is not yet ready")
             event.defer()
             return
+
+        # Publish mon addresses independently of OSD availability and of Ceph
+        # mon leadership: a client must learn every mon as soon as it relates.
+        self._publish_mon_data()
 
         if get_osd_count() == 0:
             logger.info("Storage not available, deferring event.")
@@ -618,19 +627,72 @@ class CephClientProvides(Object):
         for k, v in data.items():
             relation.data[self.this_unit][k] = str(v)
 
-    def _on_ceph_peers(self, _event):
-        """Handle ceph peers relation events."""
-        # Mon addrs might have changed, update the relation data
+    def _mon_addresses_to_publish(self):
+        """Return cross-checked mon addresses to publish, or None to skip.
+
+        Guards here so every caller (relation-changed, peers, update-status) is
+        protected from running before the microceph API is up or during teardown.
+        """
         if utils.is_departing(self.charm.app):
             logger.debug("Application is being removed; skipping mon address update")
-            return
-        if not self.model.unit.is_leader():
-            return
-        mon_key = "ceph-mon-public-addresses"
-        addrs = utils.get_mon_addresses()
+            return None
+        if not self.charm.ready_for_service():
+            logger.debug("Service not ready; skipping mon address update")
+            return None
+        try:
+            return utils.get_mon_addresses() or None
+        except Exception as e:
+            logger.warning("Could not fetch mon addresses: %s", e)
+            return None
 
-        for relation in self.framework.model.relations.get(self.relation_name, []):
-            relation.data[self.model.app][mon_key] = json.dumps(addrs)
+    def _publish_mon_data(self) -> None:
+        """Publish mon addresses to all relations of this provider.
+
+        Independent of Ceph mon leadership, so the full list is always
+        advertised even when the Juju leader and the Ceph mon leader are
+        different units (the cause of clients seeing a single mon host):
+
+        * every unit writes its own ``ceph-public-address`` to its unit databag
+          so the client fallback also lists all mons;
+        * the Juju leader writes the full ``ceph-mon-public-addresses`` list to
+          the application databag (the address list clients prefer).
+        """
+        relations = self.framework.model.relations.get(self.relation_name, [])
+        if not relations:
+            return
+        addrs = self._mon_addresses_to_publish()
+        if not addrs:
+            return
+
+        self_addr = self.charm._lookup_system_interfaces(addrs)
+        if not self_addr:
+            logger.debug(
+                "This unit's address is not in the current mon list %s; "
+                "clearing any ceph-public-address it previously advertised",
+                addrs,
+            )
+        is_leader = self.model.unit.is_leader()
+        for relation in relations:
+            unit_data = relation.data[self.this_unit]
+            if self_addr:
+                unit_data["ceph-public-address"] = self_addr
+            elif unit_data.get("ceph-public-address"):
+                # This unit is no longer a mon (e.g. its mon left the monmap);
+                # stop advertising the now-dead address. ops deletes on "".
+                unit_data["ceph-public-address"] = ""
+            if is_leader:
+                relation.data[self.model.app]["ceph-mon-public-addresses"] = json.dumps(addrs)
+
+    def _on_ceph_peers(self, _event):
+        """Handle ceph peers relation events.
+
+        Mon membership may have changed; refresh the published mon data.
+        """
+        self._publish_mon_data()
+
+    def _on_update_status(self, _event):
+        """Reconcile published mon data on update-status (self-healing)."""
+        self._publish_mon_data()
 
 
 class CephClientProviderHandler(RelationHandler):

--- a/src/utils.py
+++ b/src/utils.py
@@ -16,6 +16,7 @@
 
 """Utils module."""
 
+import ipaddress
 import logging
 import subprocess
 
@@ -25,6 +26,14 @@ import microceph
 from microceph_client import Client
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_ip(addr: str) -> str:
+    """Return the canonical form of a bare IP, or the input unchanged."""
+    try:
+        return str(ipaddress.ip_address(addr))
+    except ValueError:
+        return addr
 
 
 def run_cmd(cmd: list, timeout: int = 180) -> str:
@@ -90,13 +99,40 @@ def is_departing(app, context: str = "") -> bool:
 
 
 def get_mon_addresses():
-    """Get the Ceph mon addresses."""
+    """Get the Ceph mon addresses, cross-checked against the live monmap.
+
+    The microceph service API is not refreshed when a mon leaves the cluster
+    out-of-band, so it can report dead mons. Filter the reported addresses to
+    those present in the live monmap (``ceph mon dump``). Fall back to the
+    unfiltered list if the monmap is unavailable or the intersection is empty,
+    so a format mismatch can never regress to an empty list.
+    """
+    # Local import: ceph imports utils, so a module-level import would cycle.
+    import ceph
+
     client = Client.from_socket()
     try:
-        return client.cluster.get_mon_addresses()
+        addrs = client.cluster.get_mon_addresses()
     except requests.HTTPError:
+        # The /1.0/services/mon endpoint is newer than some microceph snap
+        # channels the charm can deploy; on an older snap it returns 404 (a bare
+        # HTTPError - "daemon/db not yet initialized" and a missing socket are
+        # raised as ClusterServiceUnavailableException, not caught here). Parse
+        # ceph.conf instead, which carries the mon host list on every version.
         logger.debug("Mon api call failed, fall back to legacy method")
-        return microceph.get_mon_public_addresses()
+        addrs = microceph.get_mon_public_addresses()
+
+    live = ceph.get_live_mon_ips()
+    if addrs and live:
+        filtered = [a for a in addrs if _normalize_ip(a) in live]
+        if filtered:
+            return filtered
+        logger.warning(
+            "Live monmap cross-check removed all reported mon addresses; "
+            "using the unfiltered list %s",
+            addrs,
+        )
+    return addrs
 
 
 def get_fsid():

--- a/tests/integration/test_mon_addresses.py
+++ b/tests/integration/test_mon_addresses.py
@@ -1,0 +1,357 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test: microceph must advertise ALL mons to its ceph clients.
+
+Reproduces the bug where a client (e.g. cinder-volume) ends up with a single
+``mon host``. On the provider side this shows up as:
+
+* only the Ceph mon-leader unit publishing its per-unit ``ceph-public-address``
+  (so the client fallback sees one mon), and
+* the application-level ``ceph-mon-public-addresses`` list being published only
+  when the Juju leader and the Ceph mon leader happen to be the same unit.
+"""
+
+import json
+import logging
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests import helpers
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+APP_NAME = METADATA["name"]
+CEPHCLIENT_APP = "cephclient"
+NUM_UNITS = 3
+LOOP_OSD_SPEC = "1G,3"
+TESTER_CHARM = (
+    Path(__file__).parent / "testers/cephclient/cephclient-requirer-mock.charm"
+).resolve()
+
+# How long to wait for every mon unit to advertise its address after integrate.
+PUBLISH_TIMEOUT = 360
+PUBLISH_INTERVAL = 15
+
+
+@pytest.fixture(scope="module")
+def integrated_cluster(juju_vm, microceph_charm):
+    """Deploy 3 microceph units + the ceph client tester and integrate them."""
+    juju = juju_vm
+    logger.info("Deploying %s (-n%d) on VMs", APP_NAME, NUM_UNITS)
+    juju.deploy(str(microceph_charm), APP_NAME, num_units=NUM_UNITS)
+    with helpers.fast_forward(juju):
+        helpers.wait_for_apps(juju, APP_NAME, timeout=2400)
+
+    helpers.ensure_loop_osd(juju, APP_NAME, LOOP_OSD_SPEC)
+
+    logger.info("Deploying ceph client tester %s", TESTER_CHARM)
+    juju.deploy(str(TESTER_CHARM), CEPHCLIENT_APP)
+    with helpers.fast_forward(juju):
+        helpers.wait_for_apps(juju, APP_NAME, CEPHCLIENT_APP, timeout=2400)
+
+    juju.integrate(f"{CEPHCLIENT_APP}:ceph", f"{APP_NAME}:ceph")
+    with helpers.fast_forward(juju):
+        helpers.wait_for_apps(juju, APP_NAME, CEPHCLIENT_APP, timeout=1200)
+    return juju
+
+
+def _first_json(text: str):
+    """Parse the first JSON value in *text*, ignoring surrounding noise.
+
+    ``juju ssh`` can fold the remote command's stderr into its output (e.g.
+    ``microceph.ceph mon dump`` prints ``dumped monmap epoch N``, and ssh may
+    append ``Connection to <ip> closed.``), which would otherwise make
+    ``json.loads`` raise "Extra data". Skip to the first ``{``/``[`` and decode
+    just that value.
+    """
+    start = min((i for i in (text.find("{"), text.find("[")) if i >= 0), default=-1)
+    if start < 0:
+        raise ValueError(f"no JSON found in output: {text!r}")
+    obj, _ = json.JSONDecoder().raw_decode(text[start:])
+    return obj
+
+
+def _provider_units(juju) -> list:
+    """Return the sorted microceph unit names."""
+    return sorted(juju.status().apps[APP_NAME].units)
+
+
+def _mon_count(juju) -> int:
+    """Return how many monitors the live cluster reports."""
+    unit = helpers.first_unit_name(juju.status(), APP_NAME)
+    out = juju.ssh(unit, "sudo", "microceph.ceph", "mon", "dump", "--format", "json")
+    return len(_first_json(out).get("mons", []))
+
+
+def _units_publishing_address(juju, client_unit) -> dict:
+    """Map each microceph unit to the ceph-public-address it advertises.
+
+    Read from the client's perspective: provider units appear as related-units
+    in the client's ceph relation data.
+    """
+    model = juju.status().model.name
+    published = {}
+    for unit in _provider_units(juju):
+        data = helpers.get_relation_data(client_unit, "ceph", unit, model)
+        published[unit] = data.get("ceph-public-address")
+    return published
+
+
+def _juju_leader(juju) -> str:
+    """Return the microceph Juju leader unit name (falls back to unit 0)."""
+    model = juju.status().model.name
+    for unit in _provider_units(juju):
+        if helpers.get_unit_info(unit, model).get("leader"):
+            return unit
+    return f"{APP_NAME}/0"
+
+
+def _app_mon_addresses(juju) -> list:
+    """Return microceph's app-level ceph-mon-public-addresses list (or []).
+
+    Read via ``relation-get --app`` from the leader, the authoritative view of
+    the provider's own application databag. The leader is resolved from
+    ``juju status`` (controller-side) so it stays correct even while another
+    unit's agent is intentionally stopped.
+    """
+    model = juju.status().model.name
+    leader = _leader_of(_microceph_units(model)) or f"{APP_NAME}/0"
+    rel = subprocess.run(
+        ["juju", "exec", "-m", model, "--unit", leader, "--", "relation-ids", "ceph"],
+        capture_output=True,
+        text=True,
+    )
+    if rel.returncode != 0:
+        logger.warning("relation-ids ceph failed: %s", rel.stderr.strip())
+        return []
+    relids = rel.stdout.split()
+    if not relids:
+        return []
+    got = subprocess.run(
+        # fmt: off
+        [
+            "juju", "exec", "-m", model, "--unit", leader, "--",
+            "relation-get", "--app", "-r", relids[0], "-", leader,
+        ],
+        # fmt: on
+        capture_output=True,
+        text=True,
+    )
+    if got.returncode != 0:
+        logger.warning("relation-get --app failed: %s", got.stderr.strip())
+        return []
+    data = yaml.safe_load(got.stdout) or {}
+    raw = data.get("ceph-mon-public-addresses")
+    return json.loads(raw) if raw else []
+
+
+def _log_leadership(juju) -> None:
+    """Log which unit is the Juju leader vs the Ceph mon leader (diagnostic).
+
+    The bug only manifests when these differ; logging it makes the run's
+    conditions visible.
+    """
+    juju_leader = _juju_leader(juju)
+    mon_leader = None
+    for unit in _provider_units(juju):
+        try:
+            out = juju.ssh(
+                unit,
+                "sudo",
+                "microceph.ceph",
+                "tell",
+                "mon.$(hostname)",
+                "mon_status",
+                "--format",
+                "json",
+            )
+            if _first_json(out).get("state") == "leader":
+                mon_leader = unit
+        except Exception as exc:  # diagnostic only; never fail the test here
+            logger.debug("mon_status probe failed on %s: %s", unit, exc)
+    logger.info(
+        "Juju leader=%s  Ceph mon leader=%s  coincide=%s",
+        juju_leader,
+        mon_leader,
+        juju_leader == mon_leader,
+    )
+
+
+def _microceph_units(model: str) -> dict:
+    """Return the microceph units block from ``juju status`` JSON.
+
+    Read via the controller, so it stays usable while a unit agent is
+    intentionally stopped.
+    """
+    out = subprocess.run(
+        ["juju", "status", "-m", model, APP_NAME, "--format", "json"],
+        capture_output=True,
+        text=True,
+    ).stdout
+    apps = json.loads(out).get("applications", {}) if out else {}
+    return (apps.get(APP_NAME) or {}).get("units", {}) or {}
+
+
+def _leader_of(units: dict) -> str:
+    """Return the leader unit name from a units block, or '' if none."""
+    for name, unit in units.items():
+        if unit.get("leader"):
+            return name
+    return ""
+
+
+@pytest.mark.smoke
+def test_all_mons_advertised_to_client(integrated_cluster):
+    """Every mon unit must advertise its address; clients must see all mons."""
+    juju = integrated_cluster
+    client_unit = helpers.first_unit_name(juju.status(), CEPHCLIENT_APP)
+
+    expected = _mon_count(juju)
+    # All deployed units should be mons; if not, fail fast with a clear message
+    # rather than silently breaking the per-unit discriminator below.
+    assert (
+        expected == NUM_UNITS
+    ), f"expected {NUM_UNITS} mons (one per unit), monmap reports {expected}"
+    _log_leadership(juju)
+
+    # Poll until every mon unit advertises its own ceph-public-address AND the
+    # app-level list enumerates every mon. With the bug only the mon-leader unit
+    # advertises its address (count stays 1); once fixed all mon units do.
+    published, app_addrs = {}, []
+    deadline = time.time() + PUBLISH_TIMEOUT
+    with helpers.fast_forward(juju):
+        while time.time() < deadline:
+            published = _units_publishing_address(juju, client_unit)
+            app_addrs = _app_mon_addresses(juju)
+            advertised = {u: a for u, a in published.items() if a}
+            if len(advertised) == expected and len(app_addrs) == expected:
+                break
+            logger.info(
+                "waiting: per-unit=%d/%d app=%d/%d  per-unit=%s",
+                len(advertised),
+                expected,
+                len(app_addrs),
+                expected,
+                published,
+            )
+            time.sleep(PUBLISH_INTERVAL)
+
+    advertised = {u: a for u, a in published.items() if a}
+    assert len(advertised) == expected, (
+        f"expected all {expected} mon units to advertise ceph-public-address, "
+        f"got {len(advertised)}: {published}"
+    )
+    # Addresses must be distinct (each unit its own mon address).
+    assert len(set(advertised.values())) == expected, f"duplicate addresses: {advertised}"
+    # The authoritative app-level list must also enumerate every mon.
+    assert (
+        len(app_addrs) == expected
+    ), f"app ceph-mon-public-addresses should list {expected} mons, got {app_addrs}"
+
+
+@pytest.mark.regression
+def test_app_list_published_when_leaders_differ(integrated_cluster):
+    """Force Juju leader != Ceph mon leader and confirm the app list survives.
+
+    This is the exact bug-triggering condition: pre-fix, when these two leaders
+    were different units, the full mon list was never published on a fresh
+    deploy. We move Juju leadership off the mon-leader unit by bouncing that
+    unit's machine agent (its ceph mon stays up, so it remains the Ceph mon
+    leader), clear the published list, and assert the new non-mon-leader Juju
+    leader republishes the full list.
+    """
+    juju = integrated_cluster
+    model = juju.status().model.name
+    expected = _mon_count(juju)
+
+    units = _microceph_units(model)
+    old_leader = _leader_of(units)
+    assert old_leader, "no Juju leader found"
+    agent = f"jujud-machine-{units[old_leader]['machine']}"
+
+    # Bounce the leader's agent so leadership moves to a peon unit. Its ceph mon
+    # is untouched, so old_leader stays the Ceph mon leader. Keep the agent
+    # stopped through the entire check so old_leader cannot reclaim Juju
+    # leadership mid-test (which would silently restore J == M and let the test
+    # pass for the wrong reason). All operations below target the new leader
+    # (agent up) and the controller, so they work while old_leader is down.
+    juju.ssh(old_leader, "sudo", "systemctl", "stop", agent)
+    try:
+        new_leader = ""
+        deadline = time.time() + 300
+        while time.time() < deadline:
+            new_leader = _leader_of(_microceph_units(model))
+            if new_leader and new_leader != old_leader:
+                break
+            new_leader = ""
+            time.sleep(10)
+        assert new_leader, f"Juju leadership did not move off {old_leader}"
+        logger.info(
+            "Juju leader moved %s -> %s; Ceph mon leader stays on %s",
+            old_leader,
+            new_leader,
+            old_leader,
+        )
+
+        with helpers.fast_forward(juju):
+            # Clear the published app list, then confirm the J!=M leader rewrites it.
+            relids = subprocess.run(
+                ["juju", "exec", "-m", model, "--unit", new_leader, "--", "relation-ids", "ceph"],
+                capture_output=True,
+                text=True,
+            ).stdout.split()
+            assert relids, f"no ceph relation-id visible on {new_leader}"
+            subprocess.run(
+                # fmt: off
+                [
+                    "juju", "exec", "-m", model, "--unit", new_leader, "--",
+                    "relation-set", "--app", "-r", relids[0], "ceph-mon-public-addresses=",
+                ],
+                # fmt: on
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            app_addrs = []
+            deadline = time.time() + 240
+            while time.time() < deadline:
+                app_addrs = _app_mon_addresses(juju)
+                if len(app_addrs) == expected:
+                    break
+                logger.info(
+                    "waiting for republish by %s: app=%d/%d", new_leader, len(app_addrs), expected
+                )
+                time.sleep(15)
+
+        assert len(app_addrs) == expected, (
+            f"non-mon-leader Juju leader {new_leader} did not republish the full mon "
+            f"list; got {app_addrs}"
+        )
+    finally:
+        # Always bring the bounced agent back, even on assertion failure, and
+        # never let a restart hiccup mask the real test result.
+        for _ in range(5):
+            try:
+                juju.ssh(old_leader, "sudo", "systemctl", "start", agent)
+                break
+            except Exception as exc:  # noqa: BLE001 - best-effort cleanup
+                logger.warning("retrying agent restart on %s: %s", old_leader, exc)
+                time.sleep(5)

--- a/tests/unit/test_ceph.py
+++ b/tests/unit/test_ceph.py
@@ -80,3 +80,98 @@ class TestCeph(unittest.TestCase):
 
         run_cmd.assert_called_once_with(["microceph.ceph", "fs", "volume", "ls"])
         self.assertEqual(fs_volumes, [volume])
+
+    @patch("ceph.check_output")
+    def test_get_live_mon_ips(self, check_output):
+        """get_live_mon_ips parses bare IPs out of the live monmap."""
+        dump = {
+            "mons": [
+                {
+                    "name": "node1",
+                    "public_addr": "10.0.0.1:6789/0",
+                    "public_addrs": {
+                        "addrvec": [
+                            {"type": "v2", "addr": "10.0.0.1:3300", "nonce": 0},
+                            {"type": "v1", "addr": "10.0.0.1:6789", "nonce": 0},
+                        ]
+                    },
+                },
+                {
+                    "name": "node2",
+                    "public_addr": "10.0.0.2:6789/0",
+                    "public_addrs": {
+                        "addrvec": [{"type": "v2", "addr": "10.0.0.2:3300", "nonce": 0}]
+                    },
+                },
+            ],
+            "quorum": [0, 1],
+        }
+        check_output.return_value = json.dumps(dump).encode("UTF-8")
+
+        self.assertEqual(ceph.get_live_mon_ips(), {"10.0.0.1", "10.0.0.2"})
+        check_output.assert_called_once_with(["microceph.ceph", "mon", "dump", "--format", "json"])
+
+    @patch("ceph.check_output")
+    def test_get_live_mon_ips_handles_failure(self, check_output):
+        """A failed mon dump yields an empty set so callers fall back safely."""
+        from subprocess import CalledProcessError
+
+        check_output.side_effect = CalledProcessError(1, "cmd")
+        self.assertEqual(ceph.get_live_mon_ips(), set())
+
+    @patch("ceph.check_output")
+    def test_get_live_mon_ips_ipv6(self, check_output):
+        """Bracketed IPv6 messenger addresses are reduced to the bare IP."""
+        dump = {
+            "mons": [
+                {
+                    "name": "node1",
+                    "public_addr": "[fd00::1]:6789/0",
+                    "public_addrs": {
+                        "addrvec": [
+                            {"type": "v2", "addr": "[fd00::1]:3300", "nonce": 0},
+                            {"type": "v1", "addr": "[fd00::1]:6789", "nonce": 0},
+                        ]
+                    },
+                },
+                {
+                    "name": "node2",
+                    "public_addr": "[fd00::2]:6789/0",
+                    "public_addrs": {
+                        "addrvec": [{"type": "v2", "addr": "[fd00::2]:3300", "nonce": 0}]
+                    },
+                },
+            ],
+        }
+        check_output.return_value = json.dumps(dump).encode("UTF-8")
+
+        self.assertEqual(ceph.get_live_mon_ips(), {"fd00::1", "fd00::2"})
+
+    @patch("ceph.check_output")
+    def test_get_live_mon_ips_non_json(self, check_output):
+        """A non-JSON mon dump (e.g. a warning prefix) yields an empty set."""
+        check_output.return_value = b"WARNING: noise\nnot json"
+        self.assertEqual(ceph.get_live_mon_ips(), set())
+
+    @patch("ceph.check_output")
+    def test_get_live_mon_ips_non_dict_json(self, check_output):
+        """Valid but non-object JSON (e.g. `null`) yields an empty set, not a crash."""
+        check_output.return_value = b"null"
+        self.assertEqual(ceph.get_live_mon_ips(), set())
+
+    def test_addr_to_ip(self):
+        """_addr_to_ip parses all messenger forms and canonicalises the result."""
+        cases = {
+            "10.0.0.1:6789/0": "10.0.0.1",
+            "10.0.0.1:3300": "10.0.0.1",
+            "10.0.0.1": "10.0.0.1",
+            "[fd00::1]:6789/0": "fd00::1",
+            "[fd00::1]:3300": "fd00::1",
+            "fd00::1": "fd00::1",
+            "fd00:0:0:0:0:0:0:1": "fd00::1",  # non-canonical IPv6 -> canonical
+            "": "",
+            "garbage": "",
+            "[bad::v6": "",
+        }
+        for addr, expected in cases.items():
+            self.assertEqual(ceph._addr_to_ip(addr), expected, addr)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -974,7 +974,7 @@ class TestCharm(testbase.TestBaseCharm):
         action_event.set_results.assert_called_with(expected_endpoints)
         action_event.fail.assert_not_called()
 
-    @patch("charm.microceph_client.Client")
+    @patch("maintenance.microceph_client.Client")
     def test_enter_maintenance_action_success(self, cclient):
         cclient.from_socket().cluster.enter_maintenance_mode.return_value = {
             "metadata": [
@@ -1021,7 +1021,7 @@ class TestCharm(testbase.TestBaseCharm):
         )
         action_event.fail.assert_not_called()
 
-    @patch("charm.microceph_client.Client")
+    @patch("maintenance.microceph_client.Client")
     def test_enter_maintenance_action_failure(self, cclient):
         mock_enter = cclient.from_socket().cluster.enter_maintenance_mode
         mock_enter.side_effect = MaintenanceOperationFailedException(
@@ -1072,7 +1072,7 @@ class TestCharm(testbase.TestBaseCharm):
         )
         action_event.fail.assert_called()
 
-    @patch("charm.microceph_client.Client")
+    @patch("maintenance.microceph_client.Client")
     def test_enter_maintenance_action_error(self, cclient):
         cclient.from_socket().cluster.enter_maintenance_mode.side_effect = Exception("some errors")
         action_event = MagicMock()
@@ -1091,7 +1091,7 @@ class TestCharm(testbase.TestBaseCharm):
         )
         action_event.fail.assert_called()
 
-    @patch("charm.microceph_client.Client")
+    @patch("maintenance.microceph_client.Client")
     def test_enter_maintenance_action_mutually_exclusive(self, cclient):
         action_event = MagicMock()
         action_event.params = {"check-only": True, "ignore-check": True}
@@ -1106,7 +1106,7 @@ class TestCharm(testbase.TestBaseCharm):
         )
         action_event.fail.assert_called()
 
-    @patch("charm.microceph_client.Client")
+    @patch("maintenance.microceph_client.Client")
     def test_exit_maintenance_action_success(self, cclient):
         cclient.from_socket().cluster.exit_maintenance_mode.return_value = {
             "metadata": [
@@ -1146,7 +1146,7 @@ class TestCharm(testbase.TestBaseCharm):
         )
         action_event.fail.assert_not_called()
 
-    @patch("charm.microceph_client.Client")
+    @patch("maintenance.microceph_client.Client")
     def test_exit_maintenance_action_failure(self, cclient):
         mock_exit = cclient.from_socket().cluster.exit_maintenance_mode
         mock_exit.side_effect = MaintenanceOperationFailedException(
@@ -1190,7 +1190,7 @@ class TestCharm(testbase.TestBaseCharm):
         )
         action_event.fail.assert_called()
 
-    @patch("charm.microceph_client.Client")
+    @patch("maintenance.microceph_client.Client")
     def test_exit_maintenance_action_error(self, cclient):
         cclient.from_socket().cluster.exit_maintenance_mode.side_effect = Exception("some errors")
         action_event = MagicMock()
@@ -1202,7 +1202,7 @@ class TestCharm(testbase.TestBaseCharm):
         )
         action_event.fail.assert_called()
 
-    @patch("charm.microceph_client.Client")
+    @patch("maintenance.microceph_client.Client")
     def test_exit_maintenance_action_mutually_exclusive(self, cclient):
         action_event = MagicMock()
         action_event.params = {"check-only": True, "ignore-check": True}

--- a/tests/unit/test_relation_handlers.py
+++ b/tests/unit/test_relation_handlers.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import unittest
+from unittest.mock import patch
 
 import ops_sunbeam.test_utils as test_utils
 from unit import testbase
@@ -61,6 +63,244 @@ class TestRelationHelpers(testbase.TestBaseCharm):
         # assert that collect_peer_data raises an exception
         with self.assertRaises(relation_handlers.HostnameChangeError):
             relation_handlers.collect_peer_data(self.harness.model)
+
+
+class TestCephClientProvides(testbase.TestBaseCharm):
+    """Regression tests for mon-address publishing to ceph clients.
+
+    Reproduces the bug where a client (e.g. cinder-volume) receives only a
+    single mon host. The microceph charm must publish the full mon list and
+    every unit's own address independently of Ceph mon leadership, otherwise
+    clients only see the one unit that is both the Juju leader and the Ceph
+    mon leader.
+    """
+
+    PATCHES: list = []
+
+    # The full set of mons the cluster reports. The unit under test owns the
+    # second address (see the _lookup_system_interfaces mock below).
+    MON_ADDRS = ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
+    SELF_ADDR = "10.0.0.2"
+
+    def setUp(self):
+        """Setup MicroCeph Charm tests."""
+        super().setUp(relation_handlers, self.PATCHES)
+        with open("config.yaml", "r") as f:
+            config_data = f.read()
+        with open("metadata.yaml", "r") as f:
+            metadata = f.read()
+        self.harness = test_utils.get_harness(
+            testbase._MicroCephCharm,
+            container_calls=self.container_calls,
+            charm_config=config_data,
+            charm_metadata=metadata,
+        )
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+        # Service is up and has OSDs so _on_relation_changed proceeds.
+        ready = patch.object(self.harness.charm, "ready_for_service", return_value=True)
+        ready.start()
+        self.addCleanup(ready.stop)
+
+        # This unit's own public address resolved from the mon list.
+        lookup = patch.object(
+            self.harness.charm, "_lookup_system_interfaces", return_value=self.SELF_ADDR
+        )
+        lookup.start()
+        self.addCleanup(lookup.stop)
+
+        patch_list = [
+            ("get_osd_count", "relation_handlers.get_osd_count"),
+            ("is_ceph_mon_leader", "relation_handlers.is_ceph_mon_leader"),
+            ("get_mon_addresses", "utils.get_mon_addresses"),
+        ]
+        for attr_name, thing in patch_list:
+            patcher = patch(thing)
+            mock_obj = patcher.start()
+            setattr(self, attr_name, mock_obj)
+            self.addCleanup(patcher.stop)
+
+        self.get_osd_count.return_value = 3
+        # The crux of the bug: this unit is NOT the Ceph mon leader.
+        self.is_ceph_mon_leader.return_value = False
+        self.get_mon_addresses.return_value = list(self.MON_ADDRS)
+
+    def _add_ceph_client_relation(self, app="cinder-volume"):
+        broker_req = json.dumps({"request-id": "req-1", "ops": []})
+        return self.harness.add_relation("ceph", app, unit_data={"broker_req": broker_req})
+
+    def test_publishes_full_mon_list_when_not_mon_leader(self):
+        """Fix A: the Juju leader publishes the full mon list to app data.
+
+        This must happen even though the unit is not the Ceph mon leader.
+        """
+        self.harness.set_leader(True)
+        rel_id = self._add_ceph_client_relation()
+
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertIn("ceph-mon-public-addresses", app_data)
+        self.assertEqual(json.loads(app_data["ceph-mon-public-addresses"]), self.MON_ADDRS)
+
+    def test_unit_publishes_own_address_when_not_mon_leader(self):
+        """Fix B: every unit advertises its own ceph-public-address.
+
+        Mirrors classic ceph-mon, so the client fallback also lists all mons.
+        """
+        self.harness.set_leader(True)
+        rel_id = self._add_ceph_client_relation()
+
+        unit_data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        self.assertEqual(unit_data.get("ceph-public-address"), self.SELF_ADDR)
+
+    def test_non_juju_leader_publishes_unit_addr_but_not_app_list(self):
+        """A non-Juju-leader publishes its own address but never the app list.
+
+        Only the Juju leader may write app data; a non-leader writing the app
+        databag would raise. It still publishes its own per-unit address.
+        """
+        self.harness.set_leader(False)
+        rel_id = self._add_ceph_client_relation()
+
+        unit_data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        self.assertEqual(unit_data.get("ceph-public-address"), self.SELF_ADDR)
+
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertNotIn("ceph-mon-public-addresses", app_data)
+
+    def test_mon_leader_without_juju_leadership_still_correct(self):
+        """The other half of the Juju-leader != Ceph-mon-leader scenario.
+
+        Here this unit IS the Ceph mon leader but is NOT the Juju leader. It
+        must process the broker (deliver key/auth) and advertise its own
+        address, but it must NOT own the app-level list - only the Juju leader
+        writes that. Together with test_publishes_full_mon_list_when_not_mon_leader
+        (the Juju-leader-but-not-mon-leader unit), this pins the full J != M case.
+        """
+        self.harness.set_leader(False)
+        self.is_ceph_mon_leader.return_value = True
+        with patch("relation_handlers.process_requests", return_value={"exit-code": 0}):
+            with patch("ceph.get_named_key", return_value="a-key"):
+                rel_id = self._add_ceph_client_relation()
+
+        unit_data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        # Advertises its own monitor address (Fix B) and delivers the credentials.
+        self.assertEqual(unit_data.get("ceph-public-address"), self.SELF_ADDR)
+        self.assertEqual(unit_data.get("key"), "a-key")
+        self.assertEqual(unit_data.get("auth"), "cephx")
+        # But it does NOT own the app-level list - that is the Juju leader's job.
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertNotIn("ceph-mon-public-addresses", app_data)
+
+    def test_non_mon_unit_does_not_advertise_an_address(self):
+        """A unit with no mon must not advertise a ceph-public-address.
+
+        On a cluster larger than the mon count some units are OSD/mgr-only; their
+        own IP is not in the mon list, so _lookup_system_interfaces returns "" and
+        nothing is written. The Juju leader still publishes the full app list even
+        when it is itself a non-mon unit.
+        """
+        self.harness.set_leader(True)
+        # This unit's IP is not one of the cluster mon addresses.
+        self.harness.charm._lookup_system_interfaces.return_value = ""
+
+        rel_id = self._add_ceph_client_relation()
+
+        unit_data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        self.assertNotIn("ceph-public-address", unit_data)
+        # The full mon list is still published by the (non-mon) Juju leader.
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertEqual(json.loads(app_data["ceph-mon-public-addresses"]), self.MON_ADDRS)
+
+    def test_update_status_republishes(self):
+        """_on_update_status refreshes the mon data (self-healing path)."""
+        self.harness.set_leader(True)
+        rel_id = self._add_ceph_client_relation()
+        # Drop what relation-changed published, then prove update-status restores it.
+        self.harness.update_relation_data(
+            rel_id, self.harness.charm.app.name, {"ceph-mon-public-addresses": ""}
+        )
+
+        # Fire the real event so the new observer registration is exercised; the
+        # charm-level update-status handler is covered elsewhere, so silence it.
+        with patch.object(self.harness.charm, "_on_update_status"):
+            self.harness.charm.on.update_status.emit()
+
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertEqual(json.loads(app_data["ceph-mon-public-addresses"]), self.MON_ADDRS)
+
+    def test_peers_change_republishes(self):
+        """A peers relation-changed event refreshes the published mon data."""
+        self.harness.set_leader(True)
+        rel_id = self._add_ceph_client_relation()
+        self.harness.update_relation_data(
+            rel_id, self.harness.charm.app.name, {"ceph-mon-public-addresses": ""}
+        )
+
+        # Fire a real peers relation-changed (a peer unit's data changes);
+        # silence the cluster peer handler so only the ceph provider observer runs.
+        peer_rel_id = self.harness.add_relation("peers", self.harness.charm.app.name)
+        with patch.object(self.harness.charm.peers.interface, "on_changed"):
+            self.harness.add_relation_unit(peer_rel_id, "microceph/1")
+            self.harness.update_relation_data(
+                peer_rel_id, "microceph/1", {"public-address": "10.0.0.3"}
+            )
+
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertEqual(json.loads(app_data["ceph-mon-public-addresses"]), self.MON_ADDRS)
+
+    def test_stale_address_cleared_when_unit_leaves_mon_list(self):
+        """A unit must stop advertising its address once it leaves the mon list.
+
+        e.g. its mon is removed from the monmap, or Fix C's cross-check drops it.
+        """
+        self.harness.set_leader(True)
+        rel_id = self._add_ceph_client_relation()
+        unit_data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        self.assertEqual(unit_data.get("ceph-public-address"), self.SELF_ADDR)
+
+        # This unit's IP is no longer a mon address; a refresh must clear it.
+        self.harness.charm._lookup_system_interfaces.return_value = ""
+        self.harness.update_relation_data(rel_id, "cinder-volume/0", {"broker_req": "{}"})
+
+        unit_data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        self.assertNotIn("ceph-public-address", unit_data)
+
+    def test_publish_skipped_while_app_departing(self):
+        """No mon data is published while the whole application is being removed."""
+        self.harness.set_leader(True)
+        self.harness.set_planned_units(0)  # planned_units()==0 -> is_departing True
+
+        rel_id = self._add_ceph_client_relation()
+
+        unit_data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        self.assertNotIn("ceph-public-address", unit_data)
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertNotIn("ceph-mon-public-addresses", app_data)
+
+    def test_publish_swallows_fetch_errors(self):
+        """A failure to fetch mon addresses must not crash the hook."""
+        self.harness.set_leader(True)
+        self.get_mon_addresses.side_effect = ConnectionError("socket gone")
+
+        rel_id = self._add_ceph_client_relation()
+
+        unit_data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        self.assertNotIn("ceph-public-address", unit_data)
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertNotIn("ceph-mon-public-addresses", app_data)
+
+    def test_publishes_to_radosgw_relation(self):
+        """The shared publish logic also serves the radosgw provider relation."""
+        self.harness.set_leader(True)
+        rel_id = self.harness.add_relation(
+            "radosgw", "ceph-radosgw", unit_data={"key_name": "rgw"}
+        )
+
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertEqual(json.loads(app_data["ceph-mon-public-addresses"]), self.MON_ADDRS)
+        unit_data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        self.assertEqual(unit_data.get("ceph-public-address"), self.SELF_ADDR)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -18,6 +18,8 @@ import subprocess
 import unittest
 from unittest.mock import MagicMock, patch
 
+import requests
+
 import utils
 
 
@@ -56,3 +58,97 @@ class TestUtils(unittest.TestCase):
         with self.assertRaises(subprocess.CalledProcessError) as ctx:
             utils.snap_has_connection("microceph.daemon", "dm-crypt")
         self.assertEqual(ctx.exception.returncode, 2)
+
+
+class TestGetMonAddresses(unittest.TestCase):
+    """get_mon_addresses must cross-check the live monmap to drop dead mons.
+
+    The microceph service API is not refreshed when a mon leaves the cluster
+    out-of-band, so it can advertise dead mons. The published list is
+    cross-checked against the live monmap (ceph mon dump).
+    """
+
+    @patch("ceph.get_live_mon_ips")
+    @patch("utils.Client")
+    def test_filters_dead_mons(self, client, get_live):
+        # The service API still reports a mon that has left the cluster.
+        client.from_socket.return_value.cluster.get_mon_addresses.return_value = [
+            "10.0.0.1",
+            "10.0.0.2",
+            "10.0.0.3",
+        ]
+        get_live.return_value = {"10.0.0.1", "10.0.0.2"}  # .3 is dead
+
+        self.assertEqual(utils.get_mon_addresses(), ["10.0.0.1", "10.0.0.2"])
+
+    @patch("ceph.get_live_mon_ips")
+    @patch("utils.Client")
+    def test_no_live_monmap_returns_full_list(self, client, get_live):
+        # If the live monmap is unavailable, never drop addresses.
+        addrs = ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
+        client.from_socket.return_value.cluster.get_mon_addresses.return_value = addrs
+        get_live.return_value = set()
+
+        self.assertEqual(utils.get_mon_addresses(), addrs)
+
+    @patch("ceph.get_live_mon_ips")
+    @patch("utils.Client")
+    def test_empty_intersection_falls_back_to_full_list(self, client, get_live):
+        # A format mismatch (no overlap) must not regress to an empty list.
+        addrs = ["10.0.0.1", "10.0.0.2"]
+        client.from_socket.return_value.cluster.get_mon_addresses.return_value = addrs
+        get_live.return_value = {"9.9.9.9"}
+
+        self.assertEqual(utils.get_mon_addresses(), addrs)
+
+    @patch("ceph.get_live_mon_ips")
+    @patch("utils.microceph.get_mon_public_addresses")
+    @patch("utils.Client")
+    def test_api_failure_uses_legacy_then_filters(self, client, legacy, get_live):
+        # API down -> legacy ceph.conf parse, still cross-checked against monmap.
+        client.from_socket.return_value.cluster.get_mon_addresses.side_effect = (
+            requests.HTTPError()
+        )
+        legacy.return_value = ["10.0.0.1", "10.0.0.2"]
+        get_live.return_value = {"10.0.0.1"}
+
+        self.assertEqual(utils.get_mon_addresses(), ["10.0.0.1"])
+
+    @patch("ceph.get_live_mon_ips")
+    @patch("utils.Client")
+    def test_empty_api_list_does_not_warn_or_crash(self, client, get_live):
+        # API returns nothing yet; with a live monmap the result is still [] and
+        # the "removed all addresses" warning must not fire (nothing was removed).
+        client.from_socket.return_value.cluster.get_mon_addresses.return_value = []
+        get_live.return_value = {"10.0.0.1"}
+
+        with self.assertNoLogs(utils.logger, level="WARNING"):
+            self.assertEqual(utils.get_mon_addresses(), [])
+
+    @patch("ceph.get_live_mon_ips")
+    @patch("utils.Client")
+    def test_ipv6_representation_mismatch_still_matches(self, client, get_live):
+        # The API reports a non-canonical IPv6; the monmap is canonical. The
+        # cross-check compares by value, so both addresses are kept (and the
+        # original API strings are returned unchanged).
+        addrs = ["fd00:0:0:0:0:0:0:1", "fd00::2"]
+        client.from_socket.return_value.cluster.get_mon_addresses.return_value = addrs
+        get_live.return_value = {"fd00::1", "fd00::2"}
+
+        self.assertEqual(utils.get_mon_addresses(), addrs)
+
+
+class TestNormalizeIp(unittest.TestCase):
+    """_normalize_ip canonicalises bare IPs and leaves anything else untouched."""
+
+    def test_normalize_ip(self):
+        cases = {
+            "10.0.0.1": "10.0.0.1",
+            "fd00::1": "fd00::1",
+            "fd00:0:0:0:0:0:0:1": "fd00::1",  # non-canonical IPv6 -> canonical
+            "10.0.0.1:6789": "10.0.0.1:6789",  # has a port: not a bare IP, unchanged
+            "not-an-ip": "not-an-ip",
+            "": "",
+        }
+        for addr, expected in cases.items():
+            self.assertEqual(utils._normalize_ip(addr), expected, addr)


### PR DESCRIPTION
This is a backport of https://github.com/canonical/charm-microceph/pull/316

Clients integrated with microceph (e.g. cinder-volume) could be configured with only one monitor in `mon host`, so shutting down that one node stalled every volume operation.

Mon addresses were only published from the broker-response path, which runs solely on the Ceph mon leader and gates the application-databag write on also being the Juju leader. Those two are independent elections, so the full `ceph-mon-public-addresses` list was published only when one unit happened to hold both roles, and the per-unit `ceph-public-address` was written by just the mon-leader unit.

Decouple address advertising from the broker:

- A new `_publish_mon_data` helper runs on ceph relation-changed, peer relation changes and update-status, independent of mon leadership. Every unit writes its own `ceph-public-address` (only when its IP is a real mon address, so non-mon units stay silent, and clearing a stale value when its IP leaves the mon list), and the Juju leader always writes the full `ceph-mon-public-addresses` list.
- `utils.get_mon_addresses` cross-checks the reported addresses against the live monmap (`ceph mon dump`) so dead mons are never advertised, with a safe fallback to the unfiltered list. Address parsing and comparison use `urllib.parse.urlsplit` + `ipaddress` for robust IPv4/IPv6 handling, and `get_live_mon_ips` returns an empty set on any error, including an unexpected JSON shape.
- `get_ceph_info_from_configs` now sources addresses through that same cross-checked helper.

Removing the inlined service-API call drops the now-unused microceph_client and requests imports from charm.py; the maintenance unit tests are repointed to patch `maintenance.microceph_client` where the dependency is actually used.

test: cover all-mons publishing, monmap cross-check and split leadership

Unit tests:

- relation_handlers: a Juju-leader-but-not-mon-leader unit publishes the full app list; a mon-leader-but-not-Juju-leader unit delivers key/auth and its own address but not the app list; a non-mon unit advertises nothing and a unit that leaves the mon list has its stale address cleared; the update-status and peers relation-changed events (fired through the harness, so the new observer wiring is exercised); the radosgw path; the is_departing guard; and the fetch-error guard.
- utils/ceph: the live-monmap cross-check filters dead mons with a safe fallback, IPv4/IPv6 messenger-address parsing (including non-object JSON and malformed input), and value-based comparison so a non-canonical IPv6 from the API still matches the monmap.

Integration tests (tests/integration/test_mon_addresses.py, 3 units on VMs):

- test_all_mons_advertised_to_client (smoke): every mon unit advertises a distinct ceph-public-address and the app list enumerates every mon.
- test_app_list_published_when_leaders_differ (regression): forces Juju leader != Ceph mon leader by bouncing the leader's machine agent, keeps it stopped through the whole check so the old leader cannot reclaim leadership and pass it for the wrong reason, and asserts the new non-mon-leader Juju leader republishes the full list. The agent restart is a guarded cleanup and the leader is resolved from controller-side juju status.

Registers the regression pytest marker.

Assisted-by: claude-code:claude-opus-4-8, pi:z-ai/glm-5.2



(cherry picked from commit 479d8e2b8c530db45f38b4a01de76ebe408bdf1f) (cherry picked from commit 784f961306c2fafe7b778ba77f14cc484e285ca6)

