### PR TITLE
fix: normalize mon ipaddr sorting (#340) [backport stable/squid]

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -98,6 +98,19 @@ def is_departing(app, context: str = "") -> bool:
         return False
 
 
+def _sort_mon_addresses(addrs: list[str]) -> list[str]:
+    """Return mon addresses in a stable, deterministic order.
+
+    The microceph service API (and the ceph.conf fallback) can report the same
+    set of mons in a different order on successive calls. Publishing that list
+    verbatim makes an otherwise unchanged mon set serialize differently each
+    time, which Juju treats as a real relation-data change and fans out to every
+    client (LP#2161602). Sort by normalized IP so equivalent representations
+    order consistently, with the original string as a tiebreaker.
+    """
+    return sorted(addrs, key=lambda a: (_normalize_ip(a) or a, a))
+
+
 def get_mon_addresses():
     """Get the Ceph mon addresses, cross-checked against the live monmap.
 
@@ -106,6 +119,10 @@ def get_mon_addresses():
     those present in the live monmap (``ceph mon dump``). Fall back to the
     unfiltered list if the monmap is unavailable or the intersection is empty,
     so a format mismatch can never regress to an empty list.
+
+    The returned list is sorted in a stable order so that an unchanged set of
+    mons always serializes identically; this prevents mere reordering from
+    triggering spurious relation-changed events (LP#2161602).
     """
     # Local import: ceph imports utils, so a module-level import would cycle.
     import ceph
@@ -132,7 +149,7 @@ def get_mon_addresses():
                 addrs,
                 sorted(live),
             )
-            return filtered
+            return _sort_mon_addresses(filtered)
         logger.warning(
             "Live monmap cross-check removed all reported mon addresses; "
             "using the unfiltered list %s",
@@ -144,7 +161,7 @@ def get_mon_addresses():
             live or "empty",
             addrs,
         )
-    return addrs
+    return _sort_mon_addresses(addrs)
 
 
 def get_fsid():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -137,6 +137,47 @@ class TestGetMonAddresses(unittest.TestCase):
 
         self.assertEqual(utils.get_mon_addresses(), addrs)
 
+    @patch("ceph.get_live_mon_ips")
+    @patch("utils.Client")
+    def test_stable_order_regardless_of_api_order(self, client, get_live):
+        # The same set of mons reported in different orders must serialize to the
+        # same list, so a mere reordering never looks like a relation change
+        # (LP#2161602).
+        get_live.return_value = {"10.241.3.26", "10.241.3.45", "10.241.3.52"}
+
+        client.from_socket.return_value.cluster.get_mon_addresses.return_value = [
+            "10.241.3.26",
+            "10.241.3.45",
+            "10.241.3.52",
+        ]
+        first = utils.get_mon_addresses()
+
+        client.from_socket.return_value.cluster.get_mon_addresses.return_value = [
+            "10.241.3.52",
+            "10.241.3.26",
+            "10.241.3.45",
+        ]
+        second = utils.get_mon_addresses()
+
+        self.assertEqual(first, second)
+        self.assertEqual(first, ["10.241.3.26", "10.241.3.45", "10.241.3.52"])
+
+    @patch("ceph.get_live_mon_ips")
+    @patch("utils.Client")
+    def test_stable_order_no_live_monmap(self, client, get_live):
+        # Ordering is stabilised even on the fallback path (no live monmap).
+        get_live.return_value = set()
+        client.from_socket.return_value.cluster.get_mon_addresses.return_value = [
+            "10.241.3.52",
+            "10.241.3.26",
+            "10.241.3.45",
+        ]
+
+        self.assertEqual(
+            utils.get_mon_addresses(),
+            ["10.241.3.26", "10.241.3.45", "10.241.3.52"],
+        )
+
 
 class TestNormalizeIp(unittest.TestCase):
     """_normalize_ip canonicalises bare IPs and leaves anything else untouched."""


### PR DESCRIPTION
# Description

Backport of #340 (`fix: normalize mon ipaddr sorting`) to `stable/squid`.

The microceph service API (and the `ceph.conf` fallback) can report the same set of mons in a different order on successive calls. Publishing that list verbatim makes an otherwise unchanged mon set serialize differently each time, which Juju treats as a real relation-data change and fans out to every client. Sort by normalized IP so equivalent representations order consistently, with the original string as a tiebreaker.

This is a clean cherry-pick of the upstream fix; the relevant code (`_normalize_ip` and `get_mon_addresses` in `src/utils.py`) is identical on `stable/squid`, so the patch applies without conflicts.

Fixes # (LP#2161602)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified locally on `stable/squid`:

- `tox -e lint` — codespell + pflake8 + isort + black: clean.
- `tox -e py3` — 247 unit tests pass, including the two new tests backported alongside the fix:
  - `TestGetMonAddresses::test_stable_order_regardless_of_api_order` — the same mon set returned in different orders by the API serializes identically (LP#2161602 regression).
  - `TestGetMonAddresses::test_stable_order_no_live_monmap` — ordering is stabilized on the fallback path (no live monmap).
- Confirmed the cherry-picked diff is byte-for-byte identical to the upstream change (only the git blob index lines differ, as expected between branch bases).

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes. _(N/A — internal ordering fix, no user-facing surface change.)_
- [x] added tests to verify effectiveness of this change.
