### PR TITLE
fix: backport: query snap tracks via snapd to respect store proxy (#344)

### DIFF
--- a/src/microceph.py
+++ b/src/microceph.py
@@ -39,6 +39,7 @@ MAJOR_VERSIONS = {
     "17": "quincy",
     "18": "reef",
     "19": "squid",
+    "20": "tentacle",
 }
 
 
@@ -596,12 +597,15 @@ def add_disk_match_cmd(
 
 
 def get_snap_info(snap_name):
-    """Get snap info from the charm store."""
-    url = f"https://api.snapcraft.io/v2/snaps/info/{snap_name}"
-    headers = {"Snap-Device-Series": "16"}  # magic header val for snapstore
-    response = requests.get(url, headers=headers)
-    response.raise_for_status()
-    return response.json()
+    """Get snap info from the store via snapd.
+
+    We query the local snapd daemon (over its Unix socket) rather than hitting
+    the public Snapcraft API (api.snapcraft.io) directly. snapd honours the
+    system's snap store proxy configuration, so this works in airgapped
+    environments where only the proxy -- and not the public store -- is
+    reachable. See snapd's GET /v2/find endpoint.
+    """
+    return snap.SnapClient().get_snap_information(snap_name)
 
 
 def list_disk_cmd(host_only: bool = False) -> dict:
@@ -680,10 +684,30 @@ def _is_block_device_enrollable(disk: str) -> bool:
 
 
 def get_snap_tracks(snap_name):
-    """Get snap tracks from the charm store."""
+    """Get snap tracks from the store via snapd."""
     info = get_snap_info(snap_name)
-    tracks = {item["channel"]["track"] for item in info["channel-map"]}
-    return tracks
+    # snapd's find endpoint returns the list of tracks directly.
+    return set(info.get("tracks", []))
+
+
+def _major_series_from_version(version: str) -> str:
+    """Map a snap version string (e.g. '19.2.3+snap...') to a release series."""
+    major = version.split(".", 1)[0]
+    return MAJOR_VERSIONS[major]
+
+
+def _resolve_latest_track(snap_name: str) -> str:
+    """Resolve the 'latest' track to its current release series (e.g. 'squid').
+
+    snapd reports a per-channel version in its ``channels`` map. Prefer the
+    stable risk of the latest track, falling back to the snap's default
+    channel version reported at the top level.
+    """
+    info = get_snap_info(snap_name)
+    channels = info.get("channels", {})
+    latest_stable = channels.get("latest/stable")
+    version = latest_stable["version"] if latest_stable else info["version"]
+    return _major_series_from_version(version)
 
 
 def can_upgrade_snap(current, new: str) -> bool:
@@ -700,8 +724,7 @@ def can_upgrade_snap(current, new: str) -> bool:
 
     # resolve major version if set to latest currently
     if current == "latest":
-        ver = get_snap_info("microceph")["latest"]
-        current = MAJOR_VERSIONS[ver]
+        current = _resolve_latest_track("microceph")
         logger.debug(f"Resolved 'latest' track to {current}")
 
     # We must not downgrade the major version of the snap

--- a/tests/unit/test_airgap_snap_channel.py
+++ b/tests/unit/test_airgap_snap_channel.py
@@ -1,0 +1,152 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for airgapped snap-channel handling.
+
+Bug: when the snap-channel config was changed in a strictly airgapped
+environment (one that uses a snap store proxy for snap installs but has no
+route to the public internet), the leader unit went into an error state.
+
+Root cause: to validate the requested snap track, the charm made a *direct*
+outbound HTTPS request to the public Snapcraft API (``api.snapcraft.io``)
+instead of asking the local snapd, which is configured to use the store
+proxy. In an airgapped env that request failed with a ConnectionError and the
+exception propagated out of the config-changed / update-status hook.
+
+Fix: query snapd's ``find`` endpoint (via ``snap.SnapClient``) over its Unix
+socket. snapd honours the system snap store proxy configuration, so the track
+lookup succeeds anywhere snap installs already work.
+
+These tests pin the proxy-aware behaviour: the track lookup must go through
+snapd and must not touch ``requests`` / ``api.snapcraft.io``.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import requests
+from unit import testbase
+
+import charm as charm_module
+import microceph
+
+# A representative snapd `find` (GET /v2/find) response for microceph, matching
+# the shape snapd returns over its Unix socket. snapd routes this query through
+# the configured store proxy.
+SNAPD_FIND_RESULT = {
+    "name": "microceph",
+    "channel": "squid/stable",
+    "version": "19.2.3+snapcf306793a4",
+    "tracks": ["squid", "latest", "tentacle", "reef", "quincy"],
+    "channels": {
+        "latest/stable": {"version": "18.2.4+snapc9f2b08f92", "channel": "latest/stable"},
+        "squid/stable": {"version": "19.2.3+snapcf306793a4", "channel": "squid/stable"},
+        "tentacle/edge": {"version": "20.2.1+snapb8f87722ee", "channel": "tentacle/edge"},
+    },
+}
+
+
+def _network_unreachable(*args, **kwargs):
+    """Emulate an airgapped host with no route to the public snapstore."""
+    raise requests.exceptions.ConnectionError(
+        "HTTPSConnectionPool(host='api.snapcraft.io', port=443): "
+        "Max retries exceeded (Network is unreachable)"
+    )
+
+
+class TestAirgapSnapChannelUnit(unittest.TestCase):
+    """Track lookups must go through snapd, not the public snapstore."""
+
+    @patch("requests.get", side_effect=_network_unreachable)
+    @patch("microceph.snap.SnapClient")
+    def test_get_snap_info_uses_snapd(self, mock_snap_client, mock_requests_get):
+        """get_snap_info asks snapd (proxy-aware) rather than api.snapcraft.io."""
+        client = mock_snap_client.return_value
+        client.get_snap_information.return_value = SNAPD_FIND_RESULT
+
+        result = microceph.get_snap_info("microceph")
+
+        self.assertEqual(result, SNAPD_FIND_RESULT)
+        client.get_snap_information.assert_called_once_with("microceph")
+        # The whole point of the fix: no direct call to the public snapstore.
+        mock_requests_get.assert_not_called()
+
+    @patch("requests.get", side_effect=_network_unreachable)
+    @patch("microceph.snap.SnapClient")
+    def test_get_snap_tracks_from_snapd(self, mock_snap_client, _mock_requests_get):
+        """Tracks are derived from snapd's top-level ``tracks`` list."""
+        mock_snap_client.return_value.get_snap_information.return_value = SNAPD_FIND_RESULT
+
+        tracks = microceph.get_snap_tracks("microceph")
+
+        self.assertEqual(tracks, {"squid", "latest", "tentacle", "reef", "quincy"})
+
+    @patch("requests.get", side_effect=_network_unreachable)
+    @patch("microceph.snap.SnapClient")
+    def test_can_upgrade_snap_when_airgapped(self, mock_snap_client, _mock_requests_get):
+        """The track check succeeds via snapd even with no public route."""
+        mock_snap_client.return_value.get_snap_information.return_value = SNAPD_FIND_RESULT
+
+        # e.g. moving from squid/edge to squid/stable, as in the bug report.
+        self.assertTrue(microceph.can_upgrade_snap("squid", "squid"))
+        # And a forward move to a newer series still validates.
+        self.assertTrue(microceph.can_upgrade_snap("squid", "tentacle"))
+
+    @patch("requests.get", side_effect=_network_unreachable)
+    @patch("microceph.snap.SnapClient")
+    def test_can_upgrade_from_latest_resolves_via_snapd(
+        self, mock_snap_client, _mock_requests_get
+    ):
+        """Resolving a current 'latest' track reads the version from snapd."""
+        mock_snap_client.return_value.get_snap_information.return_value = SNAPD_FIND_RESULT
+
+        # latest/stable is reef (18.x) here, so upgrading to squid is allowed
+        # and downgrading to quincy is not.
+        self.assertTrue(microceph.can_upgrade_snap("latest", "squid"))
+        self.assertFalse(microceph.can_upgrade_snap("latest", "quincy"))
+
+
+class TestAirgapSnapChannelCharm(testbase.TestBaseCharm):
+    """End-to-end: a snap-channel change no longer errors the leader unit."""
+
+    def setUp(self):
+        super().setUp(charm_module, [])
+        self.init_harness()
+        self.harness.set_leader()
+
+    @patch("requests.get", side_effect=_network_unreachable)
+    @patch("microceph.snap.SnapClient")
+    def test_can_upgrade_charm_payload_airgapped(self, mock_snap_client, _mock_requests_get):
+        """can_upgrade_charm_payload succeeds airgapped by consulting snapd."""
+        mock_snap_client.return_value.get_snap_information.return_value = SNAPD_FIND_RESULT
+        unit_charm = self.harness.charm
+
+        with (
+            patch.object(unit_charm, "ready_for_service", return_value=True),
+            patch("cluster.CephStatus") as mock_status,
+        ):
+            mock_status.return_value.ceph_health.return_value = (
+                charm_module.cluster.CephHealth.Ok,
+                "",
+            )
+            # Mirror the bug report's squid/edge -> squid/stable: a same-track
+            # move whose validation used to hit api.snapcraft.io. The default
+            # channel track is 'tentacle', so validate a tentacle/stable move.
+            ok, msg = unit_charm.cluster_upgrades.can_upgrade_charm_payload("tentacle/stable")
+
+        self.assertTrue(ok, msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -894,44 +894,33 @@ class TestCharm(testbase.TestBaseCharm):
         }
         self._test_list_disks_action(microceph_cmd_output, expected_disks)
 
-    @patch("requests.get")
-    def test_get_snap_info(self, mock_get):
-        # Sample mocked response data
+    @patch("microceph.snap.SnapClient")
+    def test_get_snap_info(self, mock_snap_client):
+        # snapd's find endpoint (queried over the Unix socket) honours the
+        # snap store proxy, unlike a direct call to api.snapcraft.io.
         mock_response_data = {
             "name": "test-snap",
             "summary": "A test snap",
             # ... add more fields as needed
         }
-        mock_response = MagicMock()
-        # mock_response.raise_for_status.return_value = None  # Avoid raising exceptions
-        mock_response.json.return_value = mock_response_data
-        mock_get.return_value = mock_response
+        client = mock_snap_client.return_value
+        client.get_snap_information.return_value = mock_response_data
 
         result = microceph.get_snap_info("test-snap")
 
         self.assertEqual(result, mock_response_data)
-        mock_get.assert_called_once_with(
-            "https://api.snapcraft.io/v2/snaps/info/test-snap",
-            headers={"Snap-Device-Series": "16"},
-        )
+        client.get_snap_information.assert_called_once_with("test-snap")
 
     @patch("microceph.get_snap_info")
     def test_get_snap_tracks(self, mock_get_snap_info):
-        # Simulate get_snap_info output
-        mock_snap_info = {
-            "channel-map": [
-                {"channel": {"track": "quincy/stable"}},
-                {"channel": {"track": "reef/beta"}},
-                {"channel": {"track": "quincy/stable"}},
-            ]
-        }
-        mock_get_snap_info.return_value = mock_snap_info
+        # snapd's find endpoint returns the list of tracks directly.
+        mock_get_snap_info.return_value = {"tracks": ["quincy", "reef", "quincy"]}
 
         # Execute the code under test
         result = microceph.get_snap_tracks("test-snap")
 
         # Expected Assertion
-        self.assertEqual(sorted(result), ["quincy/stable", "reef/beta"])
+        self.assertEqual(sorted(result), ["quincy", "reef"])
 
     @patch("microceph.get_snap_tracks")
     def test_can_upgrade_snap_empty_new_version(self, mock_get_snap_tracks):
@@ -943,6 +932,23 @@ class TestCharm(testbase.TestBaseCharm):
     def test_can_upgrade_snap_to_latest(self, mock_get_snap_tracks):
         mock_get_snap_tracks.return_value = {"quincy", "reef"}
         result = microceph.can_upgrade_snap("latest", "latest")
+        self.assertTrue(result)
+
+    @patch("microceph.get_snap_info")
+    @patch("microceph.get_snap_tracks")
+    def test_can_upgrade_from_latest_resolves_tentacle(
+        self, mock_get_snap_tracks, mock_get_snap_info
+    ):
+        mock_get_snap_tracks.return_value = {"squid", "tentacle"}
+        # snapd reports a per-channel version in its `channels` map; resolving
+        # 'latest' uses the latest/stable channel version.
+        mock_get_snap_info.return_value = {
+            "channels": {"latest/stable": {"version": "20.2.1+snapb8f87722ee"}},
+            "version": "20.2.1+snapb8f87722ee",
+        }
+
+        result = microceph.can_upgrade_snap("latest", "tentacle")
+
         self.assertTrue(result)
 
     @patch("microceph.get_snap_tracks")

--- a/tests/unit/testbase.py
+++ b/tests/unit/testbase.py
@@ -78,6 +78,21 @@ class _MicroCephCharm(charm.MicroCephCharm):
 
 
 class TestBaseCharm(test_utils.CharmTestCase):
+    def init_harness(self) -> None:
+        """Create, register cleanup for, and begin a microceph charm harness."""
+        with open("config.yaml", "r") as f:
+            config_data = f.read()
+        with open("metadata.yaml", "r") as f:
+            metadata = f.read()
+        self.harness = test_utils.get_harness(
+            _MicroCephCharm,
+            container_calls=self.container_calls,
+            charm_config=config_data,
+            charm_metadata=metadata,
+        )
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
     def add_complete_identity_relation(self, harness: Harness) -> None:
         """Add complete identity-service relation."""
         credentials_content = {"username": "svcuser1", "password": "svcpass1"}


### PR DESCRIPTION
The charm validated snap tracks by calling api.snapcraft.io directly, which fails in airgapped environments that only reach the snap store proxy. Query snapd's find endpoint instead, which honours the proxy.

Assisted-by: pi:anthropic/opus-4.8

Signed-off-by: Peter Sabaini <peter.sabaini@canonical.com>
(cherry picked from commit 29b7df5a68f11219364eae9c021250044c54e944)

Backport to stable/squid required three adaptations, since the commit was authored on main which had drifted:

- Resolved a conflict in tests/unit/test_charm.py: the upstream commit edited test_can_upgrade_from_latest_resolves_tentacle, which did not yet exist on this branch. Kept the new snapd-based test.
- Added "20": "tentacle" to MAJOR_VERSIONS in src/microceph.py. The new _resolve_latest_track() maps a snap version's major number through MAJOR_VERSIONS, and the backported tests exercise version 20.x; without this entry it raised KeyError('20') at runtime. This mapping exists on main via the tentacle-release commit (d83dae9).
- Backported the init_harness() helper to tests/unit/testbase.py, which the new tests/unit/test_airgap_snap_channel.py depends on. The helper was added on main in commit 7c7d224 and had not landed here.

