### PR TITLE
ci: add scheduled Build/Test runs on main for CI health dashboard

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,6 +2,13 @@ name: Build/Test
 
 on:
   workflow_call:
+  # Periodic full-suite run for the CI health dashboard:
+  # the dashboard only counts push/schedule/workflow_dispatch
+  # events, and this suite otherwise only runs via workflow_call from
+  # pr.yaml on pull_request, which the dashboard excludes by design.
+  schedule:
+    - cron: "0 2 * * *" # Nightly full run on main for flaky rate data
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/scheduled-branch-tests.yaml
+++ b/.github/workflows/scheduled-branch-tests.yaml
@@ -1,0 +1,26 @@
+name: Scheduled branch tests
+
+# GitHub only fires schedule: on the default branch, so stable branches
+# get their periodic Build/Test run dispatched from here instead. These
+# workflow_dispatch runs count toward the CI health dashboard's
+# per-branch flaky rate, same as build-and-test.yml's own
+# schedule: run on main.
+on:
+  schedule:
+    - cron: "0 2 * * *" # Nightly full run on stable branches for flaky rate data
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ref: [stable/squid]
+    steps:
+      - name: Dispatch build-and-test.yml on ${{ matrix.ref }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run build-and-test.yml --ref "${{ matrix.ref }}" --repo "${{ github.repository }}"


### PR DESCRIPTION
# Description

Add `schedule:` and `workflow_dispatch:` triggers to
`build-and-test.yml` alongside its existing `workflow_call:`, so the full
suite runs twice weekly on `main` independent of any PR. It also adds a new
`scheduled-branch-tests.yaml`, present on `main` only, which dispatches a
`workflow_dispatch` run of `build-and-test.yml` on `stable/squid` (GitHub only
fires `schedule:` on the default branch, so stable branches need to be
reached via dispatch). This mirrors the pattern already in use in the
`microceph` repo (`scheduled-branch-tests.yml` there).

A companion PR against `stable/squid` (#TBD) adds the `workflow_dispatch:`
trigger to that branch's `build-and-test.yml`, which is required for the
dispatch job here to have a valid target.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
