### PR TITLE
ci: add workflow_dispatch trigger to stable/squid build-and-test.yml

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,6 +2,11 @@ name: Build/Test
 
 on:
   workflow_call:
+  # Accepts workflow_dispatch runs fired by main's
+  # scheduled-branch-tests.yaml (schedule: triggers only fire on the
+  # default branch, so periodic runs on this branch are dispatched
+  # instead). Feeds the CI health dashboard's flaky-rate metric
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
# Description

Companion to #323. Allow dispatched runs for daily stable data.

## Contributor's Checklist

- [x] self-reviewed the code in this PR.
