### PR TITLE
backport: Configure public and cluster networks (#335)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -155,3 +155,41 @@ options:
       provisioning initiated by osd-devices. They are not in effect when using
       the add-osd action, which currently supports only device-level wipe and
       encryption parameters.
+  ceph-public-network:
+    type: string
+    default: ""
+    description: |
+      The IP address and netmask of the public (front-side) network (e.g.,
+      192.168.0.0/24 or fd00:a::/64).
+
+      If multiple networks are to be used, a comma-delimited or
+      space-delimited list of subnets in CIDR notation can be provided.
+      Every unit must have an address on one of the configured subnets.
+
+      This configuration option only applies at bootstrap and if changed
+      later the unit blocks, as microceph cannot apply a new public network
+      to a running cluster. Set it at deploy time with juju deploy --config
+      ...; to recover a blocked unit, revert the option to the value shown
+      in the unit's status message.
+
+      Left unset, the public network falls back to a single subnet the leader
+      unit resides on within the public space.
+  ceph-cluster-network:
+    type: string
+    default: ""
+    description: |
+      The IP address and netmask of the cluster (back-side) network (e.g.,
+      192.168.0.0/24 or fd00:b::/64).
+
+      If multiple networks are to be used, a comma-delimited or
+      space-delimited list of subnets in CIDR notation can be provided.
+      Every unit must have an address on one of the configured subnets.
+
+      Left unset, the cluster network falls back to a single subnet the
+      leader unit resides on within the cluster space. Clearing the option
+      after it has been set reverts the cluster network to the subnet the
+      then-current leader resides on within the cluster space, which can
+      differ from the subnet chosen at bootstrap if leadership has moved.
+
+      Modifying this configuration option can cause momentary service
+      disruption.

--- a/src/charm.py
+++ b/src/charm.py
@@ -47,7 +47,7 @@ import utils
 from ceph_nfs import CephNfsProviderHandler
 from ceph_rgw import CEPH_RGW_READY_RELATION, CephRgwProviderHandler
 from microceph_adopt_ceph import AdoptCephRequiresHandler
-from microceph_client import ClusterServiceUnavailableException
+from microceph_client import ClusterServiceUnavailableException, UnrecognizedClusterConfigOption
 from microceph_remote import MicroCephRemoteHandler
 from radosgw import RadosGWHandler
 from relation_handlers import (
@@ -66,6 +66,8 @@ from storage import StorageHandler
 logger = logging.getLogger(__name__)
 CACERT_FILE = "/usr/local/share/ca-certificates/receive-keystone-ca-bundle.crt"
 MAX_PG_PER_OSD = 400
+PUBLIC_NETWORK_CONFIG = "ceph-public-network"
+CLUSTER_NETWORK_CONFIG = "ceph-cluster-network"
 
 
 class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
@@ -246,11 +248,78 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         A departing unit must not reconcile: the cluster loses quorum during
         teardown, so the cluster calls made here would error or hang. Gating the
         main reconcile entry point keeps a departing unit inert.
+
+        Config checks run here rather than in _on_config_changed so every
+        reconcile path re-enforces them: relation handlers call configure_charm
+        directly, and finishing a reconcile sets the unit active, which would
+        otherwise silently clear the blocked status of a unit whose config is
+        still in violation.
         """
         if utils.is_departing(self.app):
             logger.info("Application is being removed; skipping reconcile")
             return
+        try:
+            self.check_configs()
+        except sunbeam_guard.BlockedExceptionError as e:
+            logger.warning("Charm is blocked: %s", e.msg)
+            self.status.set(e.to_status())
+            return
         super().configure_charm(event)
+
+    def check_configs(self) -> None:
+        """Validate config options and enforce the immutable ones.
+
+        Runs on every unit, so a violation blocks the whole application rather
+        than only the leader.
+
+        :raises BlockedExceptionError: on a malformed subnet, or on a change to
+            an option that cannot be applied after bootstrap.
+        """
+        self._check_immutable_config(
+            "namespace-projects", self.model.config.get("namespace-projects"), "deployment"
+        )
+        # Validate both network options on every unit, so a malformed subnet
+        # blocks before any cluster operation is attempted.
+        self._get_network_config(CLUSTER_NETWORK_CONFIG)
+        public_net = self._get_network_config(PUBLIC_NETWORK_CONFIG)
+        # microceph cannot set public_network on a bootstrapped cluster, so a
+        # post-bootstrap change can only be reported, never applied. The
+        # OPTION VALUE consumed at bootstrap ("" when the space-subnet
+        # fallback was used) is recorded by the bootstrap and adopt paths;
+        # any later change to the option blocks — including setting it to
+        # the subnet in effect, which the charm cannot verify against a
+        # running cluster.
+        # Compare as a set: subnet order is a microceph address-selection
+        # priority, but reordering an unchanged set is not a network change.
+        self._check_immutable_config(
+            PUBLIC_NETWORK_CONFIG,
+            public_net,
+            "bootstrap",
+            normalize=lambda value: set(utils.split_space_or_comma(value)),
+        )
+
+    def _check_immutable_config(self, key: str, current, applied_at: str, normalize=None) -> None:
+        """Block if an immutable config option differs from its recorded value.
+
+        :param current: the option's current value, canonicalised the same way
+            as the recorded one.
+        :param applied_at: when the recorded value was fixed, for the message.
+        :param normalize: optional transform applied to both sides before
+            comparing, for values with more than one equivalent spelling.
+        :raises BlockedExceptionError: if a value was recorded and differs.
+        """
+        recorded = self.leader_get(key)
+        if recorded is None:
+            return
+        applied = json.loads(recorded)
+        if normalize is None:
+            changed = applied != current
+        else:
+            changed = normalize(applied) != normalize(current)
+        if changed:
+            raise sunbeam_guard.BlockedExceptionError(
+                f"Config {key} cannot be changed after {applied_at}, revert to {applied!r}"
+            )
 
     def configure_unit(self, event: ops.framework.EventBase) -> None:
         """Run configuration on this unit."""
@@ -262,14 +331,12 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             if not self.is_valid_placement_directive(self.model.config.get("enable-rgw")):
                 raise sunbeam_guard.BlockedExceptionError("Improper value for config enable-rgw")
 
-            namespace_projects = self.leader_get("namespace-projects")
-            if namespace_projects and json.loads(namespace_projects) != self.model.config.get(
-                "namespace-projects"
-            ):
-                raise sunbeam_guard.BlockedExceptionError(
-                    "Config namespace-projects cannot be changed after deployment"
-                )
-
+            # check_configs also runs inside configure_charm, so every
+            # reconcile path re-enforces it. Calling it here first lets a
+            # violation bail out of this guard before the peer-data publish
+            # below, so a later failure there cannot replace the specific
+            # blocked message with a generic one.
+            self.check_configs()
             self.configure_charm(event)
 
             # Refresh peer data on config-changed so binding-derived addresses
@@ -597,9 +664,23 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
             logger.debug("Bootstrapping MicroCeph cluster")
             self.bootstrap_cluster(event)
+            # Record in the same hook that bootstrapped, so the baseline is
+            # the option value bootstrap consumed ("" when it fell back to
+            # the space subnet), not whatever the option reads as by the
+            # time a later hook happens to run.
+            self._record_applied_public_network()
 
         # Handle post bootstrap
+        self._handle_post_bootstrap_config(event)
+
+    def _handle_post_bootstrap_config(self, event: ops.framework.EventBase) -> None:
+        """Run the post-bootstrap config handlers shared by all bootstrap paths.
+
+        Both configure_app_leader and handle_ceph_adopt must run these; keeping
+        one list stops the two paths drifting apart.
+        """
         self.handle_config_leader_set_ready()
+        self.handle_config_leader_cluster_network(event)
         self.handle_config_leader_ceph_pool_pgs(event)
         self.handle_config_rgw_service(event)
         self.handle_config_leader_charm_upgrade()
@@ -627,23 +708,58 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
         if space_nets:
             return space_nets[0].subnet
 
+    def _get_network_config(self, option: str) -> str:
+        """Fetch and validate a network config option, as a comma-delimited string.
+
+        :param option: ceph-public-network or ceph-cluster-network
+        :raises BlockedExceptionError: if any subnet in the option is malformed.
+            A bad entry blocks rather than being skipped, so a typo can never
+            silently bootstrap the cluster onto a subset of the intended networks.
+        """
+        value = self.model.config.get(option) or ""
+        if not value:
+            return ""
+
+        try:
+            networks = utils.parse_networks(value)
+        except ValueError as e:
+            raise sunbeam_guard.BlockedExceptionError(f"Invalid config {option}: {e}")
+
+        return ",".join(networks)
+
     def _get_bootstrap_params(self) -> dict:
         """Fetch bootstrap parameters."""
         micro_ip = cluster_net = public_net = ""
         snap_channel = snap.SnapCache()["microceph"].channel
 
         if "quincy" in snap_channel:
-            # some quincy snap revisions do not support network configuration
+            # some quincy snap revisions do not support network configuration.
+            # Judge the options by their parsed value, like everywhere else,
+            # so whitespace-only input still counts as unset.
+            if self._get_network_config(PUBLIC_NETWORK_CONFIG) or self._get_network_config(
+                CLUSTER_NETWORK_CONFIG
+            ):
+                # Block rather than silently bootstrap without the requested
+                # networks: the recorded baseline would claim they were applied.
+                raise sunbeam_guard.BlockedExceptionError(
+                    f"neither {PUBLIC_NETWORK_CONFIG} nor {CLUSTER_NETWORK_CONFIG} are "
+                    "supported on quincy snap channels, unset them"
+                )
             logger.warning("Juju spaces incompatible with quincy revision snaps")
             return {}
 
         availability_zone = os.environ.get("JUJU_AVAILABILITY_ZONE", "")
 
+        # Read config outside the try block: the `finally: return` below would
+        # swallow the BlockedExceptionError raised on a malformed subnet.
+        public_net_cfg = self._get_network_config(PUBLIC_NETWORK_CONFIG)
+        cluster_net_cfg = self._get_network_config(CLUSTER_NETWORK_CONFIG)
+
         try:
-            # Public Network
-            public_net = self._get_space_subnet(space="public")
+            # Public Network: operator config wins, else the leader's space subnet.
+            public_net = public_net_cfg or self._get_space_subnet(space="public") or ""
             # Cluster Network
-            cluster_net = self._get_space_subnet(space="cluster")
+            cluster_net = cluster_net_cfg or self._get_space_subnet(space="cluster") or ""
             # MicroCeph IP
             micro_ip = self.model.get_binding(binding_key="admin").network.bind_address
 
@@ -683,10 +799,16 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             self.peers.interface.state.joined = True
             if applied.get("availability_zone"):
                 self.peers.set_app_data({"cluster_uses_az": "true"})
+            # Same-hook baseline recording, as in the bootstrap path.
+            self._record_applied_public_network()
             logger.debug("microceph bootstrapped successfully via adopt-ceph")
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             if "Unable to initialize cluster: Database is online" in str(e.stderr):
                 logger.info("microceph is already bootstrapped, ignore failure.")
+                # A retry of the hook that adopted but died before recording:
+                # record now, or handle_config_leader_set_ready's upgrade
+                # fallback would stamp "" and block the unchanged option.
+                self._record_applied_public_network()
                 return
 
             logger.exception("microceph adopt failed:")
@@ -833,15 +955,16 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
 
         # Mark unit as bootstrapped (required for bootstrapped() check)
         self._state.unit_bootstrapped = True
-        self.handle_config_leader_set_ready()
-        self.handle_config_leader_ceph_pool_pgs(event)
-        self.handle_config_rgw_service(event)
-        self.handle_config_leader_charm_upgrade()
-        self.handle_config_leader_new_node(event)
-        self.cos_agent._on_refresh(event)
-        # Clear any blocked status and set to active (similar to configure_charm)
-        self.bootstrap_status.set(ActiveStatus())
-        self.status.set(ActiveStatus("charm is ready"))
+        # The post-bootstrap handlers report retryable conditions by raising
+        # waiting/blocked; configure_charm runs them under the base class's
+        # guard, so run them under one here too, or a raise would error the
+        # hook (and the active statuses below must not paper over it).
+        with sunbeam_guard.guard(self, "Adopting existing Ceph cluster"):
+            self._handle_post_bootstrap_config(event)
+            self.cos_agent._on_refresh(event)
+            # Clear any blocked status and set to active (similar to configure_charm)
+            self.bootstrap_status.set(ActiveStatus())
+            self.status.set(ActiveStatus("charm is ready"))
 
     def handle_rh_cb_noop(self, event) -> None:
         """Callback for interface ceph."""
@@ -857,6 +980,102 @@ class MicroCephCharm(sunbeam_charm.OSBaseOperatorCharm):
             self.leader_set(
                 {"namespace-projects": json.dumps(self.model.config.get("namespace-projects"))}
             )
+        if self.leader_get(PUBLIC_NETWORK_CONFIG) is None:
+            # The bootstrap and adopt paths record the value they consumed, so
+            # reaching here means the cluster was bootstrapped by a charm
+            # revision that predates the option and nothing was ever applied.
+            # Record "" (not the current config): a value set only after such
+            # an upgrade must block rather than masquerade as applied, since
+            # microceph cannot change public_network on a running cluster.
+            self.leader_set({PUBLIC_NETWORK_CONFIG: json.dumps("")})
+
+    def _record_applied_public_network(self) -> None:
+        """Record the public network consumed at bootstrap, for check_configs.
+
+        First write wins: the baseline must keep describing what bootstrap
+        consumed even when this is re-run by a retried hook or a repeated
+        event after the option changed. A retry that reaches this only via
+        the "already bootstrapped" swallow can still record a value newer
+        than the one bootstrap really consumed if the option changed while
+        the unit sat in error; the true value is unrecoverable then, and the
+        current config is the closest available approximation.
+
+        Recorded as JSON so an unset option ("") stays distinguishable from a
+        key that was never written, which peer data cannot express.
+        """
+        if self.leader_get(PUBLIC_NETWORK_CONFIG) is not None:
+            return
+        self.leader_set(
+            {PUBLIC_NETWORK_CONFIG: json.dumps(self._get_network_config(PUBLIC_NETWORK_CONFIG))}
+        )
+
+    def handle_config_leader_cluster_network(self, event: ops.framework.EventBase) -> None:
+        """Apply the configured cluster network to the running cluster.
+
+        Unlike public_network, cluster_network can be set on a bootstrapped
+        cluster, so it is reconciled on every config-changed rather than only at
+        bootstrap. When the value changed, microceph restarts the affected
+        services (the momentary service disruption the config option warns
+        about).
+
+        The last value this handler applied is tracked in peer data: an
+        unchanged option is a no-op without touching the daemon, clearing the
+        option after it was set reverts the cluster network to the fallback
+        subnet (the leader's subnet in the cluster space), and an option that
+        was never set leaves whatever bootstrap applied untouched.
+
+        A pending change that cannot be applied yet defers AND raises waiting:
+        the defer gets the event re-delivered, and the raise stops the
+        reconcile from ending in active, which would misreport a cluster whose
+        requested network is not in effect (the caller's guard turns the raise
+        into a waiting status).
+        """
+        configured = self._get_network_config(CLUSTER_NETWORK_CONFIG)
+        recorded = self.leader_get(CLUSTER_NETWORK_CONFIG)
+        applied = json.loads(recorded) if recorded else ""
+
+        if configured == applied:
+            # Nothing to reconcile. Returning before any daemon call also
+            # keeps a steady-state reconcile independent of transient daemon
+            # unavailability.
+            logger.debug("Cluster network config unchanged, nothing to reconcile")
+            return
+
+        cluster_net = configured
+        if not configured:
+            subnet = self._get_space_subnet(space="cluster")
+            if subnet is None:
+                # Possibly a transient binding-resolution gap: retry on a
+                # later hook rather than silently abandoning the revert.
+                event.defer()
+                raise sunbeam_guard.WaitingExceptionError(
+                    f"No subnet in the cluster space, revert of cluster network {applied} pending"
+                )
+            cluster_net = str(subnet)
+            logger.info(f"Cluster network cleared, reverting to fallback subnet {cluster_net}")
+
+        if not self.ready_for_service():
+            event.defer()
+            raise sunbeam_guard.WaitingExceptionError(
+                f"MicroCeph not ready, update of cluster network to {cluster_net} pending"
+            )
+
+        logger.debug(f"Configuring cluster network {cluster_net}")
+        try:
+            microceph.update_cluster_configs({"cluster_network": cluster_net})
+        except ClusterServiceUnavailableException as e:
+            logger.warning(str(e))
+            event.defer()
+            raise sunbeam_guard.WaitingExceptionError(
+                f"Cluster service unavailable, update of cluster network to {cluster_net} pending"
+            )
+        except UnrecognizedClusterConfigOption as e:
+            # Not transient: the running microceph rejects the option, so
+            # deferring would retry forever. Block until the operator unsets.
+            raise sunbeam_guard.BlockedExceptionError(
+                f"microceph rejected cluster_network ({e}), unset {CLUSTER_NETWORK_CONFIG}"
+            )
+        self.leader_set({CLUSTER_NETWORK_CONFIG: json.dumps(configured)})
 
     def handle_config_leader_ceph_pool_pgs(self, event) -> None:
         """Configure Ceph."""

--- a/src/utils.py
+++ b/src/utils.py
@@ -170,3 +170,36 @@ def get_fsid():
         for line in f:
             if line.startswith("fsid") and "=" in line:
                 return line.split("=")[1].strip()
+
+
+def split_space_or_comma(s: str) -> list[str]:
+    """Split on spaces and/or commas, ignoring empty tokens."""
+    return [item for item in s.replace(",", " ").split() if item]
+
+
+def parse_networks(value: str) -> list[str]:
+    """Parse a space- or comma-delimited list of subnets into canonical form.
+
+    Each entry is canonicalised and duplicates are dropped, but the operator's
+    entry order is preserved: microceph picks the FIRST listed subnet that has
+    a local address (FindIpOnSubnet), so on a multi-homed host the order is
+    a priority the operator chose. Callers comparing parsed values for change
+    detection must therefore compare them order-insensitively themselves.
+
+    :param value: subnets as given by the operator, e.g. "10.0.0.0/24 10.0.1.0/24"
+    :raises ValueError: naming the offending entry, if any entry is not a subnet
+        with a prefix length and no host bits set.
+    """
+    networks = []
+    for token in split_space_or_comma(value):
+        # ip_network() accepts a bare address as a host route (/32, /128), which
+        # is never what an operator means by a Ceph network. Require the prefix.
+        if "/" not in token:
+            raise ValueError(f"'{token}' has no prefix length, expected e.g. 192.168.0.0/24")
+        try:
+            networks.append(ipaddress.ip_network(token))
+        except ValueError as e:
+            raise ValueError(f"'{token}' is not a valid subnet: {e}")
+    # dict.fromkeys: dedup (respelled entries collapse once canonicalised)
+    # while keeping first-seen order.
+    return [str(net) for net in dict.fromkeys(networks)]

--- a/tests/integration/test_network_config.py
+++ b/tests/integration/test_network_config.py
@@ -1,0 +1,582 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the configurable network options (spec CE147).
+
+``ceph-public-network`` and ``ceph-cluster-network`` let the operator hand the
+charm the full subnet list a deployment spans, instead of the charm
+auto-selecting the single subnet the leader happens to sit on:
+
+* ``ceph-public-network`` is consumed exactly once, at cluster bootstrap
+  (``microceph cluster bootstrap --public-network``). microceph marks
+  ``public_network`` read-only on a running cluster, so the charm blocks every
+  unit when the option changes after bootstrap; reverting the option (any
+  spelling of the same subnet set) recovers the application.
+* ``ceph-cluster-network`` is applied at bootstrap and reconciled on every
+  config change. Clearing it after it was set reverts the cluster network to
+  the leader's subnet in the ``cluster`` space - the same fallback used when
+  the option was never set.
+
+How these tests observe the live cluster
+-----------------------------------------
+microceph applies both values with ``ceph config set global <key> <value>``
+(at bootstrap via ``BootstrapCephConfigs``, at runtime via its cluster-config
+API), so ``ceph config get mon <key>`` on any unit returns exactly the string
+microceph applied. That is the read-back used throughout: it proves the
+operator's value reached Ceph itself, not merely the charm's own bookkeeping.
+
+Why the machines' subnet is split into halves
+---------------------------------------------
+On a single-network model the charm's space-subnet fallback resolves to the
+machines' provider subnet (for example ``10.x.y.0/24``), so configuring that
+same ``/24`` would be indistinguishable from the charm silently ignoring the
+option. Instead, the fixtures split the provider subnet into its two ``/25``
+halves and configure those. That yields:
+
+* values the fallback could never produce, so every read-back below proves the
+  configured value was really consumed;
+* a genuine multi-subnet, mixed-delimiter list - the exact input shape CE147
+  adds (microceph accepts a unit as long as it holds an address on ANY listed
+  subnet, and every machine here holds an address on one of the halves);
+* observable order preservation - subnet order is an address-selection
+  priority in microceph (``FindIpOnSubnet`` is first-match-wins), so the charm
+  must forward the list exactly as the operator wrote it, only canonicalised
+  to comma-separated form.
+
+Test ordering
+-------------
+The module deploys one three-unit cluster (LXD containers; OSDs are not needed
+to exercise network configuration) and the tests walk one dependent story in
+file order:
+
+1. bootstrap consumes both options;
+2. a public-network change blocks every unit and a revert recovers;
+3. a malformed value blocks and a revert recovers;
+4. a cluster-network change is applied to the running cluster;
+5. clearing the cluster network reverts it to the space fallback.
+
+Each test returns the model to the healthy state the next test expects, so a
+failure points at the step that actually broke.
+
+The deploy pins ``snap-channel`` to the squid channel carrying multi-subnet
+network flag support (see ``SNAP_CHANNEL`` below).
+"""
+
+import ipaddress
+import json
+import logging
+import time
+from pathlib import Path
+from typing import NamedTuple
+
+import jubilant
+import pytest
+import yaml
+
+from tests import helpers
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+APP_NAME = METADATA["name"]
+PUBLIC_OPTION = "ceph-public-network"
+CLUSTER_OPTION = "ceph-cluster-network"
+NUM_UNITS = 3
+# Must match the base of the charm artifact the microceph_charm fixture
+# resolves (microceph_ubuntu-24.04-amd64.charm).
+MACHINE_BASE = "ubuntu@24.04"
+SNAP_CHANNEL = "squid/stable"
+
+MACHINES_TIMEOUT = 900
+DEPLOY_TIMEOUT = 2400
+BLOCK_TIMEOUT = 600
+RECOVER_TIMEOUT = 900
+CONFIG_APPLY_TIMEOUT = 600
+QUORUM_TIMEOUT = 300
+
+
+class NetworkLayout(NamedTuple):
+    """The addressing plan derived from the machines' provider subnet.
+
+    ``public_config``/``cluster_config`` are the option values as an operator
+    would type them (mixed delimiters, cluster list deliberately reversed);
+    the ``*_canonical`` fields are the comma-joined forms the charm forwards
+    to microceph and therefore what ``ceph config get`` must return.
+    """
+
+    machines: list[str]
+    subnet: ipaddress.IPv4Network
+    halves: tuple[ipaddress.IPv4Network, ipaddress.IPv4Network]
+    public_config: str
+    public_canonical: str
+    cluster_config: str
+    cluster_canonical: str
+
+
+def _ipv4_addresses(machine: jubilant.statustypes.MachineStatus) -> list[ipaddress.IPv4Address]:
+    """Return the machine's IPv4 addresses, ignoring IPv6 and unparsable entries."""
+    addresses = []
+    for raw in machine.ip_addresses:
+        try:
+            address = ipaddress.ip_address(raw)
+        except ValueError:
+            continue
+        if address.version == 4:
+            addresses.append(address)
+    return addresses
+
+
+def _wait_for_started_machines(
+    juju: jubilant.Juju, count: int, *, timeout: int = MACHINES_TIMEOUT, interval: int = 10
+) -> dict[str, list[ipaddress.IPv4Address]]:
+    """Wait until *count* machines are started with an IPv4 address each.
+
+    The machines' addresses must exist before the app is deployed because the
+    network options are computed from them and must be present at deploy time
+    (bootstrap consumes ``ceph-public-network`` and cannot retrofit it).
+    """
+    deadline = time.time() + timeout
+    machines: dict[str, list[ipaddress.IPv4Address]] = {}
+    while time.time() < deadline:
+        status = juju.status()
+        # Fail fast on a machine stuck in an explicit failure state rather
+        # than burning the whole timeout on it.
+        broken = {
+            name: machine.machine_status.message or machine.juju_status.current
+            for name, machine in status.machines.items()
+            if "failed" in (machine.juju_status.current, machine.machine_status.current)
+            or machine.machine_status.current == "error"
+        }
+        if broken:
+            raise AssertionError(f"machine provisioning failed: {broken}")
+        machines = {
+            name: _ipv4_addresses(machine)
+            for name, machine in status.machines.items()
+            if machine.juju_status.current == "started"
+        }
+        ready = {name: addrs for name, addrs in machines.items() if addrs}
+        if len(ready) >= count:
+            return ready
+        time.sleep(interval)
+    raise AssertionError(
+        f"Timed out waiting for {count} started machines with IPv4 addresses; last: {machines}"
+    )
+
+
+def _provider_ipv4_subnets(juju: jubilant.Juju) -> list[ipaddress.IPv4Network]:
+    """Return the model's known IPv4 subnets, with their true prefix lengths.
+
+    ``juju subnets`` reports the provider CIDRs, so the layout does not have to
+    assume the substrate uses a /24.
+    """
+    raw = json.loads(juju.cli("subnets", "--format", "json"))
+    subnets = []
+    for cidr, info in raw.get("subnets", {}).items():
+        if info.get("type") == "ipv4":
+            subnets.append(ipaddress.ip_network(cidr))
+    return subnets
+
+
+def _shared_subnet(
+    subnets: list[ipaddress.IPv4Network],
+    machines: dict[str, list[ipaddress.IPv4Address]],
+) -> ipaddress.IPv4Network:
+    """Return the one subnet the test machines are actually on.
+
+    ``juju subnets`` reports every network the host knows about, not just the
+    one containers attach to. On a typical LXD host that is three or more
+    entries, for example::
+
+        10.141.192.0/24   lxdbr0    <- the containers actually live here
+        10.56.203.0/24    mpqemubr0 (multipass bridge)
+        172.17.0.0/16     docker0
+
+    The machines' own addresses tell the candidates apart: a subnet is kept
+    only if EVERY machine has at least one address inside it. In the example,
+    no machine has an address on the multipass or docker bridges, so only the
+    lxdbr0 subnet survives.
+
+    If nothing survives (the provider scattered the machines across different
+    bridges), no meaningful layout can be built, so fail right away with the
+    evidence instead of deploying and failing confusingly later.
+
+    More than one subnet can survive only when the reported subnets nest, for
+    example both 10.141.0.0/16 and 10.141.192.0/24: every machine is "on"
+    both. In that case pick the narrowest (largest prefix length, /24 over
+    /16), because that is the subnet Juju reports on the unit's own network
+    binding - and therefore exactly what the charm's space fallback resolves
+    to. The clear-reverts-to-fallback test compares against this value, so
+    the layout's notion of "the subnet" must match the charm's. The network
+    address is only an arbitrary-but-deterministic tiebreak. On a plain
+    single-bridge setup exactly one subnet survives and the sort changes
+    nothing; the log line makes the rarer nested case visible.
+    """
+    shared = [
+        subnet
+        for subnet in subnets
+        # "does every machine have an address on this subnet?"
+        if all(any(addr in subnet for addr in addrs) for addrs in machines.values())
+    ]
+    if not shared:
+        raise AssertionError(
+            f"no provider subnet contains an address of every machine; "
+            f"subnets={subnets} machines={machines}"
+        )
+    # Narrowest subnet first: -prefixlen sorts /24 before /16.
+    shared.sort(key=lambda net: (-net.prefixlen, net.network_address))
+    if len(shared) > 1:
+        logger.info("Multiple shared subnets %s; using most specific %s", shared, shared[0])
+    return shared[0]
+
+
+def _ceph_config_get(juju: jubilant.Juju, unit: str, key: str) -> str:
+    """Read *key* from Ceph's central config store on *unit*.
+
+    microceph applies both network options with ``ceph config set global``,
+    and the ``global`` section is inherited by every daemon type, so asking
+    the ``mon`` entity returns the value verbatim. An unset key reads back as
+    an empty string.
+    """
+    return juju.ssh(unit, "sudo", "microceph.ceph", "config", "get", "mon", key).strip()
+
+
+def _wait_for_ceph_config(
+    juju: jubilant.Juju,
+    unit: str,
+    key: str,
+    expected: str,
+    *,
+    timeout: int = CONFIG_APPLY_TIMEOUT,
+    interval: int = 10,
+) -> None:
+    """Poll Ceph's config store until *key* reads back as *expected*.
+
+    The charm applies cluster-network changes inside the config-changed hook,
+    but hook scheduling is asynchronous with the test process, so read-backs
+    poll instead of asserting immediately. The poll fails fast if the app
+    reports an explicit failure state (blocked/error) instead of burning the
+    whole timeout on a change that will never be applied.
+    """
+    deadline = time.time() + timeout
+    last = "<unread>"
+    while time.time() < deadline:
+        reasons = helpers.status_failure_reasons(juju.status(), APP_NAME)
+        if reasons:
+            raise AssertionError(f"aborting wait for {key}={expected!r}: {'; '.join(reasons)}")
+        try:
+            last = _ceph_config_get(juju, unit, key)
+        except jubilant.CLIError as exc:
+            # A transient ssh failure must not fail the wait: keep polling.
+            logger.info("reading %s failed (%s); retrying", key, exc)
+        else:
+            if last == expected:
+                return
+        time.sleep(interval)
+    raise AssertionError(f"{key} never became {expected!r}; last read-back: {last!r}")
+
+
+def _wait_for_all_units_blocked(
+    juju: jubilant.Juju, app: str, *fragments: str, timeout: int = BLOCK_TIMEOUT
+) -> None:
+    """Wait until every unit of *app* is blocked with all *fragments* in its message.
+
+    The config checks run on every unit (not only the leader), so a violation
+    must block the whole application - asserting on all units pins exactly
+    that behavior.
+    """
+
+    def _blocked(status: jubilant.Status) -> bool:
+        units = status.apps[app].units
+        return bool(units) and all(
+            unit.workload_status.current == "blocked"
+            and all(fragment in (unit.workload_status.message or "") for fragment in fragments)
+            for unit in units.values()
+        )
+
+    with helpers.fast_forward(juju):
+        juju.wait(_blocked, error=jubilant.any_error, timeout=timeout)
+
+
+def _charm_hook_error(status: jubilant.Status) -> bool:
+    """True when a unit reports an unhandled charm exception.
+
+    A charm bug surfaces as blocked "Error in charm (see logs)" with the agent
+    idle, which neither ``jubilant.any_error`` nor an active-wait would catch
+    until the full timeout expired. Never true for the charm's intentional
+    blocked states, whose messages name the offending config instead.
+    """
+    app = status.apps.get(APP_NAME)
+    return bool(app) and any(
+        unit.workload_status.current == "blocked"
+        and "Error in charm" in (unit.workload_status.message or "")
+        for unit in app.units.values()
+    )
+
+
+def _wait_for_active(juju: jubilant.Juju, timeout: int) -> None:
+    """Wait for every unit to reach active, failing fast on charm errors."""
+    with helpers.fast_forward(juju):
+        juju.wait(
+            lambda status: jubilant.all_active(status, APP_NAME),
+            error=lambda status: jubilant.any_error(status) or _charm_hook_error(status),
+            timeout=timeout,
+        )
+
+
+def _wait_for_recovery(juju: jubilant.Juju) -> None:
+    """Wait for the application to reconcile back to active on every unit."""
+    _wait_for_active(juju, RECOVER_TIMEOUT)
+
+
+def _wait_for_mon_quorum(
+    juju: jubilant.Juju, expected: int, *, timeout: int = QUORUM_TIMEOUT, interval: int = 15
+) -> None:
+    """Wait until *expected* monitors are in quorum.
+
+    Units join the cluster (and enable their mon) before the charm settles, but
+    quorum membership is reported asynchronously; poll briefly, failing fast if
+    the app falls into an explicit failure state (blocked/error) meanwhile.
+    """
+    deadline = time.time() + timeout
+    quorum: list = []
+    while time.time() < deadline:
+        reasons = helpers.status_failure_reasons(juju.status(), APP_NAME)
+        if reasons:
+            raise AssertionError(f"aborting wait for mon quorum: {'; '.join(reasons)}")
+        ceph_status = helpers.fetch_ceph_status(juju, APP_NAME)
+        quorum = ceph_status.get("quorum_names") or []
+        if len(quorum) >= expected:
+            return
+        time.sleep(interval)
+    raise AssertionError(f"expected {expected} mons in quorum, got {quorum}")
+
+
+@pytest.fixture(scope="module")
+def network_layout(juju: jubilant.Juju) -> NetworkLayout:
+    """Compute the addressing plan from freshly provisioned machines.
+
+    Machines are added before the deploy because ``ceph-public-network`` only
+    applies at bootstrap: the option value must exist when ``juju deploy``
+    runs, and it can only be derived from addresses the substrate actually
+    assigned. The machines' shared provider subnet is split into its two
+    halves; every machine necessarily holds an address on exactly one half, so
+    the halves form a valid multi-subnet configuration for both options.
+    """
+    logger.info("Provisioning %d machines to discover the provider subnet", NUM_UNITS)
+    juju.add_machine(base=MACHINE_BASE, num_machines=NUM_UNITS)
+    machines = _wait_for_started_machines(juju, NUM_UNITS)
+
+    subnet = _shared_subnet(_provider_ipv4_subnets(juju), machines)
+    if subnet.prefixlen > 28:
+        raise AssertionError(f"provider subnet {subnet} is too small to split into halves")
+    lower, upper = subnet.subnets(prefixlen_diff=1)
+
+    layout = NetworkLayout(
+        machines=sorted(machines, key=int),
+        subnet=subnet,
+        halves=(lower, upper),
+        # The operator's spelling: comma-delimited for the public network,
+        # space-delimited and deliberately in reversed order for the cluster
+        # network. Both delimiters are supported, and the order must survive
+        # into microceph because it is an address-selection priority there.
+        public_config=f"{lower},{upper}",
+        public_canonical=f"{lower},{upper}",
+        cluster_config=f"{upper} {lower}",
+        cluster_canonical=f"{upper},{lower}",
+    )
+    logger.info(
+        "Machines %s on %s; halves %s; per-machine addresses %s",
+        layout.machines,
+        subnet,
+        layout.halves,
+        machines,
+    )
+    return layout
+
+
+@pytest.fixture(scope="module")
+def network_cluster(
+    juju: jubilant.Juju, microceph_charm: Path, network_layout: NetworkLayout
+) -> NetworkLayout:
+    """Deploy microceph onto the pre-provisioned machines with both options set."""
+    logger.info(
+        "Deploying %s with %s=%r %s=%r",
+        APP_NAME,
+        PUBLIC_OPTION,
+        network_layout.public_config,
+        CLUSTER_OPTION,
+        network_layout.cluster_config,
+    )
+    juju.deploy(
+        str(microceph_charm),
+        APP_NAME,
+        num_units=NUM_UNITS,
+        to=network_layout.machines,
+        config={
+            "snap-channel": SNAP_CHANNEL,
+            PUBLIC_OPTION: network_layout.public_config,
+            CLUSTER_OPTION: network_layout.cluster_config,
+        },
+    )
+    _wait_for_active(juju, DEPLOY_TIMEOUT)
+    return network_layout
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.smoke
+def test_bootstrap_applies_configured_networks(
+    juju: jubilant.Juju, network_cluster: NetworkLayout
+) -> None:
+    """Bootstrap must consume both options and hand them to Ceph verbatim.
+
+    The values read back from Ceph's config store are the split halves, which
+    the space-subnet fallback could never produce, so a match proves the
+    config flowed charm -> microceph bootstrap -> Ceph. The read-back must
+    also preserve the operator's subnet order (only canonicalised to commas):
+    order is an address-selection priority in microceph. Finally, all three
+    mons must reach quorum - every unit joined a cluster whose public network
+    is the multi-subnet list, and microceph validates each joiner holds an
+    address on one of the listed subnets.
+    """
+    layout = network_cluster
+    status = juju.status()
+    assert jubilant.all_active(status, APP_NAME)
+
+    unit = helpers.first_unit_name(status, APP_NAME)
+    assert _ceph_config_get(juju, unit, "public_network") == layout.public_canonical
+    assert _ceph_config_get(juju, unit, "cluster_network") == layout.cluster_canonical
+
+    _wait_for_mon_quorum(juju, NUM_UNITS)
+
+
+@pytest.mark.smoke
+def test_public_network_change_after_bootstrap_blocks(
+    juju: jubilant.Juju, network_cluster: NetworkLayout
+) -> None:
+    """A post-bootstrap public-network change blocks; reverting recovers.
+
+    microceph cannot apply a new ``public_network`` to a running cluster, so
+    the only honest behaviors are to block (change) or stay active (no
+    change). This test pins four properties:
+
+    * every unit blocks, not only the leader (the check runs everywhere);
+    * the blocked message names the recorded value, which is the operator's
+      only way out;
+    * the live cluster keeps the bootstrap value while blocked;
+    * reverting recovers even when the revert respells the same subnet set
+      (reordered, different delimiters) - comparison is on the canonical
+      parsed set, not the raw string.
+    """
+    layout = network_cluster
+    unit = helpers.first_unit_name(juju.status(), APP_NAME)
+
+    # TEST-NET-1 (RFC 5737): guaranteed not to collide with the substrate.
+    foreign = "192.0.2.0/24"
+    assert not layout.subnet.overlaps(ipaddress.ip_network(foreign))
+
+    juju.config(APP_NAME, {PUBLIC_OPTION: foreign})
+    _wait_for_all_units_blocked(
+        juju,
+        APP_NAME,
+        f"{PUBLIC_OPTION} cannot be changed after bootstrap",
+        layout.public_canonical,
+    )
+    assert _ceph_config_get(juju, unit, "public_network") == layout.public_canonical
+
+    # Same subnet set, respelled: reversed order, comma+space delimiters and
+    # surrounding whitespace. This must count as "unchanged" and recover.
+    respelled = f" {layout.halves[1]}, {layout.halves[0]} "
+    juju.config(APP_NAME, {PUBLIC_OPTION: respelled})
+    _wait_for_recovery(juju)
+    assert _ceph_config_get(juju, unit, "public_network") == layout.public_canonical
+
+
+@pytest.mark.smoke
+def test_invalid_network_value_blocks_and_recovers(
+    juju: jubilant.Juju, network_cluster: NetworkLayout
+) -> None:
+    """A malformed subnet blocks the application and names the bad entry.
+
+    Validation must reject the whole value rather than silently dropping the
+    bad entry: a typo that half-applied would leave the cluster on a subset of
+    the intended networks. The message names the offending token so the
+    operator can fix exactly that. Reverting to the previously applied value
+    recovers without touching the running cluster (the charm's reconcile diffs
+    against what is already applied).
+    """
+    layout = network_cluster
+    unit = helpers.first_unit_name(juju.status(), APP_NAME)
+
+    juju.config(APP_NAME, {CLUSTER_OPTION: f"{layout.halves[0]} bogus/24"})
+    _wait_for_all_units_blocked(juju, APP_NAME, f"Invalid config {CLUSTER_OPTION}", "bogus/24")
+    # The rejected value must not have leaked into the running cluster.
+    assert _ceph_config_get(juju, unit, "cluster_network") == layout.cluster_canonical
+
+    juju.config(APP_NAME, {CLUSTER_OPTION: layout.cluster_config})
+    _wait_for_recovery(juju)
+    assert _ceph_config_get(juju, unit, "cluster_network") == layout.cluster_canonical
+
+
+@pytest.mark.smoke
+def test_cluster_network_reconfigure_applies_live(
+    juju: jubilant.Juju, network_cluster: NetworkLayout
+) -> None:
+    """Changing ceph-cluster-network reconfigures the running cluster.
+
+    Unlike the public network, the cluster network is mutable after bootstrap:
+    the leader reconciles it on config-changed through microceph's
+    cluster-config API (which is what restarts the affected daemons - the
+    "momentary service disruption" the option's description warns about; no
+    OSDs are deployed here so the restart set is empty). Narrowing from the
+    bootstrap-time two-subnet list to a single half is a real value change and
+    must reach Ceph's config store.
+
+    Note microceph does not re-validate subnet membership on runtime changes
+    (only at bootstrap/join), so this passes regardless of which half the
+    containers' addresses landed on.
+    """
+    layout = network_cluster
+    unit = helpers.first_unit_name(juju.status(), APP_NAME)
+
+    target = str(layout.halves[0])
+    assert target != layout.cluster_canonical
+    juju.config(APP_NAME, {CLUSTER_OPTION: target})
+
+    _wait_for_recovery(juju)
+    _wait_for_ceph_config(juju, unit, "cluster_network", target)
+
+
+@pytest.mark.smoke
+def test_cluster_network_clear_reverts_to_space_fallback(
+    juju: jubilant.Juju, network_cluster: NetworkLayout
+) -> None:
+    """Clearing ceph-cluster-network reverts to the cluster-space subnet.
+
+    "Cleared after being set" must be distinguishable from "never set": the
+    charm tracks the last value it applied, and on clearing reverts the
+    cluster network to the leader's subnet in the ``cluster`` space instead of
+    leaving the operator's last custom value in place. On this single-network
+    model that fallback is the machines' full provider subnet - a value
+    different from the half applied by the previous test, so the read-back
+    proves the revert really happened rather than nothing at all.
+    """
+    layout = network_cluster
+    unit = helpers.first_unit_name(juju.status(), APP_NAME)
+
+    fallback = str(layout.subnet)
+    assert fallback != str(layout.halves[0])
+    juju.config(APP_NAME, {CLUSTER_OPTION: ""})
+
+    _wait_for_recovery(juju)
+    _wait_for_ceph_config(juju, unit, "cluster_network", fallback)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -14,18 +14,25 @@
 
 """Tests for Microceph charm."""
 
+import ipaddress
 import json
 from pathlib import Path
 from subprocess import CalledProcessError, TimeoutExpired
 from unittest.mock import MagicMock, PropertyMock, call, mock_open, patch
 
+import ops_sunbeam.guard as sunbeam_guard
 import ops_sunbeam.test_utils as test_utils
 from charms.ceph_mon.v0 import ceph_cos_agent
+from ops.model import BlockedStatus
 from unit import testbase
 
 import charm
 import microceph
-from microceph_client import MaintenanceOperationFailedException
+from microceph_client import (
+    ClusterServiceUnavailableException,
+    MaintenanceOperationFailedException,
+    UnrecognizedClusterConfigOption,
+)
 
 
 class TestCharm(testbase.TestBaseCharm):
@@ -34,18 +41,7 @@ class TestCharm(testbase.TestBaseCharm):
     def setUp(self):
         """Setup MicroCeph Charm tests."""
         super().setUp(charm, self.PATCHES)
-        with open("config.yaml", "r") as f:
-            config_data = f.read()
-        with open("metadata.yaml", "r") as f:
-            metadata = f.read()
-        self.harness = test_utils.get_harness(
-            testbase._MicroCephCharm,
-            container_calls=self.container_calls,
-            charm_config=config_data,
-            charm_metadata=metadata,
-        )
-        self.addCleanup(self.harness.cleanup)
-        self.harness.begin()
+        self.init_harness()
 
     @patch("charm.gethostname", return_value="host-a")
     @patch.object(microceph, "remove_cluster_member")
@@ -1610,3 +1606,503 @@ class TestCharm(testbase.TestBaseCharm):
             micro_ip="10.0.0.10",
             availability_zone="az-1",
         )
+
+
+class TestNetworkConfig(testbase.TestBaseCharm):
+    """Tests for ceph-public-network and ceph-cluster-network."""
+
+    PATCHES = ["subprocess"]
+
+    def setUp(self):
+        """Setup MicroCeph Charm tests."""
+        super().setUp(charm, self.PATCHES)
+        self.init_harness()
+
+    def set_config(self, config: dict) -> None:
+        """Update config without running the config-changed hook."""
+        self.harness.disable_hooks()
+        self.harness.update_config(config)
+        self.harness.enable_hooks()
+
+    @patch.object(ceph_cos_agent, "ceph_utils")
+    @patch("ceph.enable_ceph_monitoring")
+    @patch.object(microceph, "update_cluster_configs")
+    @patch.object(microceph, "is_ready")
+    @patch.object(microceph, "Client")
+    @patch("utils.subprocess")
+    @patch.object(Path, "chmod")
+    @patch.object(Path, "write_bytes")
+    @patch("builtins.open", new_callable=mock_open, read_data="mon host dummy-ip")
+    @patch("microceph._az_flag_supported", new=lambda: False)
+    def test_bootstrap_uses_configured_networks(
+        self,
+        _mock_file,
+        _mock_path_wb,
+        _mock_path_chmod,
+        subprocess,
+        cclient,
+        is_ready,
+        update_cluster_configs,
+        _enable_ceph_monitoring,
+        _utils,
+    ):
+        """Configured networks override the leader's space subnets at bootstrap.
+
+        Regression: _get_bootstrap_params looked the options up by space name
+        ("public") rather than config key ("ceph-public-network"), so the config
+        always read back empty and the space subnet fallback always won.
+        """
+        cclient.from_socket().cluster.list_services.return_value = []
+        is_ready.return_value = True
+
+        self.harness.set_leader()
+        rel_id = self.add_complete_peer_relation(self.harness)
+        self.harness.update_config(
+            {
+                # Deliberately mixed delimiters: both forms are supported.
+                # The cluster list is deliberately not in sorted order: entry
+                # order is an address-selection priority to microceph and must
+                # reach it exactly as the operator wrote it.
+                "ceph-public-network": "10.5.0.0/24,10.5.1.0/24",
+                "ceph-cluster-network": "10.6.1.0/24 10.6.0.0/24",
+            }
+        )
+
+        subprocess.run.assert_any_call(
+            [
+                "microceph",
+                "cluster",
+                "bootstrap",
+                "--public-network",
+                "10.5.0.0/24,10.5.1.0/24",
+                "--cluster-network",
+                "10.6.1.0/24,10.6.0.0/24",
+                "--microceph-ip",
+                "10.0.0.10",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=180,
+        )
+
+        # The applied public network is recorded so later changes can be caught.
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertEqual(json.loads(app_data["ceph-public-network"]), "10.5.0.0/24,10.5.1.0/24")
+
+        # cluster_network is reconciled post-bootstrap; unchanged here, so
+        # update_cluster_configs finds nothing to do (it diffs internally).
+        update_cluster_configs.assert_called_once_with(
+            {"cluster_network": "10.6.1.0/24,10.6.0.0/24"}
+        )
+        # The reconciled cluster network is recorded too, so a later clearing
+        # of the option can revert to the fallback subnet.
+        self.assertEqual(json.loads(app_data["ceph-cluster-network"]), "10.6.1.0/24,10.6.0.0/24")
+
+        # cluster_network stays reconcilable post-bootstrap: a later config
+        # change must reach microceph end-to-end, without a new bootstrap.
+        update_cluster_configs.reset_mock()
+        self.harness.update_config({"ceph-cluster-network": "10.8.0.0/24"})
+        update_cluster_configs.assert_called_once_with({"cluster_network": "10.8.0.0/24"})
+
+    @patch.object(ceph_cos_agent, "ceph_utils")
+    @patch("ceph.enable_ceph_monitoring")
+    @patch.object(microceph, "is_ready")
+    @patch.object(microceph, "Client")
+    @patch("utils.subprocess")
+    @patch.object(Path, "chmod")
+    @patch.object(Path, "write_bytes")
+    @patch("builtins.open", new_callable=mock_open, read_data="mon host dummy-ip")
+    @patch("microceph._az_flag_supported", new=lambda: False)
+    def test_public_network_change_after_bootstrap_blocks(
+        self,
+        _mock_file,
+        _mock_path_wb,
+        _mock_path_chmod,
+        _subprocess,
+        cclient,
+        is_ready,
+        _enable_ceph_monitoring,
+        _utils,
+    ):
+        """Changing public_network after bootstrap must block the charm.
+
+        microceph cannot apply a new public_network to a running cluster, and
+        silently ignoring the change would leave the operator believing it took
+        effect.
+
+        The charm must reach a steady state before config is mutated: a handler
+        that defers config-changed leaves the notice queued, and ops then skips
+        _on_config_changed on every later emission of that event.
+        """
+        cclient.from_socket().cluster.list_services.return_value = []
+        is_ready.return_value = True
+
+        self.harness.set_leader()
+        self.add_complete_peer_relation(self.harness)
+        self.harness.update_config({"ceph-public-network": "10.5.0.0/24 10.5.1.0/24"})
+
+        # Re-setting the same subnet set (different delimiters and order) is
+        # not a change: comparison is on the canonical parsed form.
+        self.harness.update_config({"ceph-public-network": " 10.5.1.0/24, 10.5.0.0/24 "})
+        self.assertNotIsInstance(self.harness.charm.status.status, BlockedStatus)
+
+        self.harness.update_config({"ceph-public-network": "10.9.0.0/24"})
+        status = self.harness.charm.status.status
+        self.assertIsInstance(status, BlockedStatus)
+        self.assertIn("ceph-public-network cannot be changed after bootstrap", status.message)
+        # The message names the recorded value, the only way to unblock.
+        self.assertIn("10.5.0.0/24,10.5.1.0/24", status.message)
+
+        # Blocked is durable: a relation handler reconciling via
+        # configure_charm directly must not flip the unit back to active.
+        self.harness.charm.configure_charm(MagicMock())
+        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+
+        # Also durable through a real relation event dispatch, which calls
+        # configure_charm without passing through _on_config_changed.
+        self.add_complete_identity_relation(self.harness)
+        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+
+        # Reverting to the bootstrapped value recovers the unit.
+        self.harness.update_config({"ceph-public-network": "10.5.0.0/24 10.5.1.0/24"})
+        self.assertNotIsInstance(self.harness.charm.status.status, BlockedStatus)
+
+        # Clearing the option is also a change: the cluster keeps the network
+        # it bootstrapped with, so pretending to unset it must block too.
+        self.harness.update_config({"ceph-public-network": ""})
+        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+
+    @patch.object(ceph_cos_agent, "ceph_utils")
+    @patch("ceph.enable_ceph_monitoring")
+    @patch.object(microceph, "is_ready")
+    @patch.object(microceph, "Client")
+    @patch("utils.subprocess")
+    @patch.object(Path, "chmod")
+    @patch.object(Path, "write_bytes")
+    @patch("builtins.open", new_callable=mock_open, read_data="mon host dummy-ip")
+    @patch("microceph._az_flag_supported", new=lambda: False)
+    def test_public_network_change_blocks_non_leader(
+        self,
+        _mock_file,
+        _mock_path_wb,
+        _mock_path_chmod,
+        _subprocess,
+        cclient,
+        is_ready,
+        _enable_ceph_monitoring,
+        _utils,
+    ):
+        """The post-bootstrap check runs on every unit, not only the leader."""
+        cclient.from_socket().cluster.list_services.return_value = []
+        is_ready.return_value = True
+
+        self.harness.set_leader()
+        self.add_complete_peer_relation(self.harness)
+        self.harness.update_config({"ceph-public-network": "10.5.0.0/24"})
+
+        self.harness.set_leader(False)
+        self.harness.update_config({"ceph-public-network": "10.9.0.0/24"})
+        status = self.harness.charm.status.status
+        self.assertIsInstance(status, BlockedStatus)
+        self.assertIn("ceph-public-network cannot be changed after bootstrap", status.message)
+
+    @patch.object(ceph_cos_agent, "ceph_utils")
+    @patch("ceph.enable_ceph_monitoring")
+    @patch.object(microceph, "is_ready")
+    @patch.object(microceph, "Client")
+    @patch("utils.subprocess")
+    def test_upgrade_records_never_applied_baseline(
+        self, _subprocess, cclient, is_ready, _enable_ceph_monitoring, _utils
+    ):
+        """A cluster bootstrapped before the option existed records "" as baseline.
+
+        On charm upgrade the recording key is absent while the cluster is
+        already bootstrapped; whatever the option reads as at that point was
+        never consumed by bootstrap, so recording it would let an unapplied
+        value masquerade as applied.
+        """
+        cclient.from_socket().cluster.list_services.return_value = []
+        is_ready.return_value = True
+        self.harness.set_leader()
+        rel_id = self.add_complete_peer_relation(self.harness)
+        self.harness.update_relation_data(
+            rel_id, self.harness.charm.app.name, {"leader_ready": "true"}
+        )
+        # The operator sets the option at upgrade time, hoping it applies.
+        self.set_config({"ceph-public-network": "10.9.0.0/24"})
+
+        self.harness.charm.handle_config_leader_set_ready()
+
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertEqual(json.loads(app_data["ceph-public-network"]), "")
+
+        # And the pending value now blocks instead of pretending it applied.
+        self.harness.update_config({"ceph-public-network": "10.8.0.0/24"})
+        self.assertIsInstance(self.harness.charm.status.status, BlockedStatus)
+
+    def test_record_applied_public_network_first_write_wins(self):
+        """A re-run after the option changed must not overwrite the baseline.
+
+        Retried hooks and repeated adopt events re-reach the recording; the
+        baseline has to keep describing what bootstrap actually consumed.
+        """
+        self.harness.set_leader()
+        rel_id = self.add_complete_peer_relation(self.harness)
+        self.set_config({"ceph-public-network": "10.5.0.0/24"})
+        self.harness.charm._record_applied_public_network()
+
+        self.set_config({"ceph-public-network": "10.9.0.0/24"})
+        self.harness.charm._record_applied_public_network()
+
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertEqual(json.loads(app_data["ceph-public-network"]), "10.5.0.0/24")
+
+    def test_quincy_with_network_config_blocks(self):
+        """Quincy snaps cannot apply the network options; block, don't ignore.
+
+        Bootstrapping anyway would silently drop the operator's networks and
+        record a baseline claiming they were applied.
+        """
+        self.set_config({"ceph-public-network": "10.5.0.0/24"})
+        with patch("charm.snap.SnapCache") as cache:
+            cache.return_value.__getitem__.return_value.channel = "quincy/stable"
+            with self.assertRaises(sunbeam_guard.BlockedExceptionError) as ctx:
+                self.harness.charm._get_bootstrap_params()
+        self.assertIn("quincy", str(ctx.exception))
+
+    def test_quincy_without_network_config_bootstraps_bare(self):
+        """Unset options keep the pre-existing quincy behavior: no params.
+
+        Whitespace-only values parse to no subnets and must count as unset
+        here too, like everywhere else the options are read.
+        """
+        for value in ("", " , "):
+            with self.subTest(value=value):
+                self.set_config({"ceph-public-network": value})
+                with patch("charm.snap.SnapCache") as cache:
+                    cache.return_value.__getitem__.return_value.channel = "quincy/stable"
+                    self.assertEqual(self.harness.charm._get_bootstrap_params(), {})
+
+    @patch.object(microceph, "adopt_ceph_cluster")
+    def test_adopt_records_public_network_baseline(self, adopt):
+        """The adopt path records the consumed option, like the bootstrap path."""
+        adopt.return_value = {}
+        self.harness.set_leader()
+        rel_id = self.add_complete_peer_relation(self.harness)
+        self.set_config({"ceph-public-network": "10.5.0.0/24"})
+
+        self.harness.charm.adopt_cluster("fsid", ["10.0.0.1"], "key")
+
+        self.assertEqual(
+            adopt.call_args.kwargs["public_net"],
+            "10.5.0.0/24",
+        )
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertEqual(json.loads(app_data["ceph-public-network"]), "10.5.0.0/24")
+
+    @patch.object(microceph, "adopt_ceph_cluster")
+    def test_adopt_retry_records_baseline_when_already_bootstrapped(self, adopt):
+        """A retried adopt hook must still record the baseline.
+
+        Without it, handle_config_leader_set_ready's upgrade fallback stamps
+        "" and the unchanged option permanently blocks the unit.
+        """
+        self.subprocess.CalledProcessError = CalledProcessError
+        self.subprocess.TimeoutExpired = TimeoutExpired
+        adopt.side_effect = CalledProcessError(
+            1, "cmd", stderr="Unable to initialize cluster: Database is online"
+        )
+        self.harness.set_leader()
+        rel_id = self.add_complete_peer_relation(self.harness)
+        self.set_config({"ceph-public-network": "10.5.0.0/24"})
+
+        self.harness.charm.adopt_cluster("fsid", ["10.0.0.1"], "key")
+
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertEqual(json.loads(app_data["ceph-public-network"]), "10.5.0.0/24")
+
+    def test_malformed_network_config_blocks(self):
+        """A bad subnet blocks rather than being silently dropped from the list."""
+        cases = {
+            # A bare address is a valid /32 to ip_network(), but is never a
+            # network an operator means.
+            "10.0.0.1": "no prefix length",
+            # An interface address, not a subnet.
+            "10.0.0.5/24": "has host bits set",
+            "10.0.0.0/24 garbage/24": "garbage/24",
+        }
+        for value, expected in cases.items():
+            for option in ("ceph-public-network", "ceph-cluster-network"):
+                with self.subTest(option=option, value=value):
+                    self.harness.update_config({option: value})
+                    status = self.harness.charm.status.status
+                    self.assertIsInstance(status, BlockedStatus)
+                    self.assertIn(f"Invalid config {option}", status.message)
+                    self.assertIn(expected, status.message)
+                    self.set_config({option: ""})
+
+    @patch.object(charm.MicroCephCharm, "ready_for_service")
+    @patch.object(microceph, "update_cluster_configs")
+    def test_cluster_network_applied_on_config_change(self, update_cluster_configs, ready):
+        """cluster_network is mutable post-bootstrap, so reconcile it each hook."""
+        ready.return_value = True
+        self.harness.set_leader()
+        rel_id = self.add_complete_peer_relation(self.harness)
+        self.set_config({"ceph-cluster-network": "10.6.0.0/24, 10.6.1.0/24"})
+
+        self.harness.charm.handle_config_leader_cluster_network(MagicMock())
+
+        update_cluster_configs.assert_called_once_with(
+            {"cluster_network": "10.6.0.0/24,10.6.1.0/24"}
+        )
+        # The applied value is recorded, so clearing the option can revert it.
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertEqual(json.loads(app_data["ceph-cluster-network"]), "10.6.0.0/24,10.6.1.0/24")
+
+    @patch.object(charm.MicroCephCharm, "ready_for_service")
+    @patch.object(microceph, "update_cluster_configs")
+    def test_cluster_network_never_set_is_noop(self, update_cluster_configs, ready):
+        """An option that was never set leaves the bootstrap value untouched."""
+        ready.return_value = True
+        self.harness.set_leader()
+        self.add_complete_peer_relation(self.harness)
+
+        self.harness.charm.handle_config_leader_cluster_network(MagicMock())
+
+        update_cluster_configs.assert_not_called()
+
+    @patch.object(charm.MicroCephCharm, "_get_space_subnet")
+    @patch.object(charm.MicroCephCharm, "ready_for_service")
+    @patch.object(microceph, "update_cluster_configs")
+    def test_cluster_network_cleared_reverts_to_fallback(
+        self, update_cluster_configs, ready, space_subnet
+    ):
+        """Clearing a previously set option reverts to the space fallback subnet."""
+        ready.return_value = True
+        space_subnet.return_value = ipaddress.ip_network("10.7.0.0/24")
+        self.harness.set_leader()
+        rel_id = self.add_complete_peer_relation(self.harness)
+
+        # A custom value is applied, then the operator clears the option.
+        self.set_config({"ceph-cluster-network": "10.6.0.0/24"})
+        self.harness.charm.handle_config_leader_cluster_network(MagicMock())
+        update_cluster_configs.assert_called_once_with({"cluster_network": "10.6.0.0/24"})
+        update_cluster_configs.reset_mock()
+        self.set_config({"ceph-cluster-network": ""})
+
+        self.harness.charm.handle_config_leader_cluster_network(MagicMock())
+
+        space_subnet.assert_called_once_with(space="cluster")
+        update_cluster_configs.assert_called_once_with({"cluster_network": "10.7.0.0/24"})
+        # The revert is recorded: later hooks with the option still unset are
+        # no-ops rather than repeatedly re-applying the fallback.
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertEqual(json.loads(app_data["ceph-cluster-network"]), "")
+        update_cluster_configs.reset_mock()
+        self.harness.charm.handle_config_leader_cluster_network(MagicMock())
+        update_cluster_configs.assert_not_called()
+
+    @patch.object(charm.MicroCephCharm, "ready_for_service")
+    @patch.object(microceph, "update_cluster_configs")
+    def test_cluster_network_unchanged_skips_daemon(self, update_cluster_configs, ready):
+        """An unchanged option must be a pure no-op on the steady-state path.
+
+        This handler runs on every reconcile of the leader's lifetime, so an
+        unchanged value must not gate on readiness or call the cluster API:
+        both would make a steady-state reconcile defer (and so look degraded)
+        whenever the daemon is transiently unavailable.
+        """
+        ready.return_value = False  # would defer if the no-op path consulted it
+        self.harness.set_leader()
+        self.add_complete_peer_relation(self.harness)
+        self.set_config({"ceph-cluster-network": "10.6.0.0/24"})
+        self.harness.charm.leader_set({"ceph-cluster-network": json.dumps("10.6.0.0/24")})
+
+        event = MagicMock()
+        self.harness.charm.handle_config_leader_cluster_network(event)
+
+        update_cluster_configs.assert_not_called()
+        ready.assert_not_called()
+        event.defer.assert_not_called()
+
+    @patch.object(charm.MicroCephCharm, "_get_space_subnet")
+    @patch.object(charm.MicroCephCharm, "ready_for_service")
+    @patch.object(microceph, "update_cluster_configs")
+    def test_cluster_network_revert_defers_without_subnet(
+        self, update_cluster_configs, ready, space_subnet
+    ):
+        """A transient binding gap must not silently abandon a requested revert.
+
+        Deferring alone would let the reconcile finish and mark the unit
+        active while the revert never happened; raising waiting keeps the
+        pending revert visible until a later hook can resolve the subnet.
+        """
+        ready.return_value = True
+        space_subnet.return_value = None
+        self.harness.set_leader()
+        self.add_complete_peer_relation(self.harness)
+        self.harness.charm.leader_set({"ceph-cluster-network": json.dumps("10.6.0.0/24")})
+
+        event = MagicMock()
+        with self.assertRaises(sunbeam_guard.WaitingExceptionError):
+            self.harness.charm.handle_config_leader_cluster_network(event)
+
+        update_cluster_configs.assert_not_called()
+        event.defer.assert_called_once()
+
+    @patch.object(charm.MicroCephCharm, "ready_for_service")
+    @patch.object(microceph, "update_cluster_configs")
+    def test_cluster_network_defers_until_ready(self, update_cluster_configs, ready):
+        """Setting cluster config on a not-yet-ready daemon would error."""
+        ready.return_value = False
+        self.harness.set_leader()
+        self.add_complete_peer_relation(self.harness)
+        self.set_config({"ceph-cluster-network": "10.6.0.0/24"})
+
+        event = MagicMock()
+        with self.assertRaises(sunbeam_guard.WaitingExceptionError):
+            self.harness.charm.handle_config_leader_cluster_network(event)
+
+        update_cluster_configs.assert_not_called()
+        event.defer.assert_called_once()
+
+        # The re-emitted event must actually apply the config once ready.
+        ready.return_value = True
+        retry = MagicMock()
+        self.harness.charm.handle_config_leader_cluster_network(retry)
+        update_cluster_configs.assert_called_once_with({"cluster_network": "10.6.0.0/24"})
+        retry.defer.assert_not_called()
+
+    @patch.object(charm.MicroCephCharm, "ready_for_service")
+    @patch.object(microceph, "update_cluster_configs")
+    def test_cluster_network_defers_when_cluster_unavailable(self, update_cluster_configs, ready):
+        """A transiently unavailable cluster service is retried on a later hook."""
+        ready.return_value = True
+        update_cluster_configs.side_effect = ClusterServiceUnavailableException("unavailable")
+        self.harness.set_leader()
+        rel_id = self.add_complete_peer_relation(self.harness)
+        self.set_config({"ceph-cluster-network": "10.6.0.0/24"})
+
+        event = MagicMock()
+        with self.assertRaises(sunbeam_guard.WaitingExceptionError):
+            self.harness.charm.handle_config_leader_cluster_network(event)
+
+        event.defer.assert_called_once()
+        # Nothing may be recorded as applied when the update did not happen.
+        app_data = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertNotIn("ceph-cluster-network", app_data)
+
+    @patch.object(charm.MicroCephCharm, "ready_for_service")
+    @patch.object(microceph, "update_cluster_configs")
+    def test_cluster_network_unrecognized_option_blocks(self, update_cluster_configs, ready):
+        """A daemon that rejects cluster_network cannot be retried into accepting it."""
+        ready.return_value = True
+        update_cluster_configs.side_effect = UnrecognizedClusterConfigOption("Option not found")
+        self.harness.set_leader()
+        self.add_complete_peer_relation(self.harness)
+        self.set_config({"ceph-cluster-network": "10.6.0.0/24"})
+
+        with self.assertRaises(sunbeam_guard.BlockedExceptionError) as ctx:
+            self.harness.charm.handle_config_leader_cluster_network(MagicMock())
+        self.assertIn("ceph-cluster-network", str(ctx.exception))

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -193,3 +193,72 @@ class TestNormalizeIp(unittest.TestCase):
         }
         for addr, expected in cases.items():
             self.assertEqual(utils._normalize_ip(addr), expected, addr)
+
+
+class TestSplitSpaceOrComma(unittest.TestCase):
+    """Operators may delimit lists with spaces, commas, or both."""
+
+    def test_split(self):
+        cases = {
+            "": [],
+            "  ": [],
+            "10.0.0.0/24": ["10.0.0.0/24"],
+            "10.0.0.0/24,10.0.1.0/24": ["10.0.0.0/24", "10.0.1.0/24"],
+            "10.0.0.0/24 10.0.1.0/24": ["10.0.0.0/24", "10.0.1.0/24"],
+            "10.0.0.0/24, 10.0.1.0/24": ["10.0.0.0/24", "10.0.1.0/24"],
+            " 10.0.0.0/24 ,, 10.0.1.0/24 ": ["10.0.0.0/24", "10.0.1.0/24"],
+        }
+        for value, expected in cases.items():
+            self.assertEqual(utils.split_space_or_comma(value), expected, value)
+
+
+class TestParseNetworks(unittest.TestCase):
+    """parse_networks validates subnets and returns them canonicalised."""
+
+    def test_valid_networks(self):
+        cases = {
+            "": [],
+            "10.0.0.0/24": ["10.0.0.0/24"],
+            "10.0.0.0/24 10.0.1.0/24": ["10.0.0.0/24", "10.0.1.0/24"],
+            "10.0.0.0/24,10.0.1.0/24": ["10.0.0.0/24", "10.0.1.0/24"],
+            "fd00::/64": ["fd00::/64"],
+            "fd00:0:0:0::/64": ["fd00::/64"],  # canonicalised
+        }
+        for value, expected in cases.items():
+            self.assertEqual(utils.parse_networks(value), expected, value)
+
+    def test_order_preserved_and_deduped(self):
+        """Entry order is the operator's priority; duplicates collapse.
+
+        microceph picks the first listed subnet with a local address, so
+        parse_networks must not reorder entries — only canonicalise and dedup.
+        """
+        cases = {
+            # Operator order is preserved, not sorted.
+            "10.0.1.0/24 10.0.0.0/24": ["10.0.1.0/24", "10.0.0.0/24"],
+            "fd00::/64 10.0.0.0/24": ["fd00::/64", "10.0.0.0/24"],
+            # Duplicates collapse to the first occurrence, respelled ones too.
+            "10.0.0.0/24,10.0.0.0/24": ["10.0.0.0/24"],
+            "fd00::/64 fd00:0:0:0::/64": ["fd00::/64"],
+            "10.0.1.0/24 10.0.0.0/24 10.0.1.0/24": ["10.0.1.0/24", "10.0.0.0/24"],
+        }
+        for value, expected in cases.items():
+            self.assertEqual(utils.parse_networks(value), expected, value)
+
+    def test_bare_address_rejected(self):
+        """ip_network() would accept a bare address as a /32 host route."""
+        for value in ("10.0.0.1", "fd00::1", "10.0.0.0/24 10.0.1.1"):
+            with self.assertRaises(ValueError) as ctx:
+                utils.parse_networks(value)
+            self.assertIn("no prefix length", str(ctx.exception))
+
+    def test_host_bits_set_rejected(self):
+        """An interface address is not a subnet: 10.0.0.5/24 has host bits set."""
+        with self.assertRaises(ValueError) as ctx:
+            utils.parse_networks("10.0.0.5/24")
+        self.assertIn("10.0.0.5/24", str(ctx.exception))
+
+    def test_malformed_entry_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            utils.parse_networks("10.0.0.0/24 not-a-subnet/24")
+        self.assertIn("not-a-subnet/24", str(ctx.exception))

--- a/tests/unit/testbase.py
+++ b/tests/unit/testbase.py
@@ -78,6 +78,21 @@ class _MicroCephCharm(charm.MicroCephCharm):
 
 
 class TestBaseCharm(test_utils.CharmTestCase):
+    def init_harness(self) -> None:
+        """Create, register cleanup for, and begin a microceph charm harness."""
+        with open("config.yaml", "r") as f:
+            config_data = f.read()
+        with open("metadata.yaml", "r") as f:
+            metadata = f.read()
+        self.harness = test_utils.get_harness(
+            _MicroCephCharm,
+            container_calls=self.container_calls,
+            charm_config=config_data,
+            charm_metadata=metadata,
+        )
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
     def add_complete_identity_relation(self, harness: Harness) -> None:
         """Add complete identity-service relation."""
         credentials_content = {"username": "svcuser1", "password": "svcpass1"}


### PR DESCRIPTION
# Description

Backport of #335 to stable/squid. Changes from the original:

* tests/integration/test_network_config.py pins snap-channel to squid/stable rather than tentacle/stable. The squid snap gained multi-subnet public/cluster network support in microceph#803, which squid/stable now carries, so the option values the test uses parse on this track.
* tests/unit/test_charm.py adds the ops_sunbeam.guard import the new tests need; on main it was already present from an earlier change that has not been backported.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
